### PR TITLE
fix: update iOS simulator destination in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -147,7 +147,7 @@ jobs:
             -scheme pulse \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,arch=arm64' \
             build
         elif [ "${{ matrix.language }}" = "java-kotlin" ]; then
           echo "Building Android project for CodeQL analysis..."
@@ -168,12 +168,12 @@ jobs:
         cd ios
         
         # Try a minimal build using the same approach as main.yml
-        xcodebuild -workspace pulse.xcworkspace \
-          -scheme pulse \
-          -configuration Debug \
-          -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 16' \
-          build-for-testing
+          xcodebuild -workspace pulse.xcworkspace \
+            -scheme pulse \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16,arch=arm64' \
+            build-for-testing
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -147,7 +147,7 @@ jobs:
             -scheme pulse \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,id=07770167-BCCB-4FCA-BCCD-DA7C1E9F2FC2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             build
         elif [ "${{ matrix.language }}" = "java-kotlin" ]; then
           echo "Building Android project for CodeQL analysis..."
@@ -172,7 +172,7 @@ jobs:
           -scheme pulse \
           -configuration Debug \
           -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,id=07770167-BCCB-4FCA-BCCD-DA7C1E9F2FC2' \
+          -destination 'platform=iOS Simulator,name=iPhone 16' \
           build-for-testing
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
             -scheme pulse \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,id=07770167-BCCB-4FCA-BCCD-DA7C1E9F2FC2' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             build
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
             -scheme pulse \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,arch=arm64' \
             build
 
 


### PR DESCRIPTION
- Changed the iOS simulator destination in both CodeQL and main workflows to use 'iPhone 16' instead of a specific simulator ID.
- This adjustment aims to improve build reliability and compatibility with the latest iOS features in CI environments.