### PR TITLE
feat(dev): realistic dev-seed fixtures (Git LFS) + generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 assets/dev/*.mp4 filter=lfs diff=lfs merge=lfs -text
+fixtures/*.mov filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/dev/*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,5 @@
+# Don't auto-download the big regen master on clone/checkout — it's only needed to regenerate
+# the dev-seed fixtures. Fetch it on demand with: git lfs pull --include "fixtures/*.mov"
+# The small assets/dev/*.mp4 clips are still fetched normally.
+[lfs]
+	fetchexclude = fixtures/*.mov

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 
 ## Get started
 
+> **Git LFS required.** The dev-seed video fixtures in `assets/dev/*.mp4` are stored in [Git LFS](https://git-lfs.com). Install it **before/after cloning** or those files arrive as tiny pointer stubs and the dev `+ seed` button breaks:
+>
+> ```bash
+> brew install git-lfs && git lfs install   # one-time
+> git lfs pull                              # if you cloned before installing
+> ```
+>
+> The ~400 MB fixture-regen master (`fixtures/bbb_master.mov`) is intentionally **excluded** from normal clones (see `.lfsconfig`); fetch it only when regenerating fixtures: `git lfs pull --include "fixtures/*.mov"`.
+
 1. Install dependencies
 
    ```bash
@@ -15,6 +24,8 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    ```bash
    npx expo start
    ```
+
+   This app uses native modules (`expo-camera`), so it needs a **dev build** (`npm run ios` / `npm run android`), not Expo Go. In a dev build, the Home screen has `+ seed` / `clear` buttons that create/remove a "Dev sample" draft from the bundled `assets/dev/` clips — so the editor is exercisable on a simulator with no camera. See [assets/dev/README.md](assets/dev/README.md) and [docs/implementation-status.md](docs/implementation-status.md).
 
 In the output, you'll find options to open the app in a
 

--- a/assets/dev/README.md
+++ b/assets/dev/README.md
@@ -1,0 +1,27 @@
+# Dev fixture clips (§1.0b)
+
+Sample video clips for the **dev seed** — bundled into the app so the timeline editor is
+testable on a simulator/emulator with no camera. Dev-only; never shipped in production.
+
+## How to add clips
+
+1. Drop short `.mp4` files in this folder.
+2. List each one in [`src/dev/seed.ts`](../../src/dev/seed.ts) `FIXTURES` (a static `require()` per
+   file, in the order they should appear on the timeline).
+3. In a dev build, tap **`+ seed`** on Home → a single `Dev sample` draft is created with these
+   clips as segments. The button is idempotent — pressing it again is a no-op (`clear` resets it).
+
+## What clips to pick
+
+Choose clips that are **deliberately mismatched** so they stress the export normalization path:
+
+- **Orientation:** at least one portrait (9:16) and one landscape (16:9), plus ideally one square.
+- **Resolution:** mix e.g. 720p / 1080p / 4K.
+- **Frame rate:** mix e.g. 30fps and 60fps.
+- **Codec:** mix H.264 and HEVC if you can.
+- **Length:** keep each short (~3–8s) — these are committed to the repo.
+
+## Size / git
+
+Keep the total small (a few MB). If any single clip is large (>~5 MB), prefer Git LFS or
+`.gitignore` it and document where to fetch it, rather than bloating the repo history.

--- a/assets/dev/README.md
+++ b/assets/dev/README.md
@@ -49,8 +49,15 @@ Mirror the **real video surfaces the app meets**, and span enough variety to str
 - **Codec:** mix H.264 and HEVC. **Container:** mix QuickTime (camera) and plain MP4 (shared).
 - **Length:** ~12–24s so there's room to trim.
 
-## Size / git
+## Size / git (Git LFS)
 
-The clips (~25 MB total) are **committed directly** so `+ seed` works straight after a clone with no
-extra tooling. They rarely change; regenerate with the script rather than hand-editing. If this set
-grows much larger, move it to Git LFS (`git lfs track "assets/dev/*.mp4"`) to keep history lean.
+The clips (~25 MB) are stored in **Git LFS** (`assets/dev/*.mp4`) and fetched on a normal clone, so
+`+ seed` works out of the box — just have `git lfs` installed. The regen master
+(`fixtures/bbb_master.mov`, ~400 MB) is **also** in LFS but **excluded from normal clones** via
+[`.lfsconfig`](../../.lfsconfig); fetch it only when regenerating:
+
+```sh
+git lfs pull --include "fixtures/*.mov"   # the make-dev-fixtures script does this automatically
+```
+
+They rarely change — regenerate with the script rather than hand-editing.

--- a/assets/dev/README.md
+++ b/assets/dev/README.md
@@ -3,7 +3,34 @@
 Sample video clips for the **dev seed** — bundled into the app so the timeline editor is
 testable on a simulator/emulator with no camera. Dev-only; never shipped in production.
 
-## How to add clips
+## Current clips
+
+Chosen to match the **video surfaces the app actually meets**, so the seed exercises the real
+ingest / normalization path. Derived from [Big Buck Bunny](https://peach.blender.org/) (Blender
+Foundation, CC-BY 3.0), a different scene per clip. Each has a burned-in **progress bar + playhead**
+(this ffmpeg has no freetype, so a sweeping bar stands in for a timecode) so position is visible
+while trimming.
+
+**Portrait** is the primary surface (short-form — the recorder & iPhone Camera). iPhone stores
+portrait as a **coded-landscape buffer + 90° rotation matrix** in a **QuickTime** container, _not_
+baked-portrait pixels — these fixtures replicate that exactly (so the rotation/normalization path is
+actually tested). The **landscape** clips stand in for video added later from the Photos app that
+must be normalized into the portrait timeline.
+
+| file                             | display   | coded     | rot | fps | codec | container | len |
+| -------------------------------- | --------- | --------- | --- | --- | ----- | --------- | --- |
+| `portrait-1080p-30fps-h264.mp4`  | 1080×1920 | 1920×1080 | 90° | 30  | H.264 | QuickTime | 24s |
+| `portrait-1080p-30fps-hevc.mp4`  | 1080×1920 | 1920×1080 | 90° | 30  | HEVC  | QuickTime | 22s |
+| `portrait-1080p-60fps-hevc.mp4`  | 1080×1920 | 1920×1080 | 90° | 60  | HEVC  | QuickTime | 20s |
+| `portrait-4k-60fps-hevc.mp4`     | 2160×3840 | 3840×2160 | 90° | 60  | HEVC  | QuickTime | 12s |
+| `landscape-1080p-30fps-h264.mp4` | 1920×1080 | 1920×1080 | —   | 30  | H.264 | MP4       | 24s |
+| `landscape-4k-30fps-hevc.mp4`    | 3840×2160 | 3840×2160 | —   | 30  | HEVC  | QuickTime | 14s |
+
+The `portrait-1080p-30fps-h264` clip mirrors **this recorder's exact output** (H.264/AAC 1080p30
+portrait, QuickTime bytes named `.mp4`). All have AAC audio and are ~12–24s so there's room to trim.
+Regenerate with [`scripts/make-dev-fixtures.sh`](../../scripts/make-dev-fixtures.sh).
+
+## How to add / change clips
 
 1. Drop short `.mp4` files in this folder.
 2. List each one in [`src/dev/seed.ts`](../../src/dev/seed.ts) `FIXTURES` (a static `require()` per
@@ -13,15 +40,17 @@ testable on a simulator/emulator with no camera. Dev-only; never shipped in prod
 
 ## What clips to pick
 
-Choose clips that are **deliberately mismatched** so they stress the export normalization path:
+Mirror the **real video surfaces the app meets**, and span enough variety to stress normalization:
 
-- **Orientation:** at least one portrait (9:16) and one landscape (16:9), plus ideally one square.
-- **Resolution:** mix e.g. 720p / 1080p / 4K.
-- **Frame rate:** mix e.g. 30fps and 60fps.
-- **Codec:** mix H.264 and HEVC if you can.
-- **Length:** keep each short (~3–8s) — these are committed to the repo.
+- **Orientation:** mostly **portrait (9:16)** — the short-form primary; plus some **landscape (16:9)**
+  to normalize in. iPhone portrait is a coded-landscape buffer + a 90° rotation matrix, so include
+  rotation-tagged clips (the script does this), not just baked-portrait pixels.
+- **Resolution:** mix 1080p and 4K. **Frame rate:** mix 30fps and 60fps.
+- **Codec:** mix H.264 and HEVC. **Container:** mix QuickTime (camera) and plain MP4 (shared).
+- **Length:** ~12–24s so there's room to trim.
 
 ## Size / git
 
-Keep the total small (a few MB). If any single clip is large (>~5 MB), prefer Git LFS or
-`.gitignore` it and document where to fetch it, rather than bloating the repo history.
+The clips (~25 MB total) are **committed directly** so `+ seed` works straight after a clone with no
+extra tooling. They rarely change; regenerate with the script rather than hand-editing. If this set
+grows much larger, move it to Git LFS (`git lfs track "assets/dev/*.mp4"`) to keep history lean.

--- a/assets/dev/landscape-1080p-30fps-h264.mp4
+++ b/assets/dev/landscape-1080p-30fps-h264.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2c3b758d7e0e73b8a64e5c0a0269855bdff3dd12efe2cada15d57979bbec77
+size 7606482

--- a/assets/dev/landscape-4k-30fps-hevc.mp4
+++ b/assets/dev/landscape-4k-30fps-hevc.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f19bd67f0513b0b73ec04cda4f71f32c2474d8c959f04bf531a5d6550de1da60
+size 2376194

--- a/assets/dev/portrait-1080p-30fps-h264.mp4
+++ b/assets/dev/portrait-1080p-30fps-h264.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5671ed822fb4be2379b0425a46ee47417ef2d60c90d1fce86b017035a7d1a5c
+size 5186084

--- a/assets/dev/portrait-1080p-30fps-hevc.mp4
+++ b/assets/dev/portrait-1080p-30fps-hevc.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58e51fd806ba34873f92061247a71bec88935351c5b12263d164321c06d5bfbc
+size 2460044

--- a/assets/dev/portrait-1080p-60fps-hevc.mp4
+++ b/assets/dev/portrait-1080p-60fps-hevc.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a969891cf2a2aaf85bd1954f359f2a28f7a47e9b6a0b6679ac528a65584524c
+size 3478642

--- a/assets/dev/portrait-4k-60fps-hevc.mp4
+++ b/assets/dev/portrait-4k-60fps-hevc.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41586632c84a6cbfe6acd70c047ef7ef089c84c2cf8ebf58eec004ec47a4317b
+size 3813259

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -2,7 +2,7 @@
 
 > **What this is.** A snapshot of where the build actually stands vs. the design docs, the gaps that matter, and a phased plan to continue. Pick this up later as the working checklist. Reconcile against the decisions in [pulse-new-plan.md](pulse-new-plan.md) (forward decisions) and [pulse-original-features.md](pulse-original-features.md) (behavior spec).
 >
-> **Captured:** 2026-06-04 · **last updated:** 2026-06-05 (Phase A landed, recorder refactor + tooling, commit `4c7aac8`), branch `feat/foundation-home`. Update as phases land.
+> **Captured:** 2026-06-04 · **last updated:** 2026-06-08 (real dev-seed fixtures landed + verified on the iOS simulator; clips stored in Git LFS), branch `feat/dev-seed-fixtures`. Update as phases land.
 
 ---
 
@@ -28,7 +28,8 @@
 | Prebuild plugin: disable script sandboxing | [plugins/with-disable-script-sandboxing.js](../plugins/with-disable-script-sandboxing.js) | ✅ lets bundle phase write dev-server `ip.txt` on device builds                                                    |
 | Routes registered as full-screen modals    | [src/app/\_layout.tsx](../src/app/_layout.tsx)                                            | ✅ `recorder` + `timeline` (§2.0)                                                                                  |
 | Recorder screen (#2)                       | [src/app/recorder.tsx](../src/app/recorder.tsx) + [src/features/recorder/](../src/features/recorder/) | ✅ **Phase A complete** — draft-backed, persisted, resumable (see §3)                                  |
-| Timeline screen (#3)                       | [src/app/timeline.tsx](../src/app/timeline.tsx)                                           | 🚧 **stub placeholder only** — next milestone                                                                     |
+| Timeline screen (#3)                       | [src/app/timeline.tsx](../src/app/timeline.tsx)                                           | 🚧 **stub placeholder only** ("Timeline editor — coming next") — next milestone                                   |
+| Dev-seed fixtures + seed/clear             | [src/dev/seed.ts](../src/dev/seed.ts) + [assets/dev/](../assets/dev/)                     | ✅ **real (2026-06-08)** — 6 bundled clips (Git LFS) → one idempotent "Dev sample" draft; verified on simulator (§1.0b) |
 
 **Recorder — what works:** `CameraView`; JIT camera+mic permission gate with Settings fallback (§2.3); tap-to-record start/stop; clips persisted to the document dir + autosaved as `segments` rows; segment bar driven by `useLiveQuery` with inline ✕ delete and hold+drag reorder; real first-frame thumbnails (runtime); camera controls (flip / flash / stabilization); lazy draft creation + empty-draft cleanup; resume a draft from Home via `draftId`; `→` carries `draftId` to `/timeline`.
 
@@ -37,6 +38,8 @@
 - **Feature-scoped modules.** The recorder lives in [src/features/recorder/](../src/features/recorder/): `use-recorder` (draft + recording state/actions), `use-recorder-permissions`, and presentational `permission-gate` / `camera-controls` / `segment-bar` / `close-button`. [recorder.tsx](../src/app/recorder.tsx) is a thin orchestrator. Convention going forward: `components/` = shared, `features/<screen>/` = feature-scoped.
 - **Media utils.** [src/utils/video.ts](../src/utils/video.ts) (`generateThumbnail` cached by uri, `getDurationMs`) and [src/utils/file-store.ts](../src/utils/file-store.ts) (relative-path clip storage over the SDK 56 `File`/`Directory`/`Paths` API).
 - **Formatting/lint.** Prettier configured ([.prettierrc.json](../.prettierrc.json), `npm run format` / `format:check`) and wired into ESLint via `eslint-config-prettier`. Codebase is tsc-, lint-, and Prettier-clean.
+- **Dev-seed fixtures (Git LFS).** [src/dev/seed.ts](../src/dev/seed.ts) `seedDraft()`/`clearDrafts()` back the Home `+ seed` / `clear` buttons (`__DEV__`-only). `seedDraft()` copies six bundled clips from [assets/dev/](../assets/dev/) onto disk via [`copyIntoSegments`](../src/utils/file-store.ts) (a **byte copy** that leaves the bundled source intact, vs. the move-based `persistRecording`), reads native duration, and inserts them through the production `addSegment` path. The fixtures **match the surfaces the app meets**: 4 portrait + 2 landscape, mixed H.264/HEVC, 1080p/4K, 30/60fps, QuickTime/MP4 containers — and the portrait clips carry an **iPhone-accurate coded-landscape + 90° rotation matrix** (not baked-portrait pixels), so the ingest/rotation path is genuinely exercised. The clips (~25 MB) and the regen master (`fixtures/bbb_master.mov`, ~400 MB, excluded from clones via [.lfsconfig](../.lfsconfig)) live in **Git LFS** — a clone needs `git lfs` installed. Regenerate with [scripts/make-dev-fixtures.sh](../scripts/make-dev-fixtures.sh). Full matrix + rationale in [assets/dev/README.md](../assets/dev/README.md).
+- **Recorder capture profile (reference).** `recordAsync()` is called with no options, so a real capture is iOS AVFoundation defaults: **H.264/AAC, 1080×1080… 1920×1080, ~30fps, portrait, QuickTime (`.mov`) bytes** — then persisted **renamed to `.mp4`** (the on-disk extension is always `.mp4`; bytes are unchanged). The `portrait-1080p-30fps-h264` fixture mirrors this exactly. No import-from-Photos path exists yet (`expo-image-picker` is Phase D); when it lands it must normalize the landscape/HEVC variety the fixtures already include.
 
 ---
 
@@ -45,8 +48,9 @@
 ### ⚠️ Gap A — Build-order inversion
 
 - **Docs say:** the **timeline editor is Milestone 0** ("editing leads, recording follows," §Build order, 2026-06-02), built on a `DEV_SEED_SEGMENTS` flag + bundled fixtures so it's **emulator-testable with no camera**. The riskiest piece is the native trim/concat module + timeline (§1.0).
-- **Reality:** recorder was built first; timeline is a stub; the native module doesn't exist; the dev-seed path that was meant to de-risk the editor on a simulator isn't real — [`devSeedDraft`](../src/db/drafts.ts) inserts DB rows pointing at non-existent `dev/a.mp4` / `dev/b.mp4` files (no clips in `assets/`).
-- **Not a mistake to undo** — just means the de-risking the docs planned hasn't happened yet.
+- **Reality:** recorder was built first; the native export module doesn't exist; the **timeline editor is still a stub** ("Timeline editor — coming next").
+- **Progress (2026-06-08):** the dev-seed path is now **real** — [src/dev/seed.ts](../src/dev/seed.ts) `seedDraft()` builds a real "Dev sample" draft from six bundled `assets/dev/` clips (replacing the old fake `devSeedDraft` that pointed at non-existent `dev/a.mp4`/`dev/b.mp4`). Verified end-to-end on the iOS simulator (seed → 6 segments/116 s, rotation handled in thumbnails, clear teardown, idempotent across 3 taps). So the de-risking the docs planned is now **half done**: the seed exists; the editor that consumes it is the remaining gap.
+- **Not a mistake to undo** — the editor-first risk (native trim/concat + timeline UI) is still the next real milestone.
 
 ### ✅ Gap B — Recorder doesn't go through the draft model — **RESOLVED (Phase A, 2026-06-05)**
 
@@ -88,8 +92,8 @@ Not blocking — recorded here so they aren't forgotten:
 
 Goal: the doc's actual Milestone 0, now testable because Phase A made segments real DB rows.
 
-- [ ] **Dev-seed fixtures** — add 2–3 short clips with **deliberately mismatched res/fps/codec** (§1.0b note) under `assets/dev/`; make `DEV_SEED_SEGMENTS` copy them into a draft dir and route straight into `/timeline`. (Current `devSeedDraft` points at files that don't exist — make them real.)
-- [ ] **Timeline editor UI** ([timeline.tsx](../src/app/timeline.tsx)) — clips end-to-end, playhead, `expo-video` preview, **trim** (drag edge → `trimStartMs`/`trimEndMs`), **split** (new row sharing `originalFilename`), Reset. All non-destructive metadata writes (§1.0a/§1.0c).
+- [x] **Dev-seed fixtures** ✅ **2026-06-08** — six bundled clips under [assets/dev/](../assets/dev/) (Git LFS), portrait-weighted and realistic (mixed res/fps/codec/container, iPhone-accurate rotation metadata). [src/dev/seed.ts](../src/dev/seed.ts) `seedDraft()` copies them into `drafts/dev-seed/segments/` and inserts segments via the production path; `clearDrafts()` tears it down. Idempotent (fixed `dev-seed` id). Wired to Home `+ seed`/`clear`. Verified on simulator. _Note: routes into `/timeline` (the stub) — the actual editor is the next bullet._
+- [ ] **Timeline editor UI** ([timeline.tsx](../src/app/timeline.tsx)) — **still a stub.** Build: clips end-to-end, playhead, `expo-video` preview, **trim** (drag edge → `trimStartMs`/`trimEndMs`), **split** (new row sharing `originalFilename`), Reset. All non-destructive metadata writes (§1.0a/§1.0c). This is where **upright portrait playback** gets its real test (so far confirmed only via thumbnails — the rotation matrix on the fixtures is the thing to get right here).
 
 ### Phase C — Native export module (the rebuild risk, §1.0)
 
@@ -106,7 +110,7 @@ Goal: the doc's actual Milestone 0, now testable because Phase A made segments r
 
 ## 4. Key recommendation
 
-**Phase A is done — Phase B (the timeline editor, real Milestone 0) is next.** Segments are now real DB rows, so start by making the dev-seed path real: drop 2–3 short clips with deliberately mismatched res/fps/codec under `assets/dev/`, have `DEV_SEED_SEGMENTS` copy them into a draft dir, and route straight into `/timeline` — so the editor is buildable/testable on a simulator with no camera. Then build the timeline UI ([timeline.tsx](../src/app/timeline.tsx)) as non-destructive metadata writes (§1.0a/§1.0c), with `draftId` already being passed in from the recorder's `→`. Prototype the native export module (Phase C) early — it's the single biggest rebuild risk.
+**Phase A is done, the dev-seed path is now real — the timeline editor UI is the next step.** The dev-seed fixtures landed (2026-06-08): six realistic bundled clips in Git LFS, `seedDraft()` builds a real "Dev sample" draft, verified on a simulator with no camera. So the remaining Phase B work is the **timeline UI** itself ([timeline.tsx](../src/app/timeline.tsx), today a stub) — clips end-to-end, playhead, `expo-video` preview, non-destructive trim/split (§1.0a/§1.0c), with `draftId` already passed in from the recorder's `→`. That screen is also where **upright portrait playback** gets verified for real (the fixtures' rotation metadata is correct; thumbnails already render upright). Prototype the native export module (Phase C) early on these mismatched clips — it's the single biggest rebuild risk.
 
 ## 5. Invariants to honor (don't regress these)
 

--- a/fixtures/bbb_master.mov
+++ b/fixtures/bbb_master.mov
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45c8bafeb9a53df7f491198d2e71529701bcf1cd51805782089fac1d32869f9b
+size 416751190

--- a/scripts/make-dev-fixtures.sh
+++ b/scripts/make-dev-fixtures.sh
@@ -23,15 +23,27 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="$ROOT/assets/dev"
-# Master is cached persistently (it's 400+ MB — never committed); override with BBB_MASTER.
-SRC="${BBB_MASTER:-$HOME/.cache/pulse-dev-fixtures/bbb_master.mov}"
+# Master lives in the repo at fixtures/bbb_master.mov via Git LFS, but is excluded from normal
+# clones (.lfsconfig) since it's 400+ MB. Fetch on demand: git lfs pull --include "fixtures/*.mov"
+# Override the path with BBB_MASTER=/path.
+SRC="${BBB_MASTER:-$ROOT/fixtures/bbb_master.mov}"
 MASTER_URL="https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_720p_h264.mov"
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 
 command -v ffmpeg >/dev/null || { echo "ffmpeg not found (brew install ffmpeg)"; exit 1; }
 mkdir -p "$OUT"
 rm -f "$OUT"/*.mp4
-[ -f "$SRC" ] || { echo ">>> downloading master to $SRC"; mkdir -p "$(dirname "$SRC")"; curl -L --fail -o "$SRC" "$MASTER_URL"; }
+# Resolve the master. On a fresh clone the LFS-tracked file is a small pointer (fetchexclude),
+# so pull it on demand; if it's still not a real video, download it.
+is_real_video() { [ -f "$1" ] && [ "$(wc -c <"$1")" -gt 1000000 ]; }
+if ! is_real_video "$SRC"; then
+  if [ -f "$SRC" ] && command -v git >/dev/null && git -C "$ROOT" rev-parse >/dev/null 2>&1; then
+    echo ">>> fetching master from Git LFS"; git -C "$ROOT" lfs pull --include "fixtures/*.mov" || true
+  fi
+  if ! is_real_video "$SRC"; then
+    echo ">>> downloading master to $SRC"; mkdir -p "$(dirname "$SRC")"; curl -L --fail -o "$SRC" "$MASTER_URL"
+  fi
+fi
 
 # name | orient(portrait|land) | display geom | fps | codec | container | start | dur
 #   portrait geom scales to the UPRIGHT display size (WxH, H>W); the script transposes it into a

--- a/scripts/make-dev-fixtures.sh
+++ b/scripts/make-dev-fixtures.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Regenerate the dev-seed fixture clips in assets/dev/ (§1.0b).
+#
+# Goal: clips that match the video surfaces the app actually meets, so the dev seed exercises
+# the real ingest/normalization path on a simulator with no camera.
+#
+#   - SHORT-FORM PORTRAIT is the primary surface (the recorder + iPhone Camera output).
+#     iPhone stores portrait as a CODED-LANDSCAPE buffer + a 90 rotation matrix (not baked
+#     portrait pixels), in a QuickTime (.mov) container. We replicate that exactly: the
+#     recorder writes .mov bytes and renames to .mp4, so portrait fixtures are mov-bytes /
+#     rotation-tagged / named .mp4.
+#   - LANDSCAPE clips stand in for video added later from the Photos app (HEVC .mov from the
+#     camera, or a plain H.264 .mp4 shared/downloaded) that must be normalized into the
+#     portrait timeline.
+#
+# Source: Big Buck Bunny (Blender Foundation, CC-BY 3.0), a different scene per clip.
+# Each clip has a burned-in progress bar + playhead (this ffmpeg has no freetype) so position
+# is visible while trimming.
+#
+# Requires: ffmpeg with libx264 + libx265 (brew install ffmpeg).
+# Usage: bash scripts/make-dev-fixtures.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$ROOT/assets/dev"
+# Master is cached persistently (it's 400+ MB — never committed); override with BBB_MASTER.
+SRC="${BBB_MASTER:-$HOME/.cache/pulse-dev-fixtures/bbb_master.mov}"
+MASTER_URL="https://download.blender.org/peach/bigbuckbunny_movies/big_buck_bunny_720p_h264.mov"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+command -v ffmpeg >/dev/null || { echo "ffmpeg not found (brew install ffmpeg)"; exit 1; }
+mkdir -p "$OUT"
+rm -f "$OUT"/*.mp4
+[ -f "$SRC" ] || { echo ">>> downloading master to $SRC"; mkdir -p "$(dirname "$SRC")"; curl -L --fail -o "$SRC" "$MASTER_URL"; }
+
+# name | orient(portrait|land) | display geom | fps | codec | container | start | dur
+#   portrait geom scales to the UPRIGHT display size (WxH, H>W); the script transposes it into a
+#   coded-landscape buffer and stamps a 90 rotation matrix -> iPhone-accurate portrait.
+ROWS=(
+  # --- primary surface: short-form portrait (iPhone / this recorder) ---
+  "portrait-1080p-30fps-h264|portrait|crop=ih*9/16:ih,scale=1080:1920|30|h264|mov|200|24"  # EXACT recorder match
+  "portrait-1080p-30fps-hevc|portrait|crop=ih*9/16:ih,scale=1080:1920|30|hevc|mov|60|22"   # iPhone default (HEVC)
+  "portrait-1080p-60fps-hevc|portrait|crop=ih*9/16:ih,scale=1080:1920|60|hevc|mov|300|20"  # 1080p60 portrait
+  "portrait-4k-60fps-hevc|portrait|crop=ih*9/16:ih,scale=2160:3840|60|hevc|mov|360|12"     # 4K60 portrait
+  # --- added later from Photos / shared: landscape to normalize into portrait ---
+  "landscape-1080p-30fps-h264|land|scale=1920:1080|30|h264|mp4|15|24"                      # shared/downloaded .mp4
+  "landscape-4k-30fps-hevc|land|scale=3840:2160:flags=lanczos|30|hevc|mov|480|14"          # 4K landscape from Photos
+)
+
+encode_args() { # $1 codec -> echoes encoder flags
+  if [ "$1" = "h264" ]; then echo "-c:v libx264 -preset veryfast -crf 24 -profile:v high -pix_fmt yuv420p"
+  else echo "-c:v libx265 -preset veryfast -crf 28 -pix_fmt yuv420p -tag:v hvc1"; fi
+}
+
+for row in "${ROWS[@]}"; do
+  IFS='|' read -r name orient geom fps codec container start dur <<< "$row"
+  out="$OUT/$name.mp4"
+
+  # overlays drawn in DISPLAY orientation (before any transpose): filling bar + red playhead
+  vf="${geom},fps=${fps},setpts=PTS-STARTPTS"
+  vf="${vf},drawbox=x=0:y=ih-18:w='iw*t/${dur}':h=18:color=yellow@0.85:thickness=fill"
+  vf="${vf},drawbox=x='iw*t/${dur}-2':y=0:w=4:h=ih:color=red@0.9:thickness=fill"
+
+  echo ">>> $name ($codec, $container, ${dur}s, $orient)"
+  if [ "$orient" = "portrait" ]; then
+    # step 1: transpose display->coded-landscape, encode to temp
+    ffmpeg -hide_banner -loglevel error -y -ss "$start" -t "$dur" -i "$SRC" \
+      -vf "${vf},transpose=1" $(encode_args "$codec") -c:a aac -b:a 128k "$TMP/$name.tmp.mov"
+    # step 2: stamp a 90 rotation matrix via stream copy (iPhone-style display matrix)
+    ffmpeg -hide_banner -loglevel error -y -display_rotation 90 -i "$TMP/$name.tmp.mov" \
+      -c copy -tag:v hvc1 -f "$container" -movflags +faststart "$out" 2>/dev/null \
+      || ffmpeg -hide_banner -loglevel error -y -display_rotation 90 -i "$TMP/$name.tmp.mov" \
+           -c copy -f "$container" -movflags +faststart "$out"
+  else
+    ffmpeg -hide_banner -loglevel error -y -ss "$start" -t "$dur" -i "$SRC" \
+      -vf "$vf" $(encode_args "$codec") -c:a aac -b:a 128k \
+      -f "$container" -movflags +faststart "$out"
+  fi
+done
+
+echo "ALL DONE"
+ls -la "$OUT"/*.mp4

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -8,7 +8,8 @@ import { DraftCard } from '@/components/draft-card';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { Spacing } from '@/constants/theme';
-import { devClearDrafts, devSeedDraft, draftListQuery } from '@/db/drafts';
+import { draftListQuery } from '@/db/drafts';
+import { clearDrafts, seedDraft } from '@/dev/seed';
 import { useTheme } from '@/hooks/use-theme';
 
 export default function HomeScreen() {
@@ -22,12 +23,12 @@ export default function HomeScreen() {
         <ThemedText type="title">Pulse</ThemedText>
         {__DEV__ && (
           <View style={styles.devRow}>
-            <Pressable onPress={devSeedDraft} hitSlop={8}>
+            <Pressable onPress={() => void seedDraft()} hitSlop={8}>
               <ThemedText themeColor="accent" type="small">
                 + seed
               </ThemedText>
             </Pressable>
-            <Pressable onPress={devClearDrafts} hitSlop={8}>
+            <Pressable onPress={() => void clearDrafts()} hitSlop={8}>
               <ThemedText themeColor="textSecondary" type="small">
                 clear
               </ThemedText>

--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -98,28 +98,3 @@ export async function deleteDraft(draftId: string): Promise<void> {
   await db.delete(projects).where(eq(projects.id, draftId));
   deleteDraftDir(draftId);
 }
-
-// Dev-only helpers for exercising the reactive list with throwaway data.
-
-let seedCounter = 0;
-
-export async function devSeedDraft() {
-  const id = `dev-${Date.now()}-${seedCounter++}`;
-  await db.insert(projects).values({ id, name: `Sample ${seedCounter}` });
-  await db.insert(segments).values([
-    { id: `${id}-a`, projectId: id, order: 0, originalFilename: 'dev/a.mp4', durationMs: 8200 },
-    {
-      id: `${id}-b`,
-      projectId: id,
-      order: 1,
-      originalFilename: 'dev/b.mp4',
-      durationMs: 6000,
-      trimStartMs: 1000,
-      trimEndMs: 4000,
-    },
-  ]);
-}
-
-export async function devClearDrafts() {
-  await db.delete(projects);
-}

--- a/src/dev/seed.ts
+++ b/src/dev/seed.ts
@@ -21,9 +21,33 @@ const SEED_DRAFT_ID = 'dev-seed';
  * so paths must be static string literals — no variables, no globbing.
  */
 const FIXTURES: { module: number; label: string }[] = [
-  // { module: require('../../assets/dev/portrait-1080p-h264.mp4'), label: 'portrait 1080p h264' },
-  // { module: require('../../assets/dev/landscape-4k-60fps-hevc.mp4'), label: 'landscape 4k60 hevc' },
-  // { module: require('../../assets/dev/square-720p.mp4'), label: 'square 720p' },
+  // primary surface: short-form portrait (matches the recorder / iPhone Camera — coded landscape
+  // + 90deg rotation metadata, QuickTime container). The h264 one mirrors this recorder exactly.
+  {
+    module: require('../../assets/dev/portrait-1080p-30fps-h264.mp4'),
+    label: 'portrait 1080p 30fps h264 (recorder match)',
+  },
+  {
+    module: require('../../assets/dev/portrait-1080p-30fps-hevc.mp4'),
+    label: 'portrait 1080p 30fps hevc (iPhone default)',
+  },
+  {
+    module: require('../../assets/dev/portrait-1080p-60fps-hevc.mp4'),
+    label: 'portrait 1080p 60fps hevc',
+  },
+  {
+    module: require('../../assets/dev/portrait-4k-60fps-hevc.mp4'),
+    label: 'portrait 4k 60fps hevc',
+  },
+  // added later from Photos / shared: landscape to normalize into the portrait timeline
+  {
+    module: require('../../assets/dev/landscape-1080p-30fps-h264.mp4'),
+    label: 'landscape 1080p 30fps h264 (shared mp4)',
+  },
+  {
+    module: require('../../assets/dev/landscape-4k-30fps-hevc.mp4'),
+    label: 'landscape 4k 30fps hevc (photos)',
+  },
 ];
 
 /**

--- a/src/dev/seed.ts
+++ b/src/dev/seed.ts
@@ -1,0 +1,68 @@
+import { eq } from 'drizzle-orm';
+import { Asset } from 'expo-asset';
+
+import { db } from '@/db/client';
+import { addSegment } from '@/db/drafts';
+import { projects } from '@/db/schema';
+import { absolutize, copyIntoSegments, deleteDraftDir } from '@/utils/file-store';
+import { getDurationMs } from '@/utils/video';
+
+// Dev-only helpers (§1.0b): seed one curated draft of bundled sample clips so the timeline
+// editor is exercisable on a simulator with no camera. Gate every caller behind `__DEV__`.
+
+const SEED_DRAFT_ID = 'dev-seed';
+
+/**
+ * Bundled sample clips, laid into the seed draft in array order. Pick clips with
+ * **deliberately mismatched** resolution / fps / codec / orientation so they also stress the
+ * export normalization path (§1.0b). Drop the files in `assets/dev/` and list them here.
+ *
+ * `require()` of a bundled `.mp4` returns an asset module id (resolved by metro at build time),
+ * so paths must be static string literals — no variables, no globbing.
+ */
+const FIXTURES: { module: number; label: string }[] = [
+  // { module: require('../../assets/dev/portrait-1080p-h264.mp4'), label: 'portrait 1080p h264' },
+  // { module: require('../../assets/dev/landscape-4k-60fps-hevc.mp4'), label: 'landscape 4k60 hevc' },
+  // { module: require('../../assets/dev/square-720p.mp4'), label: 'square 720p' },
+];
+
+/**
+ * Add the curated sample draft, once. Idempotent: a fixed draft id means pressing the seed
+ * button repeatedly never litters duplicates — if it already exists this is a no-op.
+ * Returns the seed draft id (or undefined when no fixtures are wired up yet).
+ */
+export async function seedDraft(): Promise<string | undefined> {
+  if (FIXTURES.length === 0) {
+    console.warn(
+      '[seed] no fixtures yet — drop clips in assets/dev/ and list them in src/dev/seed.ts',
+    );
+    return;
+  }
+
+  const existing = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.id, SEED_DRAFT_ID));
+  if (existing.length > 0) return SEED_DRAFT_ID;
+
+  await db.insert(projects).values({ id: SEED_DRAFT_ID, name: 'Dev sample' });
+
+  for (let i = 0; i < FIXTURES.length; i++) {
+    const asset = Asset.fromModule(FIXTURES[i].module);
+    await asset.downloadAsync(); // copies the bundled clip into the cache, populating localUri
+    if (!asset.localUri) continue;
+
+    const segmentId = `${SEED_DRAFT_ID}-${i}`;
+    const originalFilename = await copyIntoSegments(asset.localUri, SEED_DRAFT_ID, segmentId);
+    const durationMs = await getDurationMs(absolutize(originalFilename));
+    await addSegment(SEED_DRAFT_ID, { id: segmentId, originalFilename, durationMs });
+  }
+
+  return SEED_DRAFT_ID;
+}
+
+/** Wipe all drafts (metadata) and the seed draft's clip dir, so a re-seed starts clean. */
+export async function clearDrafts(): Promise<void> {
+  await db.delete(projects);
+  deleteDraftDir(SEED_DRAFT_ID);
+}

