### PR TITLE
Fix: Remove error screen blocking exit when all segments are deleted

### DIFF
--- a/app/reordersegments.tsx
+++ b/app/reordersegments.tsx
@@ -92,7 +92,6 @@ export default function ReorderSegmentsScreen() {
         const totalDuration = draft.totalDuration;
 
         await DraftStorage.updateDraft(draftId, updatedSegments, totalDuration);
-        
         // Navigate back after successful save
         router.back();
       } catch (error) {
@@ -118,17 +117,6 @@ export default function ReorderSegmentsScreen() {
       <View style={[styles.container, styles.loadingContainer]}>
         <ActivityIndicator size="large" color="#ff0000" />
         <ThemedText style={styles.loadingText}>Loading segments...</ThemedText>
-      </View>
-    );
-  }
-
-  if (segments.length === 0) {
-    return (
-      <View style={[styles.container, styles.errorContainer]}>
-        <ThemedText style={styles.errorText}>No segments found</ThemedText>
-        <ThemedText style={styles.errorSubtext}>
-          Please record some segments first
-        </ThemedText>
       </View>
     );
   }
@@ -166,23 +154,5 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontFamily: "Roboto-Regular",
     marginTop: 16,
-  },
-  errorContainer: {
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 40,
-  },
-  errorText: {
-    color: "#fff",
-    fontSize: 18,
-    fontFamily: "Roboto-Bold",
-    textAlign: "center",
-    marginBottom: 8,
-  },
-  errorSubtext: {
-    color: "#ccc",
-    fontSize: 14,
-    fontFamily: "Roboto-Regular",
-    textAlign: "center",
   },
 });


### PR DESCRIPTION
### Problem
After deleting all segments in the reorder screen, users were stuck on an error screen showing "No segments found, please record some segments first" with no way to navigate back. The only option was to force-kill the app.

### Solution
- Removed the error screen that appears when `segments.length === 0`
- Always render the `SegmentReorderListVertical` component, which includes a close button in the header
- When all segments are deleted, the screen now shows an empty reorder interface with "0 segments" that can be closed normally

### Changes
- Removed error screen UI and related styles from `app/reordersegments.tsx`
- Screen now gracefully handles empty segment arrays by showing the standard reorder interface with close button