### PR TITLE
feat: convert TestFlight workflow to native iOS builds

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -30,15 +30,22 @@ permissions:
     types: [published]
 
 env:
-  EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+  # Apple credentials for TestFlight upload
   APPLE_ID: ${{ secrets.APPLE_ID }}
   APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+  ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+  
+  # iOS build configuration
+  IOS_SCHEME: 'pulse'
+  IOS_WORKSPACE: 'ios/pulse.xcworkspace'
+  IOS_CONFIGURATION: 'Release'
+  IOS_DESTINATION: 'generic/platform=iOS'
 
 jobs:
   deploy-ios:
     name: Deploy iOS App to TestFlight
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     
     steps:
       - name: Checkout code
@@ -51,136 +58,81 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npx expo install
 
-      - name: Setup Expo and EAS CLI
+      - name: Set version from app.json
         run: |
-          npm install -g @expo/cli@latest
-          npm install -g eas-cli@latest
-          
-          # Verify installations
-          expo --version
-          eas --version
-
-      - name: Verify Expo authentication
-        run: |
-          if [ -z "$EXPO_TOKEN" ]; then
-            echo "ERROR: EXPO_TOKEN secret is not set"
-            echo "Please set the EXPO_TOKEN secret in your repository settings"
-            exit 1
-          fi
-          expo whoami
-
-      - name: Extract version from tag (if tag triggered)
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION=$(node -p "require('./app.json').expo.version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "DEPLOYMENT_TYPE=tag" >> $GITHUB_ENV
 
-      - name: Set version for manual dispatch
-        if: github.event_name == 'workflow_dispatch'
+      - name: Prebuild iOS project
+        run: npx expo prebuild --platform ios --clean
+
+      - name: Install iOS dependencies
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "DEPLOYMENT_TYPE=manual" >> $GITHUB_ENV
+          cd ios
+          pod install --repo-update
+          cd ..
 
-      - name: Set version for release
-        if: github.event_name == 'release'
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "DEPLOYMENT_TYPE=release" >> $GITHUB_ENV
-
-      - name: Configure app for iOS production
-        run: |
-          echo "Configuring app for production deployment"
-          echo "Version: $VERSION"
-          echo "Deployment type: $DEPLOYMENT_TYPE"
-
-      - name: Build and submit to TestFlight
+      - name: Build iOS Archive
         if: ${{ !inputs.skip_build || inputs.skip_build == false }}
         run: |
-          echo "Starting iOS build and TestFlight submission..."
-          
-          # Check if eas.json exists, if not create basic configuration
-          if [ ! -f "eas.json" ]; then
-            echo "Creating eas.json configuration..."
-            cat > eas.json << EOF
-          {
-            "cli": {
-              "version": ">= 5.8.0"
-            },
-            "build": {
-              "development": {
-                "developmentClient": true,
-                "distribution": "internal"
-              },
-              "preview": {
-                "distribution": "internal",
-                "ios": {
-                  "simulator": false
-                }
-              },
-              "production": {
-                "autoIncrement": true,
-                "ios": {
-                  "simulator": false
-                }
-              }
-            },
-            "submit": {
-              "production": {
-                "ios": {
-                  "appleId": "${{ secrets.APPLE_ID }}",
-                  "ascAppId": "${{ secrets.ASC_APP_ID }}",
-                  "appleTeamId": "${{ secrets.APPLE_TEAM_ID }}"
-                }
-              }
-            }
-          }
+          xcodebuild archive \
+            -workspace $IOS_WORKSPACE \
+            -scheme $IOS_SCHEME \
+            -configuration $IOS_CONFIGURATION \
+            -destination $IOS_DESTINATION \
+            -archivePath ./build/pulse.xcarchive \
+            -allowProvisioningUpdates \
+            CODE_SIGN_STYLE=Automatic \
+            DEVELOPMENT_TEAM=$APPLE_TEAM_ID
+
+      - name: Export IPA
+        if: ${{ !inputs.skip_build || inputs.skip_build == false }}
+        run: |
+          cat > exportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store</string>
+              <key>teamID</key>
+              <string>$APPLE_TEAM_ID</string>
+              <key>uploadBitcode</key>
+              <false/>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>compileBitcode</key>
+              <false/>
+          </dict>
+          </plist>
           EOF
-          fi
           
-          # Build for iOS
-          eas build --platform ios --profile production --non-interactive --no-wait
-          
-          # Wait for build to complete and get build ID
-          echo "Waiting for build to complete..."
-          BUILD_ID=$(eas build:list --platform ios --status finished --limit 1 --json | jq -r '.[0].id')
-          
-          # Submit to TestFlight
-          echo "Submitting build $BUILD_ID to TestFlight..."
-          eas submit --platform ios --id $BUILD_ID --profile production --non-interactive
+          xcodebuild -exportArchive \
+            -archivePath ./build/pulse.xcarchive \
+            -exportPath ./build \
+            -exportOptionsPlist exportOptions.plist
+
+      - name: Upload to TestFlight
+        if: ${{ !inputs.skip_build || inputs.skip_build == false }}
+        run: |
+          xcrun altool --upload-app \
+            --type ios \
+            --file ./build/pulse.ipa \
+            --username "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD"
 
       - name: Skip build notification
         if: ${{ inputs.skip_build == true }}
-        run: |
-          echo "Build step was skipped as requested."
-          echo "Please ensure you have a recent build available for submission."
+        run: echo "Build step was skipped as requested."
 
       - name: Deployment summary
         run: |
-          echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- **Platform**: iOS" >> $GITHUB_STEP_SUMMARY
+          echo "## 🚀 Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: $VERSION" >> $GITHUB_STEP_SUMMARY
-          echo "- **Deployment Type**: $DEPLOYMENT_TYPE" >> $GITHUB_STEP_SUMMARY
           echo "- **Target**: TestFlight" >> $GITHUB_STEP_SUMMARY
-          echo "- **Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "$DEPLOYMENT_TYPE" = "tag" ]; then
-            echo "- **Tag**: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          elif [ "$DEPLOYMENT_TYPE" = "manual" ]; then
-            echo "- **Environment**: ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-            echo "- **Skip Build**: ${{ inputs.skip_build }}" >> $GITHUB_STEP_SUMMARY
-          fi
 
       - name: Notify on failure
         if: failure()
-        run: |
-          echo "## ❌ Deployment Failed" >> $GITHUB_STEP_SUMMARY
-          echo "The TestFlight deployment failed. Please check the logs above for details." >> $GITHUB_STEP_SUMMARY
-          echo "Common issues:" >> $GITHUB_STEP_SUMMARY
-          echo "- Missing or invalid Apple credentials" >> $GITHUB_STEP_SUMMARY
-          echo "- Invalid bundle identifier or provisioning profile" >> $GITHUB_STEP_SUMMARY
-          echo "- Build errors or configuration issues" >> $GITHUB_STEP_SUMMARY
+        run: echo "## ❌ Deployment Failed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Replace EAS-based workflow with native Xcode builds
- Use xcodebuild archive and xcodebuild -exportArchive
- Upload to TestFlight using xcrun altool
- Remove EAS dependency and use app.json version
- Simplify logging and remove unnecessary echo statements
- Support manual, tag, and release triggers