### PR TITLE
 Add Upload Button for Single Segment Videos

### DIFF
--- a/app/preview.tsx
+++ b/app/preview.tsx
@@ -413,6 +413,41 @@ export default function PreviewScreen() {
         </TouchableOpacity>
       )}
 
+      {videoUris.length === 1 && (
+        <TouchableOpacity
+          style={[styles.concatenateButton, { bottom: insets.bottom + 20 }]}
+          onPress={() => {
+            try {
+              if (player1 && typeof player1.pause === "function") {
+                player1.pause();
+              }
+            } catch (error) {}
+
+            try {
+              if (player2 && typeof player2.pause === "function") {
+                player2.pause();
+              }
+            } catch (error) {}
+
+            router.push({
+              pathname: "/merged-video",
+              params: { videoUri: videoUris[0], draftId: draftId || "" },
+            });
+          }}
+          activeOpacity={0.8}
+        >
+          <View style={styles.buttonContent}>
+            <MaterialIcons
+              name="cloud-upload"
+              size={20}
+              color="#ffffff"
+              style={styles.buttonIcon}
+            />
+            <ThemedText style={styles.buttonText}>Upload Video</ThemedText>
+          </View>
+        </TouchableOpacity>
+      )}
+
       {/* Loading overlay */}
       {isConcatenating && (
         <View style={styles.loadingOverlay}>


### PR DESCRIPTION
## Add Upload Button for Single Segment Videos

### Problem
When there's only one recorded segment in the preview screen, no action button is shown because the merge button only appears when there are multiple segments. This prevents users from uploading single-segment videos.

### Solution
Added an "Upload Video" button that appears when there's exactly one segment. Clicking it navigates directly to the upload screen with that single video, bypassing the merge step.

### Changes
- Added conditional rendering for an "Upload Video" button when `videoUris.length === 1`
- Button uses the same styling as the "Merge Videos" button for consistency
- On press, pauses all video players and navigates to `/merged-video` with the single video URI and draftId
- Button displays a cloud-upload icon and "Upload Video" text

### Behavior
- Multiple segments (>1): Shows "Merge Videos" button (existing behavior)
- Single segment (=1): Shows "Upload Video" button (new behavior)
- No segments: No button shown

Fixes #214