--- a/src/utils/file-store.ts
+++ b/src/utils/file-store.ts
@@ -13,16 +13,35 @@ export function absolutize(relPath: string): string {
   return new File(Paths.document, ...relPath.split('/')).uri;
 }
 
+/** The on-disk segment file for a draft, creating the segments dir if needed. */
+function segmentDest(draftId: string, segmentId: string): File {
+  const dir = new Directory(Paths.document, 'drafts', draftId, 'segments');
+  dir.create({ intermediates: true, idempotent: true });
+  return new File(dir, `${segmentId}.mp4`);
+}
+
 /** Move a recorded clip out of the cache into the draft's segments dir; returns its relative path. */
 export async function persistRecording(
   cacheUri: string,
   draftId: string,
   segmentId: string,
 ): Promise<string> {
-  const dir = new Directory(Paths.document, 'drafts', draftId, 'segments');
-  dir.create({ intermediates: true, idempotent: true });
-  const dest = new File(dir, `${segmentId}.mp4`);
-  await new File(cacheUri).move(dest);
+  await new File(cacheUri).move(segmentDest(draftId, segmentId));
+  return segmentRelPath(draftId, segmentId);
+}
+
+/**
+ * Copy an external file (e.g. a bundled `expo-asset` clip) into the draft's segments dir,
+ * leaving the source untouched; returns its relative path. Used by the dev seed (§1.0b).
+ */
+export async function copyIntoSegments(
+  srcUri: string,
+  draftId: string,
+  segmentId: string,
+): Promise<string> {
+  const dest = segmentDest(draftId, segmentId);
+  if (dest.exists) dest.delete();
+  await new File(srcUri).copy(dest);
   return segmentRelPath(draftId, segmentId);
 }
 


