### PR TITLE
Per-draft upload config & deeplink fix

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,7 +93,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.1.1"
+        versionName "1.1.2"
     }
     signingConfigs {
         debug {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "pulse",
     "slug": "pulse",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "orientation": "portrait",
     "icon": "./assets/images/pulse-logo.png",
     "scheme": "pulsecam",

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -65,21 +65,29 @@ export default function ShortsScreen() {
     | "camera"
     | "upload";
   
-  // Store server and token if provided (from deeplink)
+  // Store server and token for this draft only when provided (from QR deeplink)
   React.useEffect(() => {
     const storeConfig = async () => {
       if (server && token) {
         try {
-          const { storeUploadConfig } = await import("@/utils/uploadConfig");
-          await storeUploadConfig(server, token);
-          console.log("✅ Stored upload config in shorts screen");
+          const {
+            storeUploadConfigForDraft,
+            storeUploadConfig,
+          } = await import("@/utils/uploadConfig");
+          if (draftId) {
+            await storeUploadConfigForDraft(draftId, server, token);
+            console.log("✅ Stored upload config for draft", draftId);
+          } else {
+            await storeUploadConfig(server, token);
+            console.log("✅ Stored upload config in shorts (global)");
+          }
         } catch (error) {
           console.error("❌ Failed to store upload config:", error);
         }
       }
     };
     storeConfig();
-  }, [server, token]);
+  }, [draftId, server, token]);
   const cameraRef = React.useRef<CameraView>(null);
   
   // Use a stable ref callback to avoid CameraView remounting on every render

--- a/app/(camera)/shorts.tsx
+++ b/app/(camera)/shorts.tsx
@@ -155,14 +155,15 @@ export default function ShortsScreen() {
   // The derived value ensures listeners are registered before values are updated
   // We reference all shared values here to create listeners
   useDerivedValue(() => {
-    // Read all shared values to create listeners
-    // This prevents warnings when values are updated from JS
-    isHoldRecording.value;
-    recordingModeShared.value;
-    currentZoom.value;
-    savedZoom.value;
-    currentTouchY.value;
-    initialTouchY.value;
+    // Read all shared values to create listeners (void = intentional read for dependency)
+    void (
+      isHoldRecording.value,
+      recordingModeShared.value,
+      currentZoom.value,
+      savedZoom.value,
+      currentTouchY.value,
+      initialTouchY.value
+    );
     return 0; // Return dummy value
   });
 
@@ -267,6 +268,8 @@ export default function ShortsScreen() {
       isHoldRecording.value = false;
       recordingModeShared.value = "";
     }
+    // isHoldRecording and recordingModeShared are Reanimated shared refs (stable), omit from deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRecording]);
 
   useFocusEffect(

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -37,6 +37,7 @@ export default function HomeScreen() {
   const [importing, setImporting] = useState(false);
   const [selectedDraftIds, setSelectedDraftIds] = useState<Set<string>>(new Set());
   const [isSelectionMode, setIsSelectionMode] = useState(false);
+
   const loadDrafts = useCallback(async () => {
     try {
       const savedDrafts = await DraftStorage.getAllDrafts();
@@ -538,7 +539,11 @@ export default function HomeScreen() {
                   <Text style={styles.uploadDestinationText} numberOfLines={2}>
                     {item.uploadConfig.server}
                   </Text>
-                ) : null}
+                ) : (
+                  <Text style={[styles.uploadDestinationText, { fontStyle: "italic", color: colors.secondaryText }]} numberOfLines={2}>
+                    Server not set up for upload
+                  </Text>
+                )}
               </View>
             )}
           </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,6 @@
 import { Draft, DraftStorage } from "@/utils/draftStorage";
 import { fileStore } from "@/utils/fileStore";
 import { DraftTransfer } from "@/utils/draftTransfer";
-import { getUploadConfig } from "@/utils/uploadConfig";
 import { DRAFT_NAME_LENGTH } from "@/constants/camera";
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
@@ -38,24 +37,14 @@ export default function HomeScreen() {
   const [importing, setImporting] = useState(false);
   const [selectedDraftIds, setSelectedDraftIds] = useState<Set<string>>(new Set());
   const [isSelectionMode, setIsSelectionMode] = useState(false);
-  const [uploadDestinationName, setUploadDestinationName] = useState<string | null>(null);
-
   const loadDrafts = useCallback(async () => {
     try {
-      const [savedDrafts, config] = await Promise.all([
-        DraftStorage.getAllDrafts(),
-        getUploadConfig(),
-      ]);
+      const savedDrafts = await DraftStorage.getAllDrafts();
       setDrafts(
         savedDrafts.sort(
           (a, b) => b.lastModified.getTime() - a.lastModified.getTime()
         )
       );
-      if (config?.server) {
-        setUploadDestinationName(config.server);
-      } else {
-        setUploadDestinationName(null);
-      }
     } catch (error) {
       console.error("Error loading drafts:", error);
     } finally {
@@ -545,9 +534,9 @@ export default function HomeScreen() {
             {item.mode === "upload" && (
               <View style={styles.uploadDestination}>
                 <MaterialIcons name="link" size={14} color={colors.secondaryText} />
-                {uploadDestinationName ? (
+                {item.uploadConfig?.server ? (
                   <Text style={styles.uploadDestinationText} numberOfLines={2}>
-                    {uploadDestinationName}
+                    {item.uploadConfig.server}
                   </Text>
                 ) : null}
               </View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,20 +4,66 @@ import {
   ThemeProvider,
 } from "@react-navigation/native";
 import { useFonts } from "expo-font";
+import { useRouter } from "expo-router";
 import { Stack } from "expo-router";
+import * as Linking from "expo-linking";
 import { StatusBar } from "expo-status-bar";
+import { useEffect } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import "react-native-reanimated";
 
 import { PermissionMonitor } from "@/components/PermissionMonitor";
 import { useColorScheme } from "@/hooks/useColorScheme";
+import { storeUploadConfigForDraft } from "@/utils/uploadConfig";
+
+const isUUIDv4 = (uuid: string) =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(uuid);
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const router = useRouter();
   const [loaded] = useFonts({
     "Roboto-Regular": require("../assets/fonts/Roboto-Regular.ttf"),
     "Roboto-Bold": require("../assets/fonts/Roboto-Bold.ttf"),
   });
+
+  // When app is in background and user opens a deeplink (e.g. scans QR), go straight to shorts or server-not-setup
+  useEffect(() => {
+    const handleUrl = async (event: { url: string }) => {
+      const url = event.url;
+      const q = url.includes("?") ? url.split("?")[1] : "";
+      const search = new URLSearchParams(q);
+      const mode = search.get("mode");
+      if (mode !== "upload") return;
+      const draftId = search.get("draftId");
+      const server = search.get("server");
+      const token = search.get("token");
+      const hasValidDraftId = draftId && isUUIDv4(draftId);
+      if (hasValidDraftId && server && token) {
+        try {
+          await storeUploadConfigForDraft(draftId, server, token);
+        } catch (e) {
+          console.warn("[Deeplink] Failed to store upload config:", e);
+        }
+        router.replace({
+          pathname: "/(camera)/shorts",
+          params: { mode: "upload", draftId, server, token },
+        });
+      } else {
+        router.replace({
+          pathname: "/",
+          params: {
+            mode: "upload",
+            ...(server && { server }),
+            ...(token && { token }),
+            serverNotSetupForUpload: "true",
+          },
+        });
+      }
+    };
+    const subscription = Linking.addEventListener("url", handleUrl);
+    return () => subscription.remove();
+  }, [router]);
 
   if (!loaded) {
     // Async font loading only occurs in development.

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -22,15 +22,17 @@ export default function Index() {
     draftId?: string;
     server?: string;
     token?: string;
+    serverNotSetupForUpload?: string;
   }>();
   const router = useRouter();
   const [hasRedirected, setHasRedirected] = useState(false);
 
   const hasValidDraftId = params.draftId && isUUIDv4(params.draftId);
   const serverNotSetupForUpload =
-    params.mode === "upload" &&
-    (params.server != null || params.token != null) &&
-    !hasValidDraftId;
+    params.serverNotSetupForUpload === "true" ||
+    (params.mode === "upload" &&
+      (params.server != null || params.token != null) &&
+      !hasValidDraftId);
 
   // Debug logging for deeplink parameters
   console.log("🔗 Deeplink params:", params);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,9 @@
 import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { storeUploadConfig } from "@/utils/uploadConfig";
+import {
+  storeUploadConfig,
+  storeUploadConfigForDraft,
+} from "@/utils/uploadConfig";
 
 // Simple UUID v4 validation (basic format check)
 const isUUIDv4 = (uuid: string) => {
@@ -26,11 +29,20 @@ export default function Index() {
   useEffect(() => {
     const handleDeeplink = async () => {
       if (params.mode === "upload") {
-        // Store server and token if provided
+        // Store server and token for this draft only (so Pulse Vault vs Pulse Clip stay per-draft)
         if (params.server && params.token) {
           try {
-            await storeUploadConfig(params.server, params.token);
-            console.log("✅ Stored upload config from deeplink");
+            if (params.draftId && isUUIDv4(params.draftId)) {
+              await storeUploadConfigForDraft(
+                params.draftId,
+                params.server,
+                params.token
+              );
+              console.log("✅ Stored upload config for draft", params.draftId);
+            } else {
+              await storeUploadConfig(params.server, params.token);
+              console.log("✅ Stored upload config from deeplink (global)");
+            }
           } catch (error) {
             console.error("❌ Failed to store upload config:", error);
           }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,9 +1,13 @@
 import { Redirect, useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
-  storeUploadConfig,
-  storeUploadConfigForDraft,
-} from "@/utils/uploadConfig";
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { storeUploadConfigForDraft } from "@/utils/uploadConfig";
 
 // Simple UUID v4 validation (basic format check)
 const isUUIDv4 = (uuid: string) => {
@@ -22,70 +26,128 @@ export default function Index() {
   const router = useRouter();
   const [hasRedirected, setHasRedirected] = useState(false);
 
+  const hasValidDraftId = params.draftId && isUUIDv4(params.draftId);
+  const serverNotSetupForUpload =
+    params.mode === "upload" &&
+    (params.server != null || params.token != null) &&
+    !hasValidDraftId;
+
   // Debug logging for deeplink parameters
   console.log("🔗 Deeplink params:", params);
 
-  // Store server and token when provided in deeplink, then redirect
+  // When we have a valid draftId: store config and redirect to shorts
   useEffect(() => {
     const handleDeeplink = async () => {
-      if (params.mode === "upload") {
-        // Store server and token for this draft only (so Pulse Vault vs Pulse Clip stay per-draft)
-        if (params.server && params.token) {
-          try {
-            if (params.draftId && isUUIDv4(params.draftId)) {
-              await storeUploadConfigForDraft(
-                params.draftId,
-                params.server,
-                params.token
-              );
-              console.log("✅ Stored upload config for draft", params.draftId);
-            } else {
-              await storeUploadConfig(params.server, params.token);
-              console.log("✅ Stored upload config from deeplink (global)");
-            }
-          } catch (error) {
-            console.error("❌ Failed to store upload config:", error);
-          }
+      if (
+        params.mode === "upload" &&
+        hasValidDraftId &&
+        params.server &&
+        params.token
+      ) {
+        try {
+          await storeUploadConfigForDraft(
+            params.draftId!,
+            params.server,
+            params.token
+          );
+          console.log("✅ Stored upload config for draft", params.draftId);
+        } catch (error) {
+          console.error("❌ Failed to store upload config:", error);
         }
-
-        // Build redirect URL with all parameters
-        const redirectParams: Record<string, string> = {
-          mode: "upload",
-        };
-
-        if (params.draftId && isUUIDv4(params.draftId)) {
-          redirectParams.draftId = params.draftId;
-        }
-
-        // Include server and token in URL (they're also stored in AsyncStorage)
-        if (params.server) {
-          redirectParams.server = params.server;
-        }
-        if (params.token) {
-          redirectParams.token = params.token;
-        }
-
-        // Redirect to shorts screen
         if (!hasRedirected) {
           setHasRedirected(true);
           router.push({
             pathname: "/(camera)/shorts",
-            params: redirectParams,
+            params: {
+              mode: "upload",
+              draftId: params.draftId,
+              server: params.server,
+              token: params.token,
+            },
           });
         }
       }
     };
 
     handleDeeplink();
-  }, [params.mode, params.draftId, params.server, params.token, router, hasRedirected]);
+  }, [
+    params.mode,
+    params.draftId,
+    params.server,
+    params.token,
+    hasValidDraftId,
+    router,
+    hasRedirected,
+  ]);
 
-  // Handle upload mode - redirect happens in useEffect
+  // Server not set up for upload (e.g. Pulse Clip QR with no draftId): show message here
+  if (serverNotSetupForUpload) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Server not set up for upload</Text>
+        <Text style={styles.message}>
+          Server is not properly set up for upload.
+        </Text>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => router.replace("/(tabs)")}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.buttonText}>Go to home</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // Valid upload with draftId: show loading until redirect
   if (params.mode === "upload") {
-    // Show nothing while processing (or a loading indicator)
-    return null;
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color="#0a84ff" />
+        <Text style={styles.text}>Opening...</Text>
+      </View>
+    );
   }
 
   // Default to tabs
   return <Redirect href="/(tabs)" />;
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#000",
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  title: {
+    color: "#fff",
+    fontSize: 20,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  message: {
+    color: "rgba(255,255,255,0.8)",
+    fontSize: 16,
+    textAlign: "center",
+  },
+  text: {
+    color: "#fff",
+    fontSize: 16,
+  },
+  button: {
+    marginTop: 16,
+    backgroundColor: "#0a84ff",
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 10,
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+});
 

--- a/app/merged-video.tsx
+++ b/app/merged-video.tsx
@@ -17,7 +17,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router, useLocalSearchParams } from "expo-router";
 import { uploadVideo } from "@/utils/tusUpload";
-import { getUploadConfig } from "@/utils/uploadConfig";
+import { getUploadConfigForDraftOrGlobal } from "@/utils/uploadConfig";
 import { DraftStorage } from "@/utils/draftStorage";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
@@ -78,10 +78,10 @@ export default function MergedVideoScreen() {
     setupPlayer();
   }, [videoUri, player]);
 
-  // Check if upload config is available and if draft is in upload mode
+  // Check if upload config is available for this draft and if draft is in upload mode
   useEffect(() => {
     const checkUploadConfig = async () => {
-      const config = await getUploadConfig();
+      const config = await getUploadConfigForDraftOrGlobal(draftId ?? undefined);
       setHasUploadConfig(!!config);
 
       // Check if the draft was created in upload mode
@@ -172,8 +172,8 @@ export default function MergedVideoScreen() {
       return;
     }
 
-    // Check if upload config exists
-    const config = await getUploadConfig();
+    // Use this draft's upload config (each draft can have its own server, e.g. Pulse Vault vs Pulse Clip)
+    const config = await getUploadConfigForDraftOrGlobal(draftId ?? undefined);
     if (!config) {
       Alert.alert(
         "Upload Not Configured",
@@ -202,7 +202,8 @@ export default function MergedVideoScreen() {
         filename,
         (progress) => {
           setUploadProgress(progress.percentage);
-        }
+        },
+        draftId ?? undefined
       );
 
       Alert.alert(

--- a/app/merged-video.tsx
+++ b/app/merged-video.tsx
@@ -17,7 +17,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { router, useLocalSearchParams } from "expo-router";
 import { uploadVideo } from "@/utils/tusUpload";
-import { getUploadConfigForDraftOrGlobal } from "@/utils/uploadConfig";
+import { getUploadConfigForDraft } from "@/utils/uploadConfig";
 import { DraftStorage } from "@/utils/draftStorage";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get("window");
@@ -78,10 +78,10 @@ export default function MergedVideoScreen() {
     setupPlayer();
   }, [videoUri, player]);
 
-  // Check if upload config is available for this draft and if draft is in upload mode
+  // Check if upload config is available for this draft (per-draft only; draftId required)
   useEffect(() => {
     const checkUploadConfig = async () => {
-      const config = await getUploadConfigForDraftOrGlobal(draftId ?? undefined);
+      const config = draftId ? await getUploadConfigForDraft(draftId) : null;
       setHasUploadConfig(!!config);
 
       // Check if the draft was created in upload mode
@@ -172,12 +172,11 @@ export default function MergedVideoScreen() {
       return;
     }
 
-    // Use this draft's upload config (each draft can have its own server, e.g. Pulse Vault vs Pulse Clip)
-    const config = await getUploadConfigForDraftOrGlobal(draftId ?? undefined);
-    if (!config) {
+    const config = draftId ? await getUploadConfigForDraft(draftId) : null;
+    if (!draftId || !config) {
       Alert.alert(
-        "Upload Not Configured",
-        "Please scan a QR code to configure upload settings first.",
+        "Server not set up for upload",
+        "Server is not properly set up for upload.",
         [
           {
             text: "OK",
@@ -318,10 +317,10 @@ export default function MergedVideoScreen() {
         {isUploadModeDraft && !hasUploadConfig && (
           <View style={styles.inputSection}>
             <ThemedText style={styles.inputLabel}>
-              Upload Not Configured
+              Server not set up for upload
             </ThemedText>
             <ThemedText style={styles.uploadInfoText}>
-              Scan a QR code to configure upload settings
+              Server is not properly set up for upload.
             </ThemedText>
           </View>
         )}

--- a/app/preview-new.tsx
+++ b/app/preview-new.tsx
@@ -94,6 +94,8 @@ export default function PreviewNewScreen() {
     };
 
     loadDraft();
+    // Intentionally only re-run when draftId changes; handleConcatenate/hasStartedMerge are stable for this flow
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftId]);
 
   const handleClose = useCallback(() => {

--- a/components/SegmentReorderListVertical.tsx
+++ b/components/SegmentReorderListVertical.tsx
@@ -10,7 +10,7 @@ import {
   Image,
   ScrollView,
 } from "react-native";
-import { router, useLocalSearchParams } from "expo-router";
+import { router } from "expo-router";
 import Sortable from "react-native-sortables";
 
 const THUMBNAIL_SIZE = 60;
@@ -155,7 +155,6 @@ export default function SegmentReorderListVertical({
 }: SegmentReorderListVerticalProps) {
   const [reorderedSegments, setReorderedSegments] =
     useState<Segment[]>(segments);
-  const [hasChanges, setHasChanges] = useState(false);
 
   // Update reorderedSegments when segments prop changes (e.g., after trim points are updated)
   useEffect(() => {
@@ -165,7 +164,6 @@ export default function SegmentReorderListVertical({
   const handleOrderChange = useCallback(
     (newOrder: Segment[]) => {
       setReorderedSegments(newOrder);
-      setHasChanges(true);
       onSegmentsReorder(newOrder);
       // Auto-save on reorder
       onSave(newOrder);
@@ -179,7 +177,6 @@ export default function SegmentReorderListVertical({
         (segment) => segment.id !== segmentId
       );
       setReorderedSegments(updatedSegments);
-      setHasChanges(true);
       onSegmentsReorder(updatedSegments);
       // Auto-save on delete
       onSave(updatedSegments);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EXConstants (17.1.7):
+  - EXConstants (17.1.8):
     - ExpoModulesCore
   - EXImageLoader (5.1.0):
     - ExpoModulesCore
     - React-Core
-  - Expo (53.0.23):
+  - Expo (53.0.25):
     - DoubleConversion
     - ExpoModulesCore
     - glog
@@ -51,9 +51,9 @@ PODS:
     - ExpoModulesCore
   - ExpoHaptics (14.1.4):
     - ExpoModulesCore
-  - ExpoHead (5.1.7):
+  - ExpoHead (5.1.10):
     - ExpoModulesCore
-  - ExpoImage (2.4.0):
+  - ExpoImage (2.4.1):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
@@ -2520,9 +2520,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EXConstants: 98bcf0f22b820f9b28f9fee55ff2daededadd2f8
+  EXConstants: d3d551cb154718f5161c4247304e96aa59f6cca7
   EXImageLoader: 4d3d3284141f1a45006cc4d0844061c182daf7ee
-  Expo: dd7f49380001a55ea776f905f8b3c1c540160b09
+  Expo: a9aaba7e05fb1445c5605b2b1be1904efa2aaaff
   ExpoAsset: ef06e880126c375f580d4923fdd1cdf4ee6ee7d6
   ExpoBlur: 3c8885b9bf9eef4309041ec87adec48b5f1986a9
   ExpoCamera: e1879906d41184e84b57d7643119f8509414e318
@@ -2531,8 +2531,8 @@ SPEC CHECKSUMS:
   ExpoFileSystem: 7f92f7be2f5c5ed40a7c9efc8fa30821181d9d63
   ExpoFont: cf508bc2e6b70871e05386d71cab927c8524cc8e
   ExpoHaptics: 0ff6e0d83cd891178a306e548da1450249d54500
-  ExpoHead: 520990db7d4e4a09a9142b2e03bcb08b85b97e0e
-  ExpoImage: e4102c93d1dbe99ff54b075452d1bc9d6ec21b7c
+  ExpoHead: f85951372332180434f1aae973f6e3c94fccbed4
+  ExpoImage: b0b4a838c62bb9d5438bb475cccc85619a5f59dc
   ExpoImagePicker: 0963da31800c906e01c03e25d7c849f16ebf02a2
   ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
   ExpoLinking: d5c183998ca6ada66ff45e407e0f965b398a8902

--- a/ios/pulse.xcodeproj/project.pbxproj
+++ b/ios/pulse.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mieweb.pulse;
-				PRODUCT_NAME = pulse;
+				PRODUCT_NAME = "pulse";
 				SWIFT_OBJC_BRIDGING_HEADER = "pulse/pulse-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -396,7 +396,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mieweb.pulse;
-				PRODUCT_NAME = pulse;
+				PRODUCT_NAME = "pulse";
 				SWIFT_OBJC_BRIDGING_HEADER = "pulse/pulse-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/pulse.xcodeproj/project.pbxproj
+++ b/ios/pulse.xcodeproj/project.pbxproj
@@ -166,8 +166,8 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = X5873NL7XM;
 						LastSwiftMigration = 1250;
-						DevelopmentTeam = "X5873NL7XM";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -339,7 +339,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = pulse/pulse.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = X5873NL7XM;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -359,15 +362,12 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mieweb.pulse;
-				PRODUCT_NAME = "pulse";
+				PRODUCT_NAME = pulse;
 				SWIFT_OBJC_BRIDGING_HEADER = "pulse/pulse-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				DEVELOPMENT_TEAM = X5873NL7XM;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Debug;
 		};
@@ -378,7 +378,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = pulse/pulse.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = X5873NL7XM;
 				INFOPLIST_FILE = pulse/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -393,14 +396,11 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mieweb.pulse;
-				PRODUCT_NAME = "pulse";
+				PRODUCT_NAME = pulse;
 				SWIFT_OBJC_BRIDGING_HEADER = "pulse/pulse-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
-				DEVELOPMENT_TEAM = X5873NL7XM;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Release;
 		};

--- a/ios/pulse/Info.plist
+++ b/ios/pulse/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.1</string>
+    <string>1.1.2</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,8 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "paths": {
-      "@/*": [
-        "./*"
-      ]
-    }
+    "paths": { "@/*": ["./*"] }
   },
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    ".expo/types/**/*.ts",
-    "expo-env.d.ts"
-  ]
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
+  "exclude": ["node_modules", "pulse-desktop", "pulse-vault"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,21 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "paths": { "@/*": ["./*"] }
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
   },
-  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
-  "exclude": ["node_modules", "pulse-desktop", "pulse-vault"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".expo/types/**/*.ts",
+    "expo-env.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "pulse-desktop",
+    "pulse-vault"
+  ]
 }

--- a/utils/tusUpload.ts
+++ b/utils/tusUpload.ts
@@ -1,5 +1,5 @@
 import * as FileSystem from "expo-file-system";
-import { getUploadConfigForDraftOrGlobal } from "./uploadConfig";
+import { getUploadConfigForDraft } from "./uploadConfig";
 
 export interface UploadProgress {
   bytesUploaded: number;
@@ -26,13 +26,13 @@ export async function uploadVideo(
   console.log(`[TUS Upload] Starting upload process for: ${filename}`);
   console.log(`[TUS Upload] Video URI: ${videoUri}`);
   
-  // Use this draft's upload config (each draft can have its own server, e.g. Pulse Vault vs Pulse Clip)
-  console.log(`[TUS Upload] Step 1: Getting upload config...`);
-  const config = await getUploadConfigForDraftOrGlobal(draftId);
+  if (!draftId) {
+    throw new Error("Server not set up for upload.");
+  }
+  console.log(`[TUS Upload] Step 1: Getting upload config for draft...`);
+  const config = await getUploadConfigForDraft(draftId);
   if (!config) {
-    throw new Error(
-      "No upload configuration found. Please scan a QR code to configure upload settings."
-    );
+    throw new Error("Server not set up for upload.");
   }
 
   let { server, token } = config;

--- a/utils/tusUpload.ts
+++ b/utils/tusUpload.ts
@@ -1,5 +1,5 @@
 import * as FileSystem from "expo-file-system";
-import { getUploadConfig } from "./uploadConfig";
+import { getUploadConfigForDraftOrGlobal } from "./uploadConfig";
 
 export interface UploadProgress {
   bytesUploaded: number;
@@ -20,14 +20,15 @@ export interface UploadResult {
 export async function uploadVideo(
   videoUri: string,
   filename: string,
-  onProgress?: (progress: UploadProgress) => void
+  onProgress?: (progress: UploadProgress) => void,
+  draftId?: string
 ): Promise<UploadResult> {
   console.log(`[TUS Upload] Starting upload process for: ${filename}`);
   console.log(`[TUS Upload] Video URI: ${videoUri}`);
   
-  // Get stored upload config
+  // Use this draft's upload config (each draft can have its own server, e.g. Pulse Vault vs Pulse Clip)
   console.log(`[TUS Upload] Step 1: Getting upload config...`);
-  const config = await getUploadConfig();
+  const config = await getUploadConfigForDraftOrGlobal(draftId);
   if (!config) {
     throw new Error(
       "No upload configuration found. Please scan a QR code to configure upload settings."

--- a/utils/updateUploadServer.ts
+++ b/utils/updateUploadServer.ts
@@ -1,28 +1,34 @@
-import { getUploadConfig, storeUploadConfig } from "./uploadConfig";
+import {
+  getUploadConfigForDraft,
+  storeUploadConfigForDraft,
+} from "./uploadConfig";
 
 /**
- * Update the server URL in stored upload config
- * Useful when switching from localhost to local IP for device testing
+ * Update the server URL in stored upload config for a specific draft.
+ * Useful when switching from localhost to local IP for device testing.
  */
-export async function updateUploadServerUrl(newServerUrl: string): Promise<void> {
-  const config = await getUploadConfig();
-  
+export async function updateUploadServerUrl(
+  draftId: string,
+  newServerUrl: string
+): Promise<void> {
+  const config = await getUploadConfigForDraft(draftId);
+
   if (!config) {
-    throw new Error("No upload config found. Please scan a QR code first.");
+    throw new Error("Server not set up for upload.");
   }
 
-  // Update with new server URL but keep the same token
-  await storeUploadConfig(newServerUrl, config.token);
-  console.log(`[UploadConfig] Updated server URL to: ${newServerUrl}`);
+  await storeUploadConfigForDraft(draftId, newServerUrl, config.token);
+  console.log("[UploadConfig] Updated server URL for draft:", draftId);
 }
 
 /**
  * Replace localhost with local IP in server URL
- * Detects common localhost patterns and suggests replacement
  */
-export function replaceLocalhostWithIP(serverUrl: string, localIP: string): string {
+export function replaceLocalhostWithIP(
+  serverUrl: string,
+  localIP: string
+): string {
   return serverUrl
     .replace(/localhost/g, localIP)
     .replace(/127\.0\.0\.1/g, localIP);
 }
-

--- a/utils/uploadConfig.ts
+++ b/utils/uploadConfig.ts
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const UPLOAD_SERVER_KEY = "upload_server_url";
 const UPLOAD_TOKEN_KEY = "upload_token";
+const UPLOAD_CONFIG_PREFIX = "upload_config_";
 
 export interface UploadConfig {
   server: string;
@@ -9,7 +10,8 @@ export interface UploadConfig {
 }
 
 /**
- * Store upload server URL and token from deeplink
+ * Store upload server URL and token from deeplink (global fallback).
+ * Prefer storeUploadConfigForDraft(draftId, ...) so each draft keeps its own server.
  */
 export async function storeUploadConfig(
   server: string,
@@ -20,7 +22,7 @@ export async function storeUploadConfig(
       [UPLOAD_SERVER_KEY, server],
       [UPLOAD_TOKEN_KEY, token],
     ]);
-    console.log("[UploadConfig] Stored server and token");
+    console.log("[UploadConfig] Stored server and token (global)");
   } catch (error) {
     console.error("[UploadConfig] Error storing upload config:", error);
     throw error;
@@ -28,7 +30,8 @@ export async function storeUploadConfig(
 }
 
 /**
- * Retrieve stored upload server URL and token
+ * Retrieve stored upload server URL and token (global fallback).
+ * Use getUploadConfigForDraft(draftId) when uploading a specific draft.
  */
 export async function getUploadConfig(): Promise<UploadConfig | null> {
   try {
@@ -51,7 +54,108 @@ export async function getUploadConfig(): Promise<UploadConfig | null> {
 }
 
 /**
- * Clear stored upload config
+ * Store upload config for a specific draft (from QR scan).
+ * Each draft can have its own server URL (e.g. Pulse Vault vs Pulse Clip).
+ */
+export async function storeUploadConfigForDraft(
+  draftId: string,
+  server: string,
+  token: string
+): Promise<void> {
+  try {
+    const key = UPLOAD_CONFIG_PREFIX + draftId;
+    await AsyncStorage.setItem(
+      key,
+      JSON.stringify({ server, token })
+    );
+    console.log("[UploadConfig] Stored config for draft:", draftId);
+  } catch (error) {
+    console.error("[UploadConfig] Error storing upload config for draft:", error);
+    throw error;
+  }
+}
+
+/**
+ * Retrieve upload config for a specific draft.
+ * Returns null if this draft has no per-draft config (e.g. camera-only or old draft).
+ */
+export async function getUploadConfigForDraft(
+  draftId: string
+): Promise<UploadConfig | null> {
+  try {
+    const key = UPLOAD_CONFIG_PREFIX + draftId;
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { server?: string; token?: string };
+    if (parsed?.server && parsed?.token) {
+      return { server: parsed.server, token: parsed.token };
+    }
+    return null;
+  } catch (error) {
+    console.error("[UploadConfig] Error retrieving upload config for draft:", error);
+    return null;
+  }
+}
+
+/**
+ * Get upload config for a draft: per-draft first, then global fallback.
+ * Use this when uploading so the correct server is used for each draft.
+ */
+export async function getUploadConfigForDraftOrGlobal(
+  draftId: string | undefined
+): Promise<UploadConfig | null> {
+  if (draftId) {
+    const perDraft = await getUploadConfigForDraft(draftId);
+    if (perDraft) return perDraft;
+  }
+  return getUploadConfig();
+}
+
+/**
+ * Retrieve upload configs for multiple drafts in one call (for draft list).
+ */
+export async function getUploadConfigsForDraftIds(
+  draftIds: string[]
+): Promise<Map<string, UploadConfig>> {
+  const map = new Map<string, UploadConfig>();
+  if (draftIds.length === 0) return map;
+  try {
+    const keys = draftIds.map((id) => UPLOAD_CONFIG_PREFIX + id);
+    const pairs = await AsyncStorage.multiGet(keys);
+    for (let i = 0; i < pairs.length; i++) {
+      const [, value] = pairs[i];
+      if (value) {
+        try {
+          const parsed = JSON.parse(value) as { server?: string; token?: string };
+          if (parsed?.server && parsed?.token) {
+            map.set(draftIds[i], { server: parsed.server, token: parsed.token });
+          }
+        } catch {
+          // skip invalid entry
+        }
+      }
+    }
+  } catch (error) {
+    console.error("[UploadConfig] Error getting configs for drafts:", error);
+  }
+  return map;
+}
+
+/**
+ * Clear stored upload config for a draft (e.g. when draft is deleted).
+ */
+export async function clearUploadConfigForDraft(draftId: string): Promise<void> {
+  try {
+    const key = UPLOAD_CONFIG_PREFIX + draftId;
+    await AsyncStorage.removeItem(key);
+    console.log("[UploadConfig] Cleared config for draft:", draftId);
+  } catch (error) {
+    console.error("[UploadConfig] Error clearing upload config for draft:", error);
+  }
+}
+
+/**
+ * Clear stored upload config (global)
  */
 export async function clearUploadConfig(): Promise<void> {
   try {


### PR DESCRIPTION
## Summary

Upload config (server + token) is now stored **per draft** instead of globally. Scanning a Pulse Clip (or Pulse Vault) QR no longer overwrites config for all drafts: each draft keeps its own server, and the app only uses config when the deeplink included a valid **draftId**. Invalid or legacy QRs (no `draftId`) show a clear "Server not set up for upload" screen instead of incorrectly applying to every draft.

## Problem

- Upload config was stored globally. Scanning a new QR (e.g. Pulse Clip) overwrote it for the whole app.
- Drafts created from different servers (Pulse Vault vs Pulse Clip) all showed the same "Pulse Clip" (or whatever was last scanned) instead of each retaining its own server.
- QRs without `draftId` (e.g. Pulse Clip’s old format) couldn’t be handled correctly and led to confusing behavior.

## Solution

### 1. Per-draft upload config (no global)

- **`utils/uploadConfig.ts`**  
  Removed global `storeUploadConfig` / `getUploadConfig` / `clearUploadConfig`.  
  Only per-draft helpers remain:  
  `storeUploadConfigForDraft(draftId, server, token)`,  
  `getUploadConfigForDraft(draftId)`,  
  `getUploadConfigsForDraftIds(draftIds)`,  
  `clearUploadConfigForDraft(draftId)`.

- **Deeplink handling** (`app/index.tsx`, `app/(camera)/shorts.tsx`)  
  Config is stored only when the URL has a valid **draftId** (UUID v4). No global write.

- **Home** (`app/(tabs)/index.tsx`)  
  Each draft shows `item.uploadConfig?.server` or "Server not set up for upload" when missing. No global fallback.

- **Upload flow** (`app/merged-video.tsx`, `utils/tusUpload.ts`)  
  Use `getUploadConfigForDraft(draftId)` only. Require `draftId`; if missing or no config, show/throw "Server not set up for upload."

- **Draft model** (`utils/draftStorage.ts`)  
  `Draft` has optional `uploadConfig?: { server, token }`.  
  `getAllDrafts()` merges per-draft config from storage.  
  Deleting a draft calls `clearUploadConfigForDraft(id)`.

- **`utils/updateUploadServer.ts`**  
  `updateUploadServerUrl(draftId, newServerUrl)` updates only that draft’s config.

### 2. "Server not set up for upload" messaging

- When the QR has **no valid draftId** (e.g. legacy Pulse Clip QR): show "Server not set up for upload" and "Go to home" on the index screen (no redirect to shorts).
- All upload-config error messaging uses "Server not set up for upload" (no draft ID/QR wording in the copy).
- **`app/index.tsx`**  
  If `serverNotSetupForUpload` (from params or derived: upload mode + server/token but no valid draftId), render that screen with "Go to home" instead of redirecting.

### 3. Deeplink when app is in background

- **`app/_layout.tsx`**  
  `Linking.addEventListener("url", handleUrl)`.
  - **Valid upload URL** (mode=upload, valid draftId, server, token):  
    In the handler, call `storeUploadConfigForDraft(draftId, server, token)` then  
    `router.replace({ pathname: "/(camera)/shorts", params: { mode, draftId, server, token } })`  
    so the user goes straight to shorts (avoids "/" resolving to tabs/home).
  - **Invalid upload URL** (no valid draftId):  
    `router.replace({ pathname: "/", params: { mode, server?, token?, serverNotSetupForUpload: "true" } })`.
- **`app/index.tsx`**  
  Accepts `serverNotSetupForUpload` in params so the server-not-setup screen can show when opened from the layout.

### 4. Pulse Clip deeplink generation (optional / separate PR)

If this branch or a related change includes the **pulseclip** clone:

- **Server:** `GET /api/upload-deeplink`  
  Generates a `draftId` (UUID v4) and `token`, returns  
  `pulsecam://?mode=upload&server=<base>&token=...&draftId=...`.
- **Client:** "Record from Pulse app" section with "Get QR for Pulse app" that calls the API and shows the QR + copyable deeplink so scanning it gives the Pulse app a valid `draftId`.

---

## Testing

- Scan a Pulse Vault QR (with draftId) → draft shows that server; open shorts, record, upload uses that draft’s config.
- Scan a Pulse Clip QR **with** draftId (from new Pulse Clip UI) → same behavior; draft shows Pulse Clip server.
- Scan a QR **without** draftId → see "Server not set up for upload" and "Go to home"; no config stored globally; other drafts unchanged.
- Open app from background via valid upload URL → lands on shorts with correct draft.  
- Open from background via invalid upload URL → lands on index with server-not-setup message.

## Branch

`feature/per-draft-upload-config`
