### PR TITLE
Add Draft Name Editing

### DIFF
--- a/app/(camera)/drafts.tsx
+++ b/app/(camera)/drafts.tsx
@@ -1,5 +1,6 @@
 import { Draft, DraftStorage } from "@/utils/draftStorage";
 import { fileStore } from "@/utils/fileStore";
+import { DRAFT_NAME_LENGTH } from "@/constants/camera";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { router } from "expo-router";
@@ -198,7 +199,7 @@ export default function DraftsScreen() {
                 placeholder="Name this draft"
                 placeholderTextColor="#888"
                 autoFocus={true}
-                maxLength={20}
+                maxLength={DRAFT_NAME_LENGTH}
                 onSubmitEditing={() => handleSaveName(item.id)}
                 onBlur={() => handleBlur(item.id)}
                 returnKeyType="done"

--- a/app/(camera)/drafts.tsx
+++ b/app/(camera)/drafts.tsx
@@ -133,6 +133,7 @@ export default function DraftsScreen() {
   const handleBlur = (draftId: string) => {
     handleSaveName(draftId).catch((error) => {
       console.error("Error saving draft name on blur:", error);
+      Alert.alert("Error", "Failed to update draft name");
     });
   };
 

--- a/app/(camera)/drafts.tsx
+++ b/app/(camera)/drafts.tsx
@@ -198,7 +198,7 @@ export default function DraftsScreen() {
                 placeholder="Name this draft"
                 placeholderTextColor="#888"
                 autoFocus={true}
-                maxLength={50}
+                maxLength={20}
                 onSubmitEditing={() => handleSaveName(item.id)}
                 onBlur={() => handleBlur(item.id)}
                 returnKeyType="done"

--- a/app/(camera)/drafts.tsx
+++ b/app/(camera)/drafts.tsx
@@ -117,11 +117,6 @@ export default function DraftsScreen() {
 
   const handleSaveName = async (draftId: string) => {
     const trimmedName = draftNameInput.trim();
-    if (trimmedName === "" && draftNameInput === "") {
-      setEditingDraftId(null);
-      setDraftNameInput("");
-      return;
-    }
 
     try {
       await DraftStorage.updateDraftName(draftId, trimmedName || undefined);

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -535,8 +535,14 @@ export default function ShortsScreen() {
           <View style={styles.recordingTimeContainer}>
             {draftName && (
               <>
-                <ThemedText style={styles.draftNameText}>
-                  {draftName}
+                <ThemedText
+                  style={styles.draftNameText}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {draftName.length > 15
+                    ? `${draftName.substring(0, 15)}...`
+                    : draftName}
                 </ThemedText>
                 <ThemedText style={styles.separatorText}>•</ThemedText>
               </>

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -479,20 +479,18 @@ export default function ShortsScreen() {
             currentRecordingDuration={currentRecordingDuration}
           />
 
-          {isRecording && (
-            <View style={styles.recordingTimeContainer}>
-              <ThemedText style={styles.recordingTimeText}>
-                {(() => {
-                  const totalSeconds = Math.floor(
-                    totalUsedDuration + currentRecordingDuration
-                  );
-                  const minutes = Math.floor(totalSeconds / 60);
-                  const seconds = totalSeconds % 60;
-                  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-                })()}
-              </ThemedText>
-            </View>
-          )}
+          <View style={styles.recordingTimeContainer}>
+            <ThemedText style={styles.recordingTimeText}>
+              {(() => {
+                const totalSeconds = Math.floor(
+                  totalUsedDuration + currentRecordingDuration
+                );
+                const minutes = Math.floor(totalSeconds / 60);
+                const seconds = totalSeconds % 60;
+                return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+              })()}
+            </ThemedText>
+          </View>
 
           {!isRecording && (
             <CloseButton
@@ -587,6 +585,8 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     alignItems: "center",
+    flexDirection: "row",
+    justifyContent: "center",
     zIndex: 10,
   },
   recordingTimeText: {

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -540,9 +540,7 @@ export default function ShortsScreen() {
                   numberOfLines={1}
                   ellipsizeMode="tail"
                 >
-                  {draftName.length > 15
-                    ? `${draftName.substring(0, 15)}...`
-                    : draftName}
+                  {draftName}
                 </ThemedText>
                 <ThemedText style={styles.separatorText}>•</ThemedText>
               </>

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -89,6 +89,10 @@ export default function ShortsScreen() {
   // Recording state
   const [isRecording, setIsRecording] = React.useState(false);
 
+  const [draftName, setDraftName] = React.useState<string | undefined>(
+    undefined
+  );
+
   // Screen-level touch state for continuous hold recording
   const [screenTouchActive, setScreenTouchActive] = React.useState(false);
   const [_buttonPressActive, setButtonPressActive] = React.useState(false); // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -158,6 +162,24 @@ export default function ShortsScreen() {
     }
   }, [loadedDuration]);
 
+  React.useEffect(() => {
+    const loadDraftName = async () => {
+      const draftToLoad = currentDraftId || draftId;
+      if (draftToLoad) {
+        try {
+          const draft = await DraftStorage.getDraftById(draftToLoad, "camera");
+          setDraftName(draft?.name);
+        } catch (error) {
+          console.error("Failed to load draft name:", error);
+          setDraftName(undefined);
+        }
+      } else {
+        setDraftName(undefined);
+      }
+    };
+    loadDraftName();
+  }, [currentDraftId, draftId]);
+
   useFocusEffect(
     React.useCallback(() => {
       const reloadDraft = async () => {
@@ -168,10 +190,13 @@ export default function ShortsScreen() {
               draftToReload,
               "camera"
             );
-            if (draft && draft.segments) {
-              const segmentsWithAbsolutePaths =
-                fileStore.convertSegmentsToAbsolute(draft.segments);
-              setRecordingSegments(segmentsWithAbsolutePaths);
+            if (draft) {
+              if (draft.segments) {
+                const segmentsWithAbsolutePaths =
+                  fileStore.convertSegmentsToAbsolute(draft.segments);
+                setRecordingSegments(segmentsWithAbsolutePaths);
+              }
+              setDraftName(draft.name);
             }
           } catch (error) {
             console.error("Failed to reload draft on focus:", error);
@@ -508,6 +533,14 @@ export default function ShortsScreen() {
           />
 
           <View style={styles.recordingTimeContainer}>
+            {draftName && (
+              <>
+                <ThemedText style={styles.draftNameText}>
+                  {draftName}
+                </ThemedText>
+                <ThemedText style={styles.separatorText}>•</ThemedText>
+              </>
+            )}
             <ThemedText style={styles.recordingTimeText}>
               {(() => {
                 const totalSeconds = Math.floor(
@@ -609,13 +642,32 @@ const styles = StyleSheet.create({
   },
   recordingTimeContainer: {
     position: "absolute",
-    top: 78,
+    top: 90,
     left: 0,
     right: 0,
     alignItems: "center",
     flexDirection: "row",
     justifyContent: "center",
     zIndex: 10,
+  },
+  draftNameText: {
+    color: "#ffffff",
+    fontSize: 16,
+    fontFamily: "Roboto-Regular",
+    textShadowColor: "rgba(0, 0, 0, 0.7)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+    marginRight: 8,
+  },
+  separatorText: {
+    color: "#ffffff",
+    fontSize: 16,
+    fontFamily: "Roboto-Regular",
+    textShadowColor: "rgba(0, 0, 0, 0.7)",
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+    marginRight: 8,
+    opacity: 0.7,
   },
   recordingTimeText: {
     color: "#ffffff",

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -66,6 +66,7 @@ export default function ShortsScreen() {
     isContinuingLastDraft,
     showContinuingIndicator,
     loadedDuration,
+    currentDraftName,
     handleStartOver,
     handleStartNew,
     handleSaveAsDraft,
@@ -88,10 +89,6 @@ export default function ShortsScreen() {
 
   // Recording state
   const [isRecording, setIsRecording] = React.useState(false);
-
-  const [draftName, setDraftName] = React.useState<string | undefined>(
-    undefined
-  );
 
   // Screen-level touch state for continuous hold recording
   const [screenTouchActive, setScreenTouchActive] = React.useState(false);
@@ -162,24 +159,6 @@ export default function ShortsScreen() {
     }
   }, [loadedDuration]);
 
-  React.useEffect(() => {
-    const loadDraftName = async () => {
-      const draftToLoad = currentDraftId || draftId;
-      if (draftToLoad) {
-        try {
-          const draft = await DraftStorage.getDraftById(draftToLoad, "camera");
-          setDraftName(draft?.name);
-        } catch (error) {
-          console.error("Failed to load draft name:", error);
-          setDraftName(undefined);
-        }
-      } else {
-        setDraftName(undefined);
-      }
-    };
-    loadDraftName();
-  }, [currentDraftId, draftId]);
-
   useFocusEffect(
     React.useCallback(() => {
       const reloadDraft = async () => {
@@ -190,13 +169,10 @@ export default function ShortsScreen() {
               draftToReload,
               "camera"
             );
-            if (draft) {
-              if (draft.segments) {
-                const segmentsWithAbsolutePaths =
-                  fileStore.convertSegmentsToAbsolute(draft.segments);
-                setRecordingSegments(segmentsWithAbsolutePaths);
-              }
-              setDraftName(draft.name);
+            if (draft && draft.segments) {
+              const segmentsWithAbsolutePaths =
+                fileStore.convertSegmentsToAbsolute(draft.segments);
+              setRecordingSegments(segmentsWithAbsolutePaths);
             }
           } catch (error) {
             console.error("Failed to reload draft on focus:", error);
@@ -533,14 +509,15 @@ export default function ShortsScreen() {
           />
 
           <View style={styles.recordingTimeContainer}>
-            {draftName && (
+            {currentDraftName && (
               <>
                 <ThemedText
                   style={styles.draftNameText}
                   numberOfLines={1}
                   ellipsizeMode="tail"
+                  accessibilityLabel={`Draft name: ${currentDraftName}`}
                 >
-                  {draftName}
+                  {currentDraftName}
                 </ThemedText>
                 <ThemedText style={styles.separatorText}>•</ThemedText>
               </>

--- a/constants/camera.ts
+++ b/constants/camera.ts
@@ -1,5 +1,7 @@
 import { Platform } from 'react-native';
 
+export const DRAFT_NAME_LENGTH = 20;
+
 /**
  * Cross-platform video stabilization mode enum.
  * Simple on/off control for both iOS and Android.

--- a/hooks/useDraftManager.ts
+++ b/hooks/useDraftManager.ts
@@ -31,6 +31,7 @@ interface DraftManagerState {
   isContinuingLastDraft: boolean;
   showContinuingIndicator: boolean;
   loadedDuration: number | null;
+  currentDraftName: string | undefined;
 }
 
 interface DraftManagerActions {
@@ -280,6 +281,8 @@ export function useDraftManager(
     };
 
     saveRedoStack();
+    // Conditionally depend on originalDraftId only when currentDraftId is null/undefined
+    // to avoid unnecessary re-runs when originalDraftId changes but currentDraftId exists
   }, [
     redoStack,
     currentDraftId,
@@ -699,6 +702,7 @@ export function useDraftManager(
     isContinuingLastDraft,
     showContinuingIndicator,
     loadedDuration,
+    currentDraftName,
     // Actions
     setRecordingSegments,
     setRedoStack,


### PR DESCRIPTION


Adds the ability to name drafts via long-press editing in the drafts screen. Draft names are preserved through undo/redo operations.

## Changes

- **Draft name editing**: Long-press any draft in the drafts list to edit its name
- **Name preservation**: Draft names are maintained through undo/redo operations
- **Auto-save**: Names save on blur or submit
- **Removed editing from shorts screen**: Draft name editing is only available in the drafts list

## Implementation

- Added `updateDraftName()` method to `DraftStorage`
- Preserved draft names in redo stack data
- Added inline `TextInput` editing in drafts screen
- Improved error handling with proper logging
