### PR TITLE
fix(reorder): auto-scroll while dragging segments

### DIFF
--- a/components/SegmentReorderListVertical.tsx
+++ b/components/SegmentReorderListVertical.tsx
@@ -8,8 +8,8 @@ import {
   View,
   TouchableOpacity,
   Image,
-  ScrollView,
 } from "react-native";
+import Animated, { useAnimatedRef } from "react-native-reanimated";
 import { router } from "expo-router";
 import Sortable from "react-native-sortables";
 
@@ -155,6 +155,7 @@ export default function SegmentReorderListVertical({
 }: SegmentReorderListVerticalProps) {
   const [reorderedSegments, setReorderedSegments] =
     useState<Segment[]>(segments);
+  const scrollableRef = useAnimatedRef<Animated.ScrollView>();
 
   // Update reorderedSegments when segments prop changes (e.g., after trim points are updated)
   useEffect(() => {
@@ -238,13 +239,15 @@ export default function SegmentReorderListVertical({
       </View>
 
       {/* Sortable List */}
-      <ScrollView
+      <Animated.ScrollView
+        ref={scrollableRef}
         style={styles.sortableContainer}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <Sortable.Grid
           data={reorderedSegments}
+          scrollableRef={scrollableRef}
           renderItem={({ item, index }) => (
             <SegmentItem
               item={item}
@@ -259,7 +262,7 @@ export default function SegmentReorderListVertical({
             handleOrderChange(data);
           }}
         />
-      </ScrollView>
+      </Animated.ScrollView>
 
     </View>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pulse",
       "version": "0.0.2",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",


### PR DESCRIPTION
Closes #341.

## Summary
- Wire an animated ref from the wrapping `ScrollView` into `Sortable.Grid`'s `scrollableRef` prop so `react-native-sortables` can drive the parent scroller during drag.
- Switch the wrapper to `Animated.ScrollView` (from `react-native-reanimated`, already a project dep) so the ref type matches.

Without this ref, the library's built-in auto-scroll-during-drag (enabled by default with a 75 px activation offset) is silently a no-op, which is why dragging a segment in a long list was clipped to the visible viewport and forced staged drags.

No styling, layout, or `onDragEnd` behavior changes.

## Test plan
- [x] Open a draft with many segments (≥ ~15 so the list scrolls).
- [x] On the **Edit Segments** screen, scroll to the bottom and long-press the last segment.
- [x] Without releasing, drag toward the top edge — the list should auto-scroll upward continuously while held near the edge, allowing a drop at index 0 in a single gesture.
- [x] Repeat in reverse: pick up the first segment, hold near the bottom edge, expect downward auto-scroll, drop at the end.
- [x] Confirm `onDragEnd` still fires once and the new order persists after backing out and reopening the screen.