### PR TITLE
Fix drafts list hidden by tab bar; unhide Home and Profile tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -8,6 +8,8 @@ import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { useFirstTimeOpen } from "@/hooks/useFirstTimeOpen";
 import AntDesign from "@expo/vector-icons/AntDesign";
+import Entypo from "@expo/vector-icons/Entypo";
+import Ionicons from "@expo/vector-icons/Ionicons";
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
@@ -36,25 +38,14 @@ export default function TabLayout() {
         }),
       }}
     >
-      {/* Commented out - Home Tab */}
-      {/* <Tabs.Screen
+      <Tabs.Screen
         name="index"
         options={{
           title: "Home",
           tabBarButton: HapticTab,
-          tabBarIcon: ({ color, focused }) => (
+          tabBarIcon: ({ color }) => (
             <Entypo name="home" size={24} color={color} />
           ),
-        }}
-      /> */}
-
-      {/* Placeholder tab to maintain center positioning */}
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: "",
-          tabBarButton: () => null, // Hidden tab
-          tabBarIcon: () => null,
         }}
       />
 
@@ -135,25 +126,14 @@ export default function TabLayout() {
         }}
       />
 
-      {/* Commented out - Profile Tab */}
-      {/* <Tabs.Screen
+      <Tabs.Screen
         name="profile"
         options={{
           title: "Profile",
           tabBarButton: HapticTab,
-          tabBarIcon: ({ color, focused }) => (
+          tabBarIcon: ({ color }) => (
             <Ionicons name="person-circle-outline" size={24} color={color} />
           ),
-        }}
-      /> */}
-
-      {/* Placeholder tab to maintain center positioning */}
-      <Tabs.Screen
-        name="profile"
-        options={{
-          title: "",
-          tabBarButton: () => null, // Hidden tab
-          tabBarIcon: () => null,
         }}
       />
     </Tabs>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -149,6 +149,7 @@ export default function HomeScreen() {
         listContent: {
           padding: 20,
           paddingTop: 0,
+          paddingBottom: insets.bottom + 88,
         },
         draftItem: {
           backgroundColor: colors.surface,
@@ -245,7 +246,7 @@ export default function HomeScreen() {
           marginTop: 100,
         },
       }),
-    [colors, colorScheme]
+    [colors, colorScheme, insets.bottom]
   );
 
   const handleDraftPress = (draft: Draft) => {


### PR DESCRIPTION
- Add bottom padding to drafts FlatList (insets + tab bar height) so last draft is visible
- Unhide Home and Profile tabs in tab bar with Entypo/Ionicons icons