### PR TITLE
BugFix: fixing android video segment merge error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,17 @@ expo-env.d.ts
 *.key
 *.mobileprovision
 
+# Android
+android/app/build/
+android/app/.cxx/
+android/build/
+android/.gradle/
+modules/video-concat/android/build/
+modules/video-concat/android/.gradle/
+*.apk
+*.aab
+local.properties
+
 # Metro
 .metro-health-check*
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,18 +82,18 @@ def enableProguardInReleaseBuilds = (findProperty('android.enableProguardInRelea
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
 android {
-    ndkVersion rootProject.ext.ndkVersion
+    ndkVersion = rootProject.ext.ndkVersion
 
-    buildToolsVersion rootProject.ext.buildToolsVersion
-    compileSdk rootProject.ext.compileSdkVersion
+    buildToolsVersion = rootProject.ext.buildToolsVersion
+    compileSdk = rootProject.ext.compileSdkVersion
 
-    namespace 'com.mieweb.pulse'
+    namespace = "com.mieweb.pulse"
     defaultConfig {
-        applicationId 'com.mieweb.pulse'
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.1"
+        applicationId = "com.mieweb.pulse"
+        minSdk = rootProject.ext.minSdkVersion
+        targetSdk = rootProject.ext.targetSdkVersion
+        versionCode = 1
+        versionName = "1.0.1"
     }
     signingConfigs {
         debug {
@@ -111,15 +111,15 @@ android {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
-            shrinkResources (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
-            minifyEnabled enableProguardInReleaseBuilds
+            shrinkResources = (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
+            minifyEnabled = enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            crunchPngs (findProperty('android.enablePngCrunchInReleaseBuilds')?.toBoolean() ?: true)
+            crunchPngs = (findProperty('android.enablePngCrunchInReleaseBuilds')?.toBoolean() ?: true)
         }
     }
     packagingOptions {
         jniLibs {
-            useLegacyPackaging (findProperty('expo.useLegacyPackaging')?.toBoolean() ?: false)
+            useLegacyPackaging = (findProperty('expo.useLegacyPackaging')?.toBoolean() ?: false)
         }
     }
     androidResources {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.mieweb.pulse">
   <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.INTERNET"/>

--- a/modules/video-concat/android/src/main/java/expo/modules/videoconcat/VideoConcatModule.kt
+++ b/modules/video-concat/android/src/main/java/expo/modules/videoconcat/VideoConcatModule.kt
@@ -2,39 +2,229 @@ package expo.modules.videoconcat
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import java.net.URL
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.net.Uri
+import java.io.File
+import java.nio.ByteBuffer
+
+data class RecordingSegment(
+  @Field val uri: String,
+  @Field val inMs: Int? = null,
+  @Field val outMs: Int? = null
+) : Record
 
 class VideoConcatModule : Module() {
-  // Each module class must implement the definition function. The definition consists of components
-  // that describes the module's functionality and behavior.
-  // See https://docs.expo.dev/modules/module-api for more details about available components.
   override fun definition() = ModuleDefinition {
-    // Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument.
-    // Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
-    // The module will be accessible from `requireNativeModule('VideoConcat')` in JavaScript.
     Name("VideoConcat")
-
-    // Sets constant properties on the module. Can take a dictionary or a closure that returns a dictionary.
-    Constants(
-      "PI" to Math.PI
-    )
-
-    // Defines event names that the module can send to JavaScript.
-    Events("onChange")
-
-    // Defines a JavaScript synchronous function that runs the native code on the JavaScript thread.
-    Function("hello") {
-      "Hello world! 👋"
-    }
-
-    // Defines a JavaScript function that always returns a Promise and whose native code
-    // is by default dispatched on the different thread than the JavaScript runtime runs on.
-    AsyncFunction("setValueAsync") { value: String ->
-      // Send an event to JavaScript.
-      sendEvent("onChange", mapOf(
-        "value" to value
+    
+    Events("onProgress")
+    
+    AsyncFunction("export") { segments: List<RecordingSegment>, draftId: String ->
+      val context = appContext.reactContext ?: throw Exception("React context not available")
+      
+      // Create output file
+      val outputFile = File(context.cacheDir, "$draftId.mp4")
+      if (outputFile.exists()) {
+        outputFile.delete()
+      }
+      
+      // Send initial progress
+      sendEvent("onProgress", mapOf(
+        "progress" to 0.0,
+        "currentSegment" to 0,
+        "phase" to "preparing"
       ))
+      
+      // Create muxer for output
+      val muxer = MediaMuxer(outputFile.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+      var videoTrackIndex = -1
+      var audioTrackIndex = -1
+      var muxerStarted = false
+      
+      // First pass: Add tracks from the first segment
+      val firstUri = Uri.parse(segments[0].uri)
+      val firstExtractor = MediaExtractor()
+      
+      try {
+        firstExtractor.setDataSource(context, firstUri, null)
+        
+        for (trackIndex in 0 until firstExtractor.trackCount) {
+          val format = firstExtractor.getTrackFormat(trackIndex)
+          val mime = format.getString(MediaFormat.KEY_MIME) ?: continue
+          
+          if (mime.startsWith("video/") && videoTrackIndex == -1) {
+            videoTrackIndex = muxer.addTrack(format)
+          } else if (mime.startsWith("audio/") && audioTrackIndex == -1) {
+            audioTrackIndex = muxer.addTrack(format)
+          }
+        }
+        
+        // Start muxer after adding all tracks
+        muxer.start()
+        muxerStarted = true
+        
+      } finally {
+        firstExtractor.release()
+      }
+      
+      // Second pass: Process all segments
+      var currentVideoPresentationTimeUs = 0L
+      var currentAudioPresentationTimeUs = 0L
+      
+      for ((index, segment) in segments.withIndex()) {
+        val uri = Uri.parse(segment.uri)
+        val extractor = MediaExtractor()
+        
+        try {
+          extractor.setDataSource(context, uri, null)
+          
+          var videoFirstSampleTimeUs = -1L
+          var audioFirstSampleTimeUs = -1L
+          val videoSegmentStartTime = currentVideoPresentationTimeUs
+          val audioSegmentStartTime = currentAudioPresentationTimeUs
+          
+          // Process video track
+          for (trackIndex in 0 until extractor.trackCount) {
+            val format = extractor.getTrackFormat(trackIndex)
+            val mime = format.getString(MediaFormat.KEY_MIME) ?: continue
+            
+            if (mime.startsWith("video/") && videoTrackIndex != -1) {
+              extractor.selectTrack(trackIndex)
+              
+              // Calculate time range
+              val startTimeUs = (segment.inMs ?: 0) * 1000L
+              val durationUs = if (format.containsKey(MediaFormat.KEY_DURATION)) {
+                format.getLong(MediaFormat.KEY_DURATION)
+              } else {
+                Long.MAX_VALUE
+              }
+              val endTimeUs = (segment.outMs?.let { it * 1000L } ?: durationUs)
+              
+              extractor.seekTo(startTimeUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+              
+              val buffer = ByteBuffer.allocate(1024 * 1024)
+              val bufferInfo = MediaCodec.BufferInfo()
+              
+              while (true) {
+                val sampleSize = extractor.readSampleData(buffer, 0)
+                if (sampleSize < 0) break
+                
+                val presentationTimeUs = extractor.sampleTime
+                if (presentationTimeUs < startTimeUs) {
+                  extractor.advance()
+                  continue
+                }
+                if (presentationTimeUs > endTimeUs) break
+                
+                // Record first sample time for offset calculation
+                if (videoFirstSampleTimeUs == -1L) {
+                  videoFirstSampleTimeUs = presentationTimeUs
+                }
+                
+                // Adjust presentation time for concatenation
+                val adjustedPresentationTime = videoSegmentStartTime + (presentationTimeUs - videoFirstSampleTimeUs)
+                
+                bufferInfo.set(0, sampleSize, adjustedPresentationTime, extractor.sampleFlags)
+                muxer.writeSampleData(videoTrackIndex, buffer, bufferInfo)
+                
+                currentVideoPresentationTimeUs = adjustedPresentationTime
+                
+                if (!extractor.advance()) break
+              }
+              
+              extractor.unselectTrack(trackIndex)
+            }
+          }
+          
+          // Process audio track separately
+          for (trackIndex in 0 until extractor.trackCount) {
+            val format = extractor.getTrackFormat(trackIndex)
+            val mime = format.getString(MediaFormat.KEY_MIME) ?: continue
+            
+            if (mime.startsWith("audio/") && audioTrackIndex != -1) {
+              extractor.selectTrack(trackIndex)
+              
+              val startTimeUs = (segment.inMs ?: 0) * 1000L
+              val durationUs = if (format.containsKey(MediaFormat.KEY_DURATION)) {
+                format.getLong(MediaFormat.KEY_DURATION)
+              } else {
+                Long.MAX_VALUE
+              }
+              val endTimeUs = (segment.outMs?.let { it * 1000L } ?: durationUs)
+              
+              extractor.seekTo(startTimeUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+              
+              val buffer = ByteBuffer.allocate(1024 * 1024)
+              val bufferInfo = MediaCodec.BufferInfo()
+              
+              while (true) {
+                val sampleSize = extractor.readSampleData(buffer, 0)
+                if (sampleSize < 0) break
+                
+                val presentationTimeUs = extractor.sampleTime
+                if (presentationTimeUs < startTimeUs) {
+                  extractor.advance()
+                  continue
+                }
+                if (presentationTimeUs > endTimeUs) break
+                
+                // Record first sample time for offset calculation
+                if (audioFirstSampleTimeUs == -1L) {
+                  audioFirstSampleTimeUs = presentationTimeUs
+                }
+                
+                // Adjust presentation time for concatenation
+                val adjustedPresentationTime = audioSegmentStartTime + (presentationTimeUs - audioFirstSampleTimeUs)
+                
+                bufferInfo.set(0, sampleSize, adjustedPresentationTime, extractor.sampleFlags)
+                muxer.writeSampleData(audioTrackIndex, buffer, bufferInfo)
+                
+                currentAudioPresentationTimeUs = adjustedPresentationTime
+                
+                if (!extractor.advance()) break
+              }
+              
+              extractor.unselectTrack(trackIndex)
+            }
+          }
+          
+          // Send progress update
+          val progress = (index + 1).toDouble() / segments.size * 0.8
+          sendEvent("onProgress", mapOf(
+            "progress" to progress,
+            "currentSegment" to index + 1,
+            "phase" to "processing"
+          ))
+          
+        } finally {
+          extractor.release()
+        }
+      }
+      
+      // Finalize
+      sendEvent("onProgress", mapOf(
+        "progress" to 0.9,
+        "currentSegment" to segments.size,
+        "phase" to "finalizing"
+      ))
+      
+      if (muxerStarted) {
+        muxer.stop()
+      }
+      muxer.release()
+      
+      // Return file URI
+      Uri.fromFile(outputFile).toString()
     }
-
+    
+    AsyncFunction("cancelExport") {
+      // Placeholder for cancel functionality
+    }
   }
 }


### PR DESCRIPTION

## BugFix: Android Video Segment Merge Error

### Problem
Video segment concatenation was failing on Android due to incomplete implementation in the `VideoConcatModule`.

### Changes
- **Implemented full video concatenation logic** using Android's `MediaExtractor` and `MediaMuxer`
  - Properly handles video and audio tracks separately
  - Adjusts presentation timestamps for seamless concatenation
  - Supports segment trimming with `inMs` and `outMs` parameters
  - Emits progress events during export

- **Updated Gradle configuration** to use explicit assignment operators for compatibility with modern Gradle versions

- **Added package declaration** to `AndroidManifest.xml` for improved build tool compatibility

- **Enhanced .gitignore** to exclude Android build artifacts and caches

### Technical Details
The new implementation uses a two-pass approach:
1. Extract track formats from the first segment to configure the muxer
2. Process all segments sequentially, adjusting timestamps to maintain A/V sync

Issue: https://github.com/mieweb/pulse/issues/246
Short: https://youtube.com/shorts/lk8E7RJEvuY