### PR DESCRIPTION
## What & why

Makes the **dev-seed path real** so the timeline editor (next milestone) is exercisable on a simulator with no camera (§1.0b). Replaces the placeholder `devSeedDraft` (which pointed at non-existent `dev/a.mp4` / `dev/b.mp4`) with six bundled clips and an idempotent `seedDraft()` that builds one **"Dev sample"** draft through the production `addSegment` path.

The fixtures are chosen to **match the video surfaces the app actually meets**, not synthetic edge cases:

| clip | display | coded | rot | fps | codec | container |
|---|---|---|---|---|---|---|
| portrait-1080p-30fps-h264 | 1080×1920 | 1920×1080 | 90° | 30 | H.264 | QuickTime |
| portrait-1080p-30fps-hevc | 1080×1920 | 1920×1080 | 90° | 30 | HEVC | QuickTime |
| portrait-1080p-60fps-hevc | 1080×1920 | 1920×1080 | 90° | 60 | HEVC | QuickTime |
| portrait-4k-60fps-hevc | 2160×3840 | 3840×2160 | 90° | 60 | HEVC | QuickTime |
| landscape-1080p-30fps-h264 | 1920×1080 | 1920×1080 | — | 30 | H.264 | MP4 |
| landscape-4k-30fps-hevc | 3840×2160 | 3840×2160 | — | 30 | HEVC | QuickTime |

- **Portrait-primary** (short-form, the recorder/iPhone surface). The portrait clips are stored the way iOS actually stores portrait — a **coded-landscape buffer + 90° rotation matrix** in a QuickTime container named `.mp4` — *not* baked-portrait pixels, so the rotation/normalization path is genuinely exercised. `portrait-1080p-30fps-h264` mirrors this recorder's exact output (H.264/AAC 1080p30).
- **Landscape** clips stand in for video added later from Photos/shared, to normalize into the portrait timeline (one plain `.mp4` H.264, one 4K HEVC QuickTime).
- Derived from Big Buck Bunny (Blender, CC-BY 3.0), a different scene each, with a burned-in progress bar + playhead for trimming.

## Contents

- `src/dev/seed.ts` — `seedDraft()` / `clearDrafts()`, wired to Home `+ seed` / `clear` (`__DEV__`). `copyIntoSegments` (byte copy, leaves bundled source intact) added alongside the move-based `persistRecording` via a shared `segmentDest` helper.
- `assets/dev/*.mp4` (6 clips, ~25 MB) + `fixtures/bbb_master.mov` (~400 MB) — **stored in Git LFS**. The master is excluded from normal clones via `.lfsconfig` (fetch on demand for regen).
- `scripts/make-dev-fixtures.sh` — reproducible generator (downloads/LFS-pulls the master, reframes, sets fps/codec/container, stamps the rotation matrix).
- Docs: `assets/dev/README.md` (full matrix + rationale), `docs/implementation-status.md` (status/Gap A/Phase B), `README.md` (Git LFS clone requirement).

## Verification (iOS simulator, iPhone 16 Pro dev build)

- `+ seed` → "Dev sample · 6 clips · 1:56"; on disk `drafts/dev-seed/segments/dev-seed-0…5.mp4`; DB = 1 project / **6 segments / 116.0 s** (= exact sum of clip durations).
- `ffprobe` on the copied segments: all 6 correct; the 4 portrait clips keep `rotation=90` (byte-copy preserved orientation metadata).
- **All in-app thumbnails render upright** (Home card + filmstrip), incl. the portrait clips — rotation handled by the `expo-video` thumbnail path.
- `clear` → draft dir gone, DB back to 0/0.
- Idempotency probe: `+ seed` ×3 → still 1 draft / 6 segments (no duplicates).

## Reviewer notes

- ⚠️ **Git LFS required** to check out — without it the `.mp4`s arrive as pointer stubs and `+ seed` breaks. `brew install git-lfs && git lfs install`.
- The **timeline editor is still a stub** ("Timeline editor — coming next"), so upright *playback* is confirmed only via thumbnails for now — the editor (next PR) is where the rotation matrix gets its real playback test.
- The 1080p60 fixture opens on a black frame (a genuine dark scene in the source), so its filmstrip thumbnail looks empty — cosmetic, not a bug.