### PR TITLE
feat: Add drag-and-drop segment reordering UI

### DIFF
--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -188,6 +188,15 @@ export default function ShortsScreen() {
     }
   };
 
+  const handleReorderSegments = () => {
+    if (currentDraftId) {
+      router.push({
+        pathname: "/reordersegments",
+        params: { draftId: currentDraftId },
+      });
+    }
+  };
+
   const handleSaveAsDraftWrapper = async (
     segments: RecordingSegment[],
     options?: { forceNew?: boolean }
@@ -381,6 +390,9 @@ export default function ShortsScreen() {
               }
               videoStabilizationMode={videoStabilizationMode}
               onVideoStabilizationChange={handleVideoStabilizationChange}
+              onReorderSegments={
+                recordingSegments.length > 1 ? handleReorderSegments : undefined
+              }
             />
           )}
 

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -62,6 +62,7 @@ export default function ShortsScreen() {
     hasStartedOver,
     isContinuingLastDraft,
     showContinuingIndicator,
+    loadedDuration,
     handleStartOver,
     handleStartNew,
     handleSaveAsDraft,
@@ -69,6 +70,7 @@ export default function ShortsScreen() {
     handleUndoSegment,
     handleRedoSegment,
     updateSegmentsAfterRecording,
+    updateDraftDuration,
   } = useDraftManager(draftId, selectedDuration);
 
   // Camera control states
@@ -145,8 +147,17 @@ export default function ShortsScreen() {
     }
   };
 
+  // Restore loaded duration when draft is loaded
+  React.useEffect(() => {
+    if (loadedDuration !== null && loadedDuration !== selectedDuration) {
+      setSelectedDuration(loadedDuration);
+    }
+  }, [loadedDuration]);
+
   const handleTimeSelect = (timeInSeconds: number) => {
     setSelectedDuration(timeInSeconds);
+    // Immediately update the draft with the new duration
+    updateDraftDuration(timeInSeconds);
   };
 
   const handleFlipCamera = () => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -66,6 +66,14 @@ export default function RootLayout() {
             }}
           />
           <Stack.Screen
