### PR TITLE
Configure pulse-desktop submodule to track main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "pulse-desktop"]
 	path = pulse-desktop
 	url = https://github.com/mieweb/pulse-desktop
+	branch = main


### PR DESCRIPTION
- Updated .gitmodules to set branch = main for pulse-desktop submodule
- Switched pulse-desktop from pinned commit to tracking main branch
- Both submodules now track main branch for easier updates