### PR TITLE
Configurable upload destinations

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,6 +9,7 @@ import { useColorScheme } from "@/hooks/useColorScheme";
 import { useFirstTimeOpen } from "@/hooks/useFirstTimeOpen";
 import AntDesign from "@expo/vector-icons/AntDesign";
 import Entypo from "@expo/vector-icons/Entypo";
+import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
 import Ionicons from "@expo/vector-icons/Ionicons";
 
 export default function TabLayout() {
@@ -129,10 +130,10 @@ export default function TabLayout() {
       <Tabs.Screen
         name="profile"
         options={{
-          title: "Profile",
+          title: "Upload",
           tabBarButton: HapticTab,
           tabBarIcon: ({ color }) => (
-            <Ionicons name="person-circle-outline" size={24} color={color} />
+            <FontAwesome5 name="upload" size={20} color={color} solid={false} />
           ),
         }}
       />

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,14 +1,206 @@
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
-import React from "react";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import {
+  getAllDestinations,
+  removeDestination,
+  type UploadDestination,
+} from "@/utils/uploadDestinations";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { useLocalSearchParams } from "expo-router";
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Alert,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export default function ProfileScreen() {
+  const insets = useSafeAreaInsets();
+  const colorScheme = useColorScheme() ?? "light";
+  const colors = Colors[colorScheme];
+  const params = useLocalSearchParams<{ destinationAdded?: string }>();
+  const [destinations, setDestinations] = useState<UploadDestination[]>([]);
+  const [showAddedMessage, setShowAddedMessage] = useState(false);
+
+  const loadDestinations = useCallback(async () => {
+    const list = await getAllDestinations();
+    setDestinations(list);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadDestinations();
+      if (params.destinationAdded === "true") {
+        setShowAddedMessage(true);
+        const t = setTimeout(() => setShowAddedMessage(false), 3000);
+        return () => clearTimeout(t);
+      }
+    }, [loadDestinations, params.destinationAdded])
+  );
+
+  const handleRemove = useCallback(
+    (dest: UploadDestination) => {
+      Alert.alert(
+        "Remove destination",
+        `Remove "${dest.name || dest.server}" from upload destinations?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Remove",
+            style: "destructive",
+            onPress: async () => {
+              await removeDestination(dest.id);
+              loadDestinations();
+            },
+          },
+        ]
+      );
+    },
+    [loadDestinations]
+  );
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: colors.background,
+        },
+        inner: {
+          paddingTop: insets.top + 16,
+          paddingHorizontal: 20,
+          paddingBottom: 24,
+        },
+        title: {
+          fontSize: 24,
+          fontWeight: "bold",
+          color: colors.text,
+          marginBottom: 4,
+        },
+        subtitle: {
+          fontSize: 16,
+          color: colors.secondaryText,
+          marginBottom: 24,
+        },
+        addedBanner: {
+          flexDirection: "row",
+          alignItems: "center",
+          backgroundColor: colors.selection + "20",
+          padding: 12,
+          borderRadius: 8,
+          marginBottom: 16,
+          gap: 8,
+        },
+        sectionTitle: {
+          fontSize: 18,
+          fontWeight: "600",
+          color: colors.text,
+          marginBottom: 12,
+        },
+        card: {
+          flexDirection: "row",
+          alignItems: "center",
+          backgroundColor: colors.surface,
+          borderRadius: 12,
+          padding: 16,
+          marginBottom: 10,
+          borderWidth: 1,
+          borderColor: colors.border,
+        },
+        cardContent: {
+          flex: 1,
+        },
+        cardName: {
+          fontSize: 16,
+          fontWeight: "600",
+          color: colors.text,
+        },
+        cardServer: {
+          fontSize: 12,
+          color: colors.secondaryText,
+          marginTop: 4,
+        },
+        cardExpiry: {
+          fontSize: 11,
+          color: colors.secondaryText,
+          marginTop: 2,
+        },
+        removeBtn: {
+          padding: 8,
+        },
+        empty: {
+          paddingVertical: 24,
+          alignItems: "center",
+        },
+        emptyText: {
+          fontSize: 15,
+          color: colors.secondaryText,
+          textAlign: "center",
+        },
+      }),
+    [colors, insets.top]
+  );
+
   return (
-    <ThemedView
-      style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
-    >
-      <ThemedText type="title">Profile</ThemedText>
-      <ThemedText>This is your profile page.</ThemedText>
+    <ThemedView style={styles.container}>
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.inner}
+        showsVerticalScrollIndicator={false}
+      >
+        <ThemedText style={styles.title}>Profile</ThemedText>
+        <ThemedText style={styles.subtitle}>
+          Manage your upload destinations
+        </ThemedText>
+
+        {showAddedMessage && (
+          <View style={styles.addedBanner}>
+            <MaterialIcons name="check-circle" size={22} color={colors.selection} />
+            <ThemedText style={{ flex: 1, color: colors.text }}>
+              Upload destination added. You can choose it when uploading a video.
+            </ThemedText>
+          </View>
+        )}
+
+        <ThemedText style={styles.sectionTitle}>Upload destinations</ThemedText>
+        {destinations.length === 0 ? (
+          <View style={styles.empty}>
+            <ThemedText style={styles.emptyText}>
+              No upload destinations yet.{"\n"}
+              Scan a &quot;Setup your app&quot; QR from a Pulse Vault upload page to add one.
+            </ThemedText>
+          </View>
+        ) : (
+          destinations.map((dest) => (
+            <View key={dest.id} style={styles.card}>
+              <View style={styles.cardContent}>
+                <ThemedText style={styles.cardName} numberOfLines={1}>
+                  {dest.name || dest.server}
+                </ThemedText>
+                <ThemedText style={styles.cardServer} numberOfLines={2}>
+                  {dest.server}
+                </ThemedText>
+                <ThemedText style={styles.cardExpiry}>
+                  Expires: {new Date(dest.expiresAt).toLocaleDateString()}
+                </ThemedText>
+              </View>
+              <TouchableOpacity
+                style={styles.removeBtn}
+                onPress={() => handleRemove(dest)}
+                accessibilityLabel="Remove destination"
+              >
+                <MaterialIcons name="delete-outline" size={22} color={colors.error} />
+              </TouchableOpacity>
+            </View>
+          ))
+        )}
+      </ScrollView>
     </ThemedView>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ import "react-native-reanimated";
 import { PermissionMonitor } from "@/components/PermissionMonitor";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { storeUploadConfigForDraft } from "@/utils/uploadConfig";
+import { addDestination } from "@/utils/uploadDestinations";
 
 const isUUIDv4 = (uuid: string) =>
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(uuid);
@@ -27,17 +28,33 @@ export default function RootLayout() {
     "Roboto-Bold": require("../assets/fonts/Roboto-Bold.ttf"),
   });
 
-  // When app is in background and user opens a deeplink (e.g. scans QR), go straight to shorts or server-not-setup
+  // Handle deeplinks: upload (per-draft) or configure_destination (add upload destination)
   useEffect(() => {
     const handleUrl = async (event: { url: string }) => {
       const url = event.url;
       const q = url.includes("?") ? url.split("?")[1] : "";
       const search = new URLSearchParams(q);
       const mode = search.get("mode");
-      if (mode !== "upload") return;
-      const draftId = search.get("draftId");
       const server = search.get("server");
       const token = search.get("token");
+      const name = search.get("name");
+
+      if (mode === "configure_destination" && server && token) {
+        try {
+          await addDestination(server, token, name ?? undefined);
+          console.log("[Deeplink] Added upload destination:", server);
+        } catch (e) {
+          console.warn("[Deeplink] Failed to add destination:", e);
+        }
+        router.replace({
+          pathname: "/(tabs)/profile",
+          params: { destinationAdded: "true" },
+        });
+        return;
+      }
+
+      if (mode !== "upload") return;
+      const draftId = search.get("draftId");
       const hasValidDraftId = draftId && isUUIDv4(draftId);
       if (hasValidDraftId && server && token) {
         try {
@@ -61,8 +78,38 @@ export default function RootLayout() {
         });
       }
     };
+
     const subscription = Linking.addEventListener("url", handleUrl);
     return () => subscription.remove();
+  }, [router]);
+
+  // Cold start: app opened via deeplink when closed
+  useEffect(() => {
+    let cancelled = false;
+    Linking.getInitialURL().then((url) => {
+      if (cancelled || !url) return;
+      const q = url.includes("?") ? url.split("?")[1] : "";
+      const search = new URLSearchParams(q);
+      const mode = search.get("mode");
+      if (mode === "configure_destination") {
+        const server = search.get("server");
+        const token = search.get("token");
+        const name = search.get("name");
+        if (server && token) {
+          addDestination(server, token, name ?? undefined).then(() => {
+            if (!cancelled) {
+              router.replace({
+                pathname: "/(tabs)/profile",
+                params: { destinationAdded: "true" },
+              });
+            }
+          });
+        }
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   if (!loaded) {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from "react-native";
 import { storeUploadConfigForDraft } from "@/utils/uploadConfig";
+import { addDestination } from "@/utils/uploadDestinations";
 
 // Simple UUID v4 validation (basic format check)
 const isUUIDv4 = (uuid: string) => {
@@ -22,6 +23,7 @@ export default function Index() {
     draftId?: string;
     server?: string;
     token?: string;
+    name?: string;
     serverNotSetupForUpload?: string;
   }>();
   const router = useRouter();
@@ -36,6 +38,35 @@ export default function Index() {
 
   // Debug logging for deeplink parameters
   console.log("🔗 Deeplink params:", params);
+
+  // configure_destination: add upload destination and go to profile (cold start)
+  useEffect(() => {
+    if (
+      params.mode === "configure_destination" &&
+      params.server &&
+      params.token &&
+      !hasRedirected
+    ) {
+      setHasRedirected(true);
+      addDestination(
+        params.server,
+        params.token,
+        params.name ?? undefined
+      ).then(() => {
+        router.replace({
+          pathname: "/(tabs)/profile",
+          params: { destinationAdded: "true" },
+        });
+      });
+    }
+  }, [
+    params.mode,
+    params.server,
+    params.token,
+    params.name,
+    hasRedirected,
+    router,
+  ]);
 
   // When we have a valid draftId: store config and redirect to shorts
   useEffect(() => {

--- a/docs/issue-upload-destinations.md
+++ b/docs/issue-upload-destinations.md
@@ -1,0 +1,57 @@
+# Configurable upload destinations (Pulse + Pulse Vault)
+
+## Summary
+
+Allow users to **configure upload destinations** in the Pulse app so one app can upload to multiple, separately hosted Pulse Vault servers. Users add a vault once (e.g. via a “setup your app” QR from the vault), manage destinations in the app, and at upload time choose where to send the video—including for camera-mode drafts where the draft ID is created by the app.
+
+## Background
+
+- **Pulse** = single mobile app (record/edit, upload).
+- **Pulse Vault** = upload server anyone can host (own domain); implements TUS and provides QR/deeplinks for the app.
+
+Today, upload is **per-draft only**: the user scans a QR from a vault that encodes a specific draft ID; that draft is tied to that server. To upload to a different vault, they must scan that vault’s QR for a (different) draft. There is no way to “save” a vault and later choose it when uploading a video whose draft was created in the app (e.g. in camera mode).
+
+## Desired behavior
+
+### Pulse app
+
+- User can **add** an upload destination (e.g. by scanning a “setup your app” QR or opening a link from a Pulse Vault).
+- User can **see and manage** saved destinations (list, remove). No duplicate entries for the same server.
+- On the **upload screen** (e.g. after merging a video), if the user has no per-draft config for that draft:
+  - If they have saved destinations, they can **choose one** from a list.
+  - Upload then goes to the selected destination using the **current draft’s ID** (created by the app).
+- So: camera-mode drafts (and any draft without a per-draft QR) can still be uploaded by picking a configured destination.
+
+### Pulse Vault
+
+- A **“Setup your app” / “Configure app”** flow on the vault’s upload page:
+  - Generates a **long-lived** upload token (e.g. valid 30 days) that is **not** tied to a specific draft ID.
+  - Presents a **QR code** and a **“Configure app”** button that open a deeplink the Pulse app understands.
+- When the user scans/clicks, the Pulse app adds this vault as a saved destination (server + token).
+- For uploads using this token, the **draft ID is sent by the app** at finalize time (e.g. the draft they just recorded in camera mode). The vault backend must accept a token without a draft ID and use the client-supplied draft ID as the video ID when finalizing.
+
+## Acceptance criteria
+
+### Pulse
+
+- [ ] New deeplink (e.g. `mode=configure_destination`) is handled when app is opened (cold start, background, foreground); app adds the destination and navigates to the destinations screen with feedback (e.g. “Destination added”).
+- [ ] Destinations screen (e.g. “Upload” tab): list all saved destinations (name/server, expiry if available), remove with confirmation, no duplicates by server.
+- [ ] Upload screen: when draft has no per-draft config but user has saved destinations, show a destination picker; user selects one and taps Upload; upload succeeds to selected vault using current draft ID.
+- [ ] Tab bar: destinations screen is reachable (e.g. “Upload” tab with appropriate icon).
+
+### Pulse Vault
+
+- [ ] New endpoint (e.g. `/qr/configure-destination`) that returns a long-lived token (no draft ID) and a deeplink URL for the Pulse app (and optionally QR payload).
+- [ ] Finalize endpoint accepts uploads where the token has no draft ID: in that case, `draftId` must be provided in the request body and is used as the video ID.
+- [ ] Upload page includes a “Setup your app” section: generate configure-destination deeplink, show QR, and “Configure app” button that opens the deeplink.
+
+## Technical notes
+
+- **Destination token**: Token payload has no `draftId`; app sends `draftId` in the finalize request body when using a saved destination.
+- **No duplicates**: Destinations are deduped by normalized server URL (e.g. same host = update existing entry).
+- **Existing flow unchanged**: Per-draft QR (draft ID in token, in deeplink) continues to work as today; this adds a second path (saved destination + app-supplied draft ID).
+
+## Scope
+
+- **Pulse**: deeplink handling, destinations storage, destinations UI (list/remove), upload-screen destination picker, TUS finalize with optional client `draftId`.
+- **Pulse Vault**: configure-destination endpoint, finalize with body `draftId`, frontend “Setup your app” QR + button.

--- a/utils/uploadDestinations.ts
+++ b/utils/uploadDestinations.ts
@@ -1,0 +1,89 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Crypto from "expo-crypto";
+
+const DESTINATIONS_KEY = "upload_destinations";
+
+export interface UploadDestination {
+  id: string;
+  name: string;
+  server: string;
+  token: string;
+  expiresAt: string;
+}
+
+function normalizeServerUrl(server: string): string {
+  try {
+    const url = new URL(server);
+    return `${url.protocol}//${url.host}`.replace(/\/$/, "");
+  } catch {
+    return server.replace(/\/$/, "");
+  }
+}
+
+export async function getAllDestinations(): Promise<UploadDestination[]> {
+  try {
+    const raw = await AsyncStorage.getItem(DESTINATIONS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as UploadDestination[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("[UploadDestinations] Error loading destinations:", error);
+    return [];
+  }
+}
+
+/** Add or update by normalized server (no duplicates by server). */
+export async function addDestination(
+  server: string,
+  token: string,
+  name?: string
+): Promise<void> {
+  const normalized = normalizeServerUrl(server);
+  const list = await getAllDestinations();
+  const existing = list.find(
+    (d) => normalizeServerUrl(d.server) === normalized
+  );
+  const expiresAt = parseExpiresAtFromToken(token);
+  const newDest: UploadDestination = {
+    id: existing?.id ?? Crypto.randomUUID(),
+    name: name?.trim() || normalized,
+    server: normalized,
+    token,
+    expiresAt: expiresAt ?? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+  };
+  const rest = list.filter((d) => normalizeServerUrl(d.server) !== normalized);
+  await AsyncStorage.setItem(
+    DESTINATIONS_KEY,
+    JSON.stringify([...rest, newDest])
+  );
+  console.log("[UploadDestinations] Added/updated destination:", newDest.id);
+}
+
+function parseExpiresAtFromToken(token: string): string | null {
+  try {
+    const base64 = token.replace(/-/g, "+").replace(/_/g, "/");
+    const json = atob(base64);
+    const decoded = JSON.parse(json);
+    const exp = decoded.expiresAt;
+    if (typeof exp === "number") {
+      return new Date(exp * 1000).toISOString();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function removeDestination(id: string): Promise<void> {
+  const list = await getAllDestinations();
+  const next = list.filter((d) => d.id !== id);
+  await AsyncStorage.setItem(DESTINATIONS_KEY, JSON.stringify(next));
+  console.log("[UploadDestinations] Removed destination:", id);
+}
+
+export async function getDestination(
+  id: string
+): Promise<UploadDestination | null> {
+  const list = await getAllDestinations();
+  return list.find((d) => d.id === id) ?? null;
+}


### PR DESCRIPTION
Adds **configurable upload destinations** so one Pulse app can upload to multiple, separately hosted Pulse Vault servers. Users add a vault once (e.g. scan “Setup your app” QR from the vault), manage destinations in the app (Upload tab), and at upload time choose where to send the video—including for camera-mode drafts where the draft ID is created by the app.

See [issue](#300 ) for full context.

## Changes

### Deeplink handling

- **New mode: `configure_destination`**  
  - URL: `pulsecam://?mode=configure_destination&server=...&token=...&name=...`  
  - Handled in `_layout.tsx` (foreground/background) and `index.tsx` (cold start).  
  - On receive: add destination via `addDestination(server, token, name)`, navigate to Upload tab with `destinationAdded=true`.

### Destinations storage

- **`utils/uploadDestinations.ts`** (new)  
  - AsyncStorage key `upload_destinations`; list of `{ id, name, server, token, expiresAt }`.  
  - `getAllDestinations()`, `addDestination(server, token, name?)`, `removeDestination(id)`, `getDestination(id)`.  
  - **No duplicates:** add/update by normalized server URL (same host = update existing entry).

### Upload tab (Profile → Upload)

- **`app/(tabs)/profile.tsx`**  
  - Lists saved destinations (name/server, expiry), remove with confirmation.  
  - “Destination added” banner when arriving with `destinationAdded=true`.  
  - Empty state: “Scan a Setup your app QR from a Pulse Vault upload page to add one.”
- **`app/(tabs)/_layout.tsx`**  
  - Tab label: “Upload”; icon: FontAwesome5 `upload` (size 20, outline).

### Upload screen (merged-video)

- **Destination picker** when draft has no per-draft config but user has saved destinations: radio list of destinations; user selects one.  
- **Upload:** if per-draft config → use it; else if destination selected → `uploadVideo(..., draftId, configOverride)` with selected destination’s server + token; finalize request includes `draftId` in body.  
- Camera-mode drafts can upload by choosing a saved destination.

### TUS upload

- **`utils/tusUpload.ts`**  
  - Optional `configOverride?: { server, token }`; when set, use it and send `draftId` in finalize body (destination token).  
  - Otherwise unchanged (per-draft config from `getUploadConfigForDraft(draftId)`).

### Other

- **`docs/issue-upload-destinations.md`** – GitHub issue for the feature.  
- **pulse-vault submodule** – Updated to main (includes configure-destination endpoint and “Setup your app” UI).

## Testing

- [x] Scan/open `configure_destination` deeplink (cold start, background, foreground): destination added, navigate to Upload tab with “Destination added” banner.
- [x] Upload tab: list destinations, remove with confirm, no duplicate entries for same server.
- [x] Merged-video: with no per-draft config but destinations, show picker; select destination and Upload → success; finalize includes `draftId` in body.
- [x] Tab bar: “Upload” label and FontAwesome5 upload icon.

## Related

- **Pulse Vault PR**: configure-destination endpoint, finalize with body `draftId`, “Setup your app” QR + button and upload page layout (side-by-side desktop, stacked mobile). Vault changes are merged to main; this PR updates the pulse-vault submodule to that commit.