+            name="reordersegments"
+            options={{
+              headerShown: false,
+              presentation: "fullScreenModal",
+              animation: "none",
+            }}
+          />
+          <Stack.Screen
             name="upload"
             options={{
               headerShown: false,

--- a/app/reordersegments.tsx
+++ b/app/reordersegments.tsx
@@ -1,0 +1,167 @@
+import { ThemedText } from "@/components/ThemedText";
+import SegmentReorderList from "@/components/SegmentReorderList";
+import { DraftStorage } from "@/utils/draftStorage";
+import { fileStore } from "@/utils/fileStore";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useCallback, useEffect, useState } from "react";
+import { StyleSheet, View, ActivityIndicator } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+interface Segment {
+  id: string;
+  uri: string;
+  duration: number;
+}
+
+export default function ReorderSegmentsScreen() {
+  const { draftId } = useLocalSearchParams<{ draftId: string }>();
+  const insets = useSafeAreaInsets();
+
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [draft, setDraft] = useState<any>(null);
+
+  useEffect(() => {
+    const loadDraft = async () => {
+      if (!draftId) {
+        router.back();
+        return;
+      }
+
+      try {
+        const draft = await DraftStorage.getDraftById(draftId);
+        if (draft && draft.segments.length > 0) {
+          setDraft(draft);
+          // Convert segments to the format expected by the reorder component
+          const formattedSegments: Segment[] = draft.segments.map(
+            (segment: any) => ({
+              id: segment.id,
+              uri: fileStore.toAbsolutePath(segment.uri),
+              duration: segment.duration,
+            })
+          );
+          setSegments(formattedSegments);
+        } else {
+          router.back();
+        }
+      } catch (error) {
+        console.error("Draft load failed:", error);
+        router.back();
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadDraft();
+  }, [draftId]);
+
+  const handleSegmentsReorder = useCallback((reorderedSegments: Segment[]) => {
+    setSegments(reorderedSegments);
+  }, []);
+
+  const handleSave = useCallback(
+    async (reorderedSegments: Segment[]) => {
+      if (!draftId || !draft) return;
+
+      try {
+        // Convert back to the draft format
+        const updatedSegments = reorderedSegments.map((segment) => ({
+          id: segment.id,
+          uri: fileStore.toRelativePath(segment.uri), // Convert back to relative path
+          duration: segment.duration,
+        }));
+
+        // Update the draft with reordered segments
+        const updatedDraft = {
+          ...draft,
+          segments: updatedSegments,
+        };
+
+        // Calculate total duration
+        const totalDuration = updatedSegments.reduce(
+          (total, segment) => total + segment.duration,
+          0
+        );
+
+        // Save the updated draft
+        await DraftStorage.updateDraft(draftId, updatedSegments, totalDuration);
+
+        // Navigate back to camera screen
+        router.back();
+      } catch (error) {
+        console.error("Failed to save reordered segments:", error);
+      }
+    },
+    [draftId, draft]
+  );
+
+  const handleCancel = useCallback(() => {
+    router.back();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.container, styles.loadingContainer]}>
+        <ActivityIndicator size="large" color="#ff0000" />
+        <ThemedText style={styles.loadingText}>Loading segments...</ThemedText>
+      </View>
+    );
+  }
+
+  if (segments.length === 0) {
+    return (
+      <View style={[styles.container, styles.errorContainer]}>
+        <ThemedText style={styles.errorText}>No segments found</ThemedText>
+        <ThemedText style={styles.errorSubtext}>
+          Please record some segments first
+        </ThemedText>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      <SegmentReorderList
+        segments={segments}
+        onSegmentsReorder={handleSegmentsReorder}
+        onSave={handleSave}
+        onCancel={handleCancel}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+  },
+  loadingContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  loadingText: {
+    color: "#fff",
+    fontSize: 16,
+    fontFamily: "Roboto-Regular",
+    marginTop: 16,
+  },
+  errorContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+  },
+  errorText: {
+    color: "#fff",
+    fontSize: 18,
+    fontFamily: "Roboto-Bold",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  errorSubtext: {
+    color: "#ccc",
+    fontSize: 14,
+    fontFamily: "Roboto-Regular",
+    textAlign: "center",
+  },
+});

--- a/app/reordersegments.tsx
+++ b/app/reordersegments.tsx
@@ -77,11 +77,8 @@ export default function ReorderSegmentsScreen() {
           segments: updatedSegments,
         };
 
-        // Calculate total duration
-        const totalDuration = updatedSegments.reduce(
-          (total, segment) => total + segment.duration,
-          0
-        );
+        // Use the original draft's totalDuration (selected duration limit)
+        const totalDuration = draft.totalDuration;
 
         // Save the updated draft
         await DraftStorage.updateDraft(draftId, updatedSegments, totalDuration);

--- a/components/CameraControls.tsx
+++ b/components/CameraControls.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { Platform, StyleSheet, TouchableOpacity, View } from "react-native";
 import VideoStabilizationControl from "./VideoStabilizationControl";
 import { VideoStabilization } from "@/constants/camera";
+import { Fontisto } from "@expo/vector-icons";
 
 interface CameraControlsProps {
   onFlipCamera?: () => void;
@@ -13,6 +14,7 @@ interface CameraControlsProps {
   cameraFacing?: CameraType;
   videoStabilizationMode?: VideoStabilization;
   onVideoStabilizationChange?: (mode: VideoStabilization) => void;
+  onReorderSegments?: () => void;
 }
 
 export default function CameraControls({
@@ -22,6 +24,7 @@ export default function CameraControls({
   cameraFacing = "back",
   videoStabilizationMode = VideoStabilization.off,
   onVideoStabilizationChange,
+  onReorderSegments,
 }: CameraControlsProps) {
   const getTorchIcon = () => {
     return torchEnabled ? (
@@ -57,6 +60,16 @@ export default function CameraControls({
           onStabilizationModeChange={onVideoStabilizationChange}
           compact
         />
+      )}
+
+      {/* Reorder segments button */}
+      {onReorderSegments && (
+        <TouchableOpacity
+          style={styles.controlButton}
+          onPress={onReorderSegments}
+        >
+          <Fontisto name="arrow-swap" size={24} color="white" />
+        </TouchableOpacity>
       )}
     </View>
   );

--- a/components/SegmentReorderList.tsx
+++ b/components/SegmentReorderList.tsx
@@ -1,0 +1,249 @@
+import { ThemedText } from "@/components/ThemedText";
+import SegmentThumbnail from "@/components/SegmentThumbnail";
+import { MaterialIcons } from "@expo/vector-icons";
+import React, { useState, useCallback } from "react";
+import {
+  StyleSheet,
+  View,
+  ScrollView,
+  TouchableOpacity,
+  Dimensions,
+} from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+} from "react-native-reanimated";
+
+const { width: screenWidth } = Dimensions.get("window");
+const THUMBNAIL_SIZE = (screenWidth - 60) / 2;
+
+interface Segment {
+  id: string;
+  uri: string;
+  duration: number;
+}
+
+interface SegmentReorderListProps {
+  segments: Segment[];
+  onSegmentsReorder: (reorderedSegments: Segment[]) => void;
+  onSave: (segments: Segment[]) => void;
+  onCancel: () => void;
+}
+
+export default function SegmentReorderList({
+  segments,
+  onSegmentsReorder,
+  onSave,
+  onCancel,
+}: SegmentReorderListProps) {
+  const [reorderedSegments, setReorderedSegments] =
+    useState<Segment[]>(segments);
+  const [isDragging, setIsDragging] = useState(false);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  // Animation for save button
+  const saveButtonScale = useSharedValue(1);
+
+  const handleDragStart = useCallback((index: number) => {
+    setIsDragging(true);
+    setDraggedIndex(index);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      setIsDragging(false);
+      setDraggedIndex(null);
+
+      if (fromIndex !== toIndex && toIndex < reorderedSegments.length) {
+        const newSegments = [...reorderedSegments];
+        const [movedSegment] = newSegments.splice(fromIndex, 1);
+        newSegments.splice(toIndex, 0, movedSegment);
+
+        setReorderedSegments(newSegments);
+        setHasChanges(true);
+        onSegmentsReorder(newSegments);
+      }
+    },
+    [reorderedSegments, onSegmentsReorder]
+  );
+
+  const handleSave = useCallback(() => {
+    if (hasChanges) {
+      saveButtonScale.value = withSpring(0.95, {}, () => {
+        saveButtonScale.value = withSpring(1);
+      });
+
+      onSave(reorderedSegments);
+      setHasChanges(false);
+    }
+  }, [hasChanges, reorderedSegments, onSave, saveButtonScale]);
+
+  const animatedSaveButtonStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: saveButtonScale.value }],
+  }));
+
+  const totalDuration = reorderedSegments.reduce(
+    (total, segment) => total + segment.duration,
+    0
+  );
+
+  const formatTotalDuration = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <View style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.cancelButton} onPress={onCancel}>
+          <MaterialIcons name="close" size={24} color="#fff" />
+        </TouchableOpacity>
+
+        <View style={styles.headerInfo}>
+          <ThemedText style={styles.headerTitle}>Reorder Segments</ThemedText>
+          <ThemedText style={styles.headerSubtitle}>
+            {reorderedSegments.length} segments •{" "}
+            {formatTotalDuration(totalDuration)}
+          </ThemedText>
+        </View>
+
+        {/* Invisible spacer to balance the close button */}
+        <View style={styles.headerSpacer} />
+      </View>
+
+      {/* Segments Grid */}
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.segmentsGrid}>
+          {reorderedSegments.map((segment, index) => (
+            <SegmentThumbnail
+              key={segment.id}
+              segment={segment}
+              index={index}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              isDragging={isDragging}
+              draggedIndex={draggedIndex}
+            />
+          ))}
+        </View>
+      </ScrollView>
+
+      {/* Save Button */}
+      <Animated.View
+        style={[styles.saveButtonContainer, animatedSaveButtonStyle]}
+      >
+        <TouchableOpacity
+          style={[styles.saveButton, !hasChanges && styles.disabledSaveButton]}
+          onPress={handleSave}
+          disabled={!hasChanges}
+          activeOpacity={0.8}
+        >
+          <MaterialIcons
+            name="save"
+            size={20}
+            color={hasChanges ? "#fff" : "#666"}
+          />
+          <ThemedText
+            style={[
+              styles.saveButtonText,
+              !hasChanges && styles.disabledSaveButtonText,
+            ]}
+          >
+            {hasChanges ? "Save New Order" : "No Changes"}
+          </ThemedText>
+        </TouchableOpacity>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 20,
+    backgroundColor: "rgba(0, 0, 0, 0.9)",
+  },
+  cancelButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  headerSpacer: {
+    width: 40,
+    height: 40,
+  },
+  headerInfo: {
+    flex: 1,
+    alignItems: "center",
+    marginHorizontal: 20,
+  },
+  headerTitle: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "700",
+    fontFamily: "Roboto-Bold",
+  },
+  headerSubtitle: {
+    color: "#ccc",
+    fontSize: 14,
+    fontFamily: "Roboto-Regular",
+    marginTop: 2,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+  },
+  segmentsGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+  },
+  saveButtonContainer: {
+    padding: 20,
+    backgroundColor: "rgba(0, 0, 0, 0.9)",
+    borderTopWidth: 1,
+    borderTopColor: "rgba(255, 255, 255, 0.1)",
+  },
+  saveButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#ff0000",
+    paddingVertical: 16,
+    paddingHorizontal: 24,
+    borderRadius: 12,
+  },
+  disabledSaveButton: {
+    backgroundColor: "#333",
+  },
+  saveButtonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
+    fontFamily: "Roboto-Bold",
+    marginLeft: 8,
+  },
+  disabledSaveButtonText: {
+    color: "#666",
+  },
+});

--- a/components/SegmentThumbnail.tsx
+++ b/components/SegmentThumbnail.tsx
@@ -1,0 +1,249 @@
+import { ThemedText } from "@/components/ThemedText";
+import { generateVideoThumbnail } from "@/utils/videoThumbnails";
+import { MaterialIcons } from "@expo/vector-icons";
+import React, { useEffect, useState } from "react";
+import {
+  Image,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  Dimensions,
+} from "react-native";
+import Animated, {
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  runOnJS,
+} from "react-native-reanimated";
+import {
+  PanGestureHandler,
+  PanGestureHandlerGestureEvent,
+} from "react-native-gesture-handler";
+
+const { width: screenWidth } = Dimensions.get("window");
+const THUMBNAIL_SIZE = (screenWidth - 60) / 2; // 2 columns with padding
+
+interface SegmentThumbnailProps {
+  segment: {
+    id: string;
+    uri: string;
+    duration: number;
+  };
+  index: number;
+  onDragStart: (index: number) => void;
+  onDragEnd: (fromIndex: number, toIndex: number) => void;
+  isDragging: boolean;
+  draggedIndex: number | null;
+}
+
+export default function SegmentThumbnail({
+  segment,
+  index,
+  onDragStart,
+  onDragEnd,
+  isDragging,
+  draggedIndex,
+}: SegmentThumbnailProps) {
+  const [thumbnailUri, setThumbnailUri] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Animation values
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const scale = useSharedValue(1);
+  const zIndex = useSharedValue(0);
+
+  const isBeingDragged = draggedIndex === index;
+  const isDragTarget = isDragging && !isBeingDragged;
+
+  // Generate thumbnail on mount
+  useEffect(() => {
+    const loadThumbnail = async () => {
+      try {
+        setIsLoading(true);
+        const uri = await generateVideoThumbnail(segment.uri, {
+          time: 1000, // 1 second into the video
+          quality: 0.8,
+        });
+        setThumbnailUri(uri);
+      } catch (error) {
+        console.error("Failed to generate thumbnail:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadThumbnail();
+  }, [segment.uri]);
+
+  // Gesture handler for drag and drop
+  const gestureHandler = useAnimatedGestureHandler<
+    PanGestureHandlerGestureEvent,
+    { startX: number; startY: number }
+  >({
+    onStart: (_, context) => {
+      context.startX = translateX.value;
+      context.startY = translateY.value;
+      zIndex.value = 1000;
+      scale.value = withSpring(1.1);
+      runOnJS(onDragStart)(index);
+    },
+    onActive: (event, context) => {
+      translateX.value = context.startX + event.translationX;
+      translateY.value = context.startY + event.translationY;
+    },
+    onEnd: () => {
+      // Calculate drop target based on position
+      const targetIndex = Math.round(
+        (translateY.value + THUMBNAIL_SIZE / 2) / THUMBNAIL_SIZE
+      );
+
+      // Reset position
+      translateX.value = withSpring(0);
+      translateY.value = withSpring(0);
+      scale.value = withSpring(1);
+      zIndex.value = 0;
+
+      runOnJS(onDragEnd)(index, Math.max(0, targetIndex));
+    },
+  });
+
+  // Animated styles
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+    zIndex: zIndex.value,
+  }));
+
+  const containerStyle = useAnimatedStyle(() => ({
+    opacity: isDragTarget ? 0.5 : 1,
+  }));
+
+  const formatDuration = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <Animated.View style={[styles.container, containerStyle]}>
+      <PanGestureHandler onGestureEvent={gestureHandler}>
+        <Animated.View style={[styles.thumbnailContainer, animatedStyle]}>
+          <View style={styles.thumbnailWrapper}>
+            {isLoading ? (
+              <View style={styles.loadingContainer}>
+                <MaterialIcons name="video-library" size={32} color="#666" />
+              </View>
+            ) : thumbnailUri ? (
+              <Image source={{ uri: thumbnailUri }} style={styles.thumbnail} />
+            ) : (
+              <View style={styles.errorContainer}>
+                <MaterialIcons name="error" size={32} color="#666" />
+              </View>
+            )}
+
+            {/* Duration overlay */}
+            <View style={styles.durationOverlay}>
+              <ThemedText style={styles.durationText}>
+                {formatDuration(segment.duration)}
+              </ThemedText>
+            </View>
+
+            {/* Drag handle */}
+            <View style={styles.dragHandle}>
+              <MaterialIcons name="drag-indicator" size={20} color="#fff" />
+            </View>
+          </View>
+
+          {/* Segment number */}
+          <View style={styles.segmentNumber}>
+            <ThemedText style={styles.segmentNumberText}>
+              {index + 1}
+            </ThemedText>
+          </View>
+        </Animated.View>
+      </PanGestureHandler>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: THUMBNAIL_SIZE,
+    marginBottom: 16,
+  },
+  thumbnailContainer: {
+    position: "relative",
+  },
+  thumbnailWrapper: {
+    position: "relative",
+    borderRadius: 12,
+    overflow: "hidden",
+    backgroundColor: "#333",
+  },
+  thumbnail: {
+    width: THUMBNAIL_SIZE,
+    height: THUMBNAIL_SIZE * 0.75, // 4:3 aspect ratio
+    resizeMode: "cover",
+  },
+  loadingContainer: {
+    width: THUMBNAIL_SIZE,
+    height: THUMBNAIL_SIZE * 0.75,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#222",
+  },
+  errorContainer: {
+    width: THUMBNAIL_SIZE,
+    height: THUMBNAIL_SIZE * 0.75,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#222",
+  },
+  durationOverlay: {
+    position: "absolute",
+    bottom: 8,
+    right: 8,
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  durationText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
+    fontFamily: "Roboto-Bold",
+  },
+  dragHandle: {
+    position: "absolute",
+    top: 8,
+    left: 8,
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    padding: 4,
+    borderRadius: 4,
+  },
+  segmentNumber: {
+    position: "absolute",
+    top: -8,
+    right: -8,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: "#ff0000",
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 2,
+    borderColor: "#000",
+  },
+  segmentNumberText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "700",
+    fontFamily: "Roboto-Bold",
+  },
+});

--- a/utils/videoThumbnails.ts
+++ b/utils/videoThumbnails.ts
@@ -1,9 +1,13 @@
 import { getThumbnailAsync } from 'expo-video-thumbnails';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export interface ThumbnailOptions {
   time?: number;
   quality?: number;
 }
+
+// Simple in-memory cache for thumbnails
+const thumbnailCache = new Map<string, string>();
 
 export async function generateVideoThumbnail(
   videoUri: string,
@@ -12,10 +16,40 @@ export async function generateVideoThumbnail(
   try {
     const { time = 0, quality = 1.0 } = options;
     
+    // Create cache key based on video URI and options
+    const cacheKey = `${videoUri}_${time}_${quality}`;
+    
+    // Check in-memory cache first
+    if (thumbnailCache.has(cacheKey)) {
+      return thumbnailCache.get(cacheKey)!;
+    }
+    
+    // Check persistent storage
+    try {
+      const cachedUri = await AsyncStorage.getItem(`thumbnail_${cacheKey}`);
+      if (cachedUri) {
+        thumbnailCache.set(cacheKey, cachedUri);
+        return cachedUri;
+      }
+    } catch (storageError) {
+      console.warn('Failed to read thumbnail from cache:', storageError);
+    }
+    
+    // Generate new thumbnail
     const { uri } = await getThumbnailAsync(videoUri, {
       time,
       quality,
     });
+    
+    // Cache the result
+    thumbnailCache.set(cacheKey, uri);
+    
+    // Store in persistent storage
+    try {
+      await AsyncStorage.setItem(`thumbnail_${cacheKey}`, uri);
+    } catch (storageError) {
+      console.warn('Failed to cache thumbnail:', storageError);
+    }
     
     console.log('Generated thumbnail:', uri);
     return uri;


### PR DESCRIPTION
- Add SegmentThumbnail component with drag-and-drop functionality
- Add SegmentReorderList component with grid layout and reordering logic
- Add reordersegments screen with modern UI
- Update CameraControls to include reorder button (shows when 2+ segments)
- Enhance videoThumbnails with caching (in-memory + AsyncStorage)
- Add reordersegments route to app layout
- Implement smooth animations with react-native-reanimated
- Add thumbnail generation with expo-video-thumbnails
- Support saving reordered segments back to draft storage

Features:
- Drag and drop reordering with visual feedback
- Auto-generated video thumbnails with caching
- Responsive 2-column grid layout
- Smooth spring animations
- Save/cancel functionality
- Proper state management and error handling 

Solves #57 