### PR TITLE
Draft & clip management: rename, delete, ⋯ menu

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,21 +1,109 @@
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { router } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
-import { FlatList, Pressable, StyleSheet, View } from 'react-native';
+import { useState } from 'react';
+import { Alert, FlatList, Pressable, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { ActionMenu, type Anchor, type MenuAction } from '@/components/action-menu';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { Spacing } from '@/constants/theme';
-import { draftListQuery } from '@/db/drafts';
+import { deleteDraft, draftListQuery, renameDraft } from '@/db/drafts';
 import { clearDrafts, seedDraft } from '@/dev/seed';
 import { DraftCard } from '@/features/home/draft-card';
 import { useTheme } from '@/hooks/use-theme';
+
+type DraftRef = { id: string; name: string | null; anchor: Anchor };
 
 export default function HomeScreen() {
   const theme = useTheme();
   const insets = useSafeAreaInsets();
   const { data: drafts } = useLiveQuery(draftListQuery);
+  const [editingDraftId, setEditingDraftId] = useState<string | null>(null);
+  // The draft whose action menu (rename, delete, …) is open; null when closed.
+  const [actionsDraft, setActionsDraft] = useState<DraftRef | null>(null);
+  // Name shown ahead of the DB write; dropped once the live query reflects it.
+  const [pendingRename, setPendingRename] = useState<{ id: string; name: string | null } | null>(
+    null,
+  );
+  // Rows hidden optimistically while their delete is in flight.
+  const [deletingIds, setDeletingIds] = useState<ReadonlySet<string>>(new Set());
+
+  if (pendingRename && drafts.some((d) => d.id === pendingRename.id && d.name === pendingRename.name)) {
+    setPendingRename(null);
+  }
+  // Once a delete lands (row gone from the query), stop tracking it so the set stays small.
+  if (deletingIds.size) {
+    const live = new Set(drafts.map((d) => d.id));
+    if ([...deletingIds].some((id) => !live.has(id))) {
+      setDeletingIds(new Set([...deletingIds].filter((id) => live.has(id))));
+    }
+  }
+
+  const visibleDrafts = drafts.filter((d) => !deletingIds.has(d.id));
+
+  const submitRename = (draftId: string, currentName: string | null, input: string) => {
+    setEditingDraftId(null);
+    const name = input || null;
+    if (name === currentName) return;
+    setPendingRename({ id: draftId, name });
+    renameDraft(draftId, name).catch(() => {
+      setPendingRename(null);
+      Alert.alert('Rename failed', 'The draft name could not be saved.');
+    });
+  };
+
+  const confirmDelete = (draft: DraftRef) => {
+    Alert.alert(
+      'Delete draft?',
+      `“${draft.name || 'Untitled'}” and its clips will be permanently deleted.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            setDeletingIds((prev) => new Set(prev).add(draft.id));
+            deleteDraft(draft.id).catch(() => {
+              setDeletingIds((prev) => {
+                const next = new Set(prev);
+                next.delete(draft.id);
+                return next;
+              });
+              Alert.alert('Delete failed', 'The draft could not be deleted.');
+            });
+          },
+        },
+      ],
+    );
+  };
+
+  // Built per-render from the open draft; new options are added here (§extensible menu).
+  const menuActions: MenuAction[] = actionsDraft
+    ? [
+        {
+          key: 'rename',
+          label: 'Rename',
+          icon: 'pencil',
+          onPress: () => {
+            setEditingDraftId(actionsDraft.id);
+            setActionsDraft(null);
+          },
+        },
+        {
+          key: 'delete',
+          label: 'Delete',
+          icon: 'trash',
+          destructive: true,
+          onPress: () => {
+            const draft = actionsDraft;
+            setActionsDraft(null);
+            confirmDelete(draft);
+          },
+        },
+      ]
+    : [];
 
   return (
     <ThemedView style={styles.container}>
@@ -37,7 +125,7 @@ export default function HomeScreen() {
         )}
       </View>
 
-      {drafts.length === 0 ? (
+      {visibleDrafts.length === 0 ? (
         <View style={styles.empty}>
           <SymbolView name="video.badge.plus" size={52} tintColor={theme.textSecondary} />
           <ThemedText style={styles.emptyTitle}>No drafts yet</ThemedText>
@@ -47,7 +135,7 @@ export default function HomeScreen() {
         </View>
       ) : (
         <FlatList
-          data={drafts}
+          data={visibleDrafts}
           keyExtractor={(item) => item.id}
           contentContainerStyle={[
             styles.list,
@@ -55,16 +143,27 @@ export default function HomeScreen() {
           ]}
           renderItem={({ item }) => (
             <DraftCard
-              name={item.name}
+              name={pendingRename?.id === item.id ? pendingRename.name : item.name}
               firstSegmentFilename={item.firstSegmentFilename}
               segmentCount={item.segmentCount}
               durationMs={item.durationMs}
               lastModified={item.lastModified}
+              editing={editingDraftId === item.id}
               onPress={() => router.push({ pathname: '/recorder', params: { draftId: item.id } })}
+              onLongPress={() => setEditingDraftId(item.id)}
+              onMore={(anchor) => setActionsDraft({ id: item.id, name: item.name, anchor })}
+              onSubmitName={(input) => submitRename(item.id, item.name, input)}
             />
           )}
         />
       )}
+
+      <ActionMenu
+        visible={actionsDraft !== null}
+        anchor={actionsDraft?.anchor ?? null}
+        actions={menuActions}
+        onClose={() => setActionsDraft(null)}
+      />
 
       <Pressable
         onPress={() => router.push('/recorder')}

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -49,6 +49,12 @@ export default function RecorderScreen() {
   const preview = usePreview(segments, previewId);
   const previewing = previewId != null;
 
+  const confirmDeleteSegment = (id: string) =>
+    Alert.alert('Delete clip?', 'This clip will be removed from the draft.', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: () => deleteSegment(id) },
+    ]);
+
   if (!permissions.ready) return <ThemedView style={styles.fill} />;
   if (!permissions.granted) {
     return <PermissionGate blocked={permissions.blocked} onRequest={permissions.request} />;
@@ -109,7 +115,7 @@ export default function RecorderScreen() {
           <SegmentBar
             segments={segments}
             onReorder={reorderSegments}
-            onDelete={deleteSegment}
+            onDelete={confirmDeleteSegment}
             onSelect={(id) => {
               if (previewing) preview.selectSegment(id);
               else if (!isRecording) setPreviewId(id);

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -96,6 +96,7 @@ export default function RecorderScreen() {
               isPlaying={preview.isPlaying}
               onTogglePlay={preview.togglePlay}
               onClose={() => setPreviewId(null)}
+              onDelete={() => preview.activeId && confirmDeleteSegment(preview.activeId)}
             />
           </View>
         )}

--- a/src/components/action-menu.tsx
+++ b/src/components/action-menu.tsx
@@ -1,0 +1,110 @@
+import { SymbolView, type SymbolViewProps } from 'expo-symbols';
+import { Modal, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Spacing } from '@/constants/theme';
+import { useTheme } from '@/hooks/use-theme';
+
+/** On-screen rect of the control the menu points at (from `measureInWindow`). */
+export type Anchor = { x: number; y: number; width: number; height: number };
+
+export type MenuAction = {
+  key: string;
+  label: string;
+  icon: SymbolViewProps['name'];
+  /** Renders the row in the accent (red) tint for irreversible actions. */
+  destructive?: boolean;
+  onPress: () => void;
+};
+
+type Props = {
+  visible: boolean;
+  /** The control the menu anchors to; its right edge aligns to the anchor's right edge. */
+  anchor: Anchor | null;
+  actions: MenuAction[];
+  onClose: () => void;
+};
+
+const MENU_WIDTH = 220;
+const GAP = Spacing.one;
+/** Approximate row height — used only to decide whether the menu opens up or down. */
+const EST_ROW_HEIGHT = 48;
+
+/**
+ * A popover menu anchored to a control (e.g. a ⋯ button) rather than a bottom sheet. Pops
+ * below the anchor, or above it when there isn't room. Generic by design: callers pass a
+ * list of {@link MenuAction}s, so new options are added by extending that array.
+ */
+export function ActionMenu({ visible, anchor, actions, onClose }: Props) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const { width: screenW, height: screenH } = useWindowDimensions();
+
+  if (!anchor) return null;
+
+  const estHeight = actions.length * EST_ROW_HEIGHT + Spacing.two;
+  const openUp = anchor.y + anchor.height + GAP + estHeight > screenH - insets.bottom;
+  const top = openUp ? Math.max(insets.top, anchor.y - GAP - estHeight) : anchor.y + anchor.height + GAP;
+  // Pin the menu's right edge to the anchor's right edge, kept on-screen.
+  const right = Math.max(insets.right + Spacing.two, screenW - (anchor.x + anchor.width));
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={StyleSheet.absoluteFill} onPress={onClose} accessibilityLabel="Dismiss">
+        {/* Swallow taps on the menu itself so they don't reach the backdrop. */}
+        <Pressable onPress={() => {}} style={[styles.menu, { top, right, width: MENU_WIDTH }]}>
+          <ThemedView style={[styles.card, { borderColor: theme.border }]}>
+            {actions.map((action, i) => {
+              const tint = action.destructive ? theme.accent : theme.text;
+              return (
+                <Pressable
+                  key={action.key}
+                  onPress={action.onPress}
+                  accessibilityRole="button"
+                  accessibilityLabel={action.label}
+                  style={({ pressed }) => [
+                    styles.row,
+                    i > 0 && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: theme.border },
+                    pressed && { backgroundColor: theme.backgroundSelected },
+                  ]}>
+                  <ThemedText style={[styles.rowLabel, { color: tint }]}>{action.label}</ThemedText>
+                  <SymbolView name={action.icon} size={18} tintColor={tint} />
+                </Pressable>
+              );
+            })}
+          </ThemedView>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  menu: {
+    position: 'absolute',
+  },
+  card: {
+    borderRadius: Spacing.three,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.three,
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.three,
+  },
+  rowLabel: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+});

--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -90,7 +90,7 @@ export async function reorderSegments(orderedIds: string[]): Promise<void> {
   });
 }
 
-export async function renameDraft(draftId: string, name: string): Promise<void> {
+export async function renameDraft(draftId: string, name: string | null): Promise<void> {
   await db.update(projects).set({ name, lastModified: now }).where(eq(projects.id, draftId));
 }
 

--- a/src/features/home/draft-card.tsx
+++ b/src/features/home/draft-card.tsx
@@ -1,12 +1,16 @@
 import { Image } from 'expo-image';
 import { SymbolView } from 'expo-symbols';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { useRef } from 'react';
+import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 
+import type { Anchor } from '@/components/action-menu';
 import { ThemedText } from '@/components/themed-text';
 import { Spacing } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
 import { useThumbnail } from '@/hooks/use-thumbnail';
 import { formatClipCount, formatDuration, formatRelativeDate } from '@/utils/format';
+
+const NAME_MAX_LENGTH = 40;
 
 type Props = {
   name: string | null;
@@ -15,7 +19,14 @@ type Props = {
   segmentCount: number;
   durationMs: number;
   lastModified: number;
+  /** Swaps the name for an inline text input; entered via long press or the ⋯ menu. */
+  editing?: boolean;
   onPress?: () => void;
+  onLongPress?: () => void;
+  /** Opens the draft's action menu, anchored to the ⋯ button's on-screen rect. */
+  onMore?: (anchor: Anchor) => void;
+  /** Fires once when editing ends (keyboard done or blur) with the trimmed name. */
+  onSubmitName?: (name: string) => void;
 };
 
 export function DraftCard({
@@ -24,17 +35,23 @@ export function DraftCard({
   segmentCount,
   durationMs,
   lastModified,
+  editing = false,
   onPress,
+  onLongPress,
+  onMore,
+  onSubmitName,
 }: Props) {
   const theme = useTheme();
   const thumbnail = useThumbnail(firstSegmentFilename);
+  const moreRef = useRef<View>(null);
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={editing ? undefined : onPress}
+      onLongPress={onLongPress}
       style={({ pressed }) => [
         styles.card,
-        { backgroundColor: theme.backgroundElement, opacity: pressed ? 0.6 : 1 },
+        { backgroundColor: theme.backgroundElement, opacity: pressed && !editing ? 0.6 : 1 },
       ]}>
       <View style={[styles.thumb, { backgroundColor: theme.backgroundSelected }]}>
         {thumbnail ? (
@@ -45,17 +62,44 @@ export function DraftCard({
       </View>
 
       <View style={styles.body}>
-        <ThemedText style={styles.name} numberOfLines={1}>
-          {name || 'Untitled'}
-        </ThemedText>
-        <ThemedText themeColor="textSecondary" type="small">
-          {formatClipCount(segmentCount)} · {formatDuration(durationMs)}
+        {editing ? (
+          <TextInput
+            defaultValue={name ?? ''}
+            placeholder="Name this draft"
+            placeholderTextColor={theme.textSecondary}
+            autoFocus
+            selectTextOnFocus
+            maxLength={NAME_MAX_LENGTH}
+            returnKeyType="done"
+            onEndEditing={(e) => onSubmitName?.(e.nativeEvent.text.trim())}
+            style={[styles.name, styles.nameInput, { color: theme.text }]}
+          />
+        ) : (
+          <ThemedText style={styles.name} numberOfLines={1}>
+            {name || 'Untitled'}
+          </ThemedText>
+        )}
+        <ThemedText themeColor="textSecondary" type="small" numberOfLines={1}>
+          {formatClipCount(segmentCount)} · {formatDuration(durationMs)} ·{' '}
+          {formatRelativeDate(lastModified)}
         </ThemedText>
       </View>
 
-      <ThemedText themeColor="textSecondary" type="small">
-        {formatRelativeDate(lastModified)}
-      </ThemedText>
+      {onMore && !editing && (
+        <Pressable
+          ref={moreRef}
+          onPress={() =>
+            moreRef.current?.measureInWindow((x, y, width, height) =>
+              onMore({ x, y, width, height }),
+            )
+          }
+          hitSlop={10}
+          accessibilityRole="button"
+          accessibilityLabel="Draft options"
+          style={({ pressed }) => [styles.more, { opacity: pressed ? 0.5 : 1 }]}>
+          <SymbolView name="ellipsis" size={18} tintColor={theme.textSecondary} />
+        </Pressable>
+      )}
     </Pressable>
   );
 }
@@ -83,5 +127,18 @@ const styles = StyleSheet.create({
   },
   name: {
     fontWeight: '600',
+  },
+  nameInput: {
+    fontSize: 16,
+    // Match the name Text's line box exactly so swapping in the input never changes
+    // the body height (which would nudge the subtitle).
+    height: 24,
+    padding: 0,
+  },
+  more: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/src/features/recorder/preview-modal.tsx
+++ b/src/features/recorder/preview-modal.tsx
@@ -9,6 +9,7 @@ type Props = {
   isPlaying: boolean;
   onTogglePlay: () => void;
   onClose: () => void;
+  onDelete: () => void;
 };
 
 /**
@@ -17,7 +18,7 @@ type Props = {
  * ✕ on the card closes. `contentFit="contain"` on black lets the native player honor each
  * clip's rotation matrix, so portrait clips render upright (§1.0a).
  */
-export function PreviewModal({ player, isPlaying, onTogglePlay, onClose }: Props) {
+export function PreviewModal({ player, isPlaying, onTogglePlay, onClose, onDelete }: Props) {
   return (
     <View style={styles.card}>
       <Pressable style={styles.surface} onPress={onTogglePlay} accessibilityLabel="Toggle playback">
@@ -41,8 +42,17 @@ export function PreviewModal({ player, isPlaying, onTogglePlay, onClose }: Props
         hitSlop={8}
         accessibilityRole="button"
         accessibilityLabel="Close preview"
-        style={styles.close}>
+        style={[styles.badge, styles.close]}>
         <SymbolView name="xmark" size={14} weight="semibold" tintColor="#fff" />
+      </Pressable>
+
+      <Pressable
+        onPress={onDelete}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Delete clip"
+        style={[styles.badge, styles.delete]}>
+        <SymbolView name="trash" size={16} weight="semibold" tintColor="#fff" />
       </Pressable>
     </View>
   );
@@ -77,15 +87,20 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingLeft: 4,
   },
-  close: {
+  badge: {
     position: 'absolute',
     top: Spacing.two,
-    left: Spacing.two,
     width: 28,
     height: 28,
     borderRadius: 14,
     backgroundColor: 'rgba(0,0,0,0.55)',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  close: {
+    left: Spacing.two,
+  },
+  delete: {
+    right: Spacing.two,
   },
 });

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -19,13 +19,18 @@ type Props = {
   cursor?: Cursor;
 };
 
-export function SegmentBar({ segments, onReorder, onDelete, onSelect, onNext, cursor }: Props) {
+export function SegmentBar(props: Props) {
+  // Gate BEFORE the hooks mount: useScrollViewOffset warns on every empty-draft render
+  // while its ref has no ScrollView attached, so the hooks live in Bar below.
+  if (props.segments.length === 0) return null;
+  return <Bar {...props} />;
+}
+
+function Bar({ segments, onReorder, onDelete, onSelect, onNext, cursor }: Props) {
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   // Owned here (not in PlayheadCursor) so the offset is already tracked when the cursor
   // mounts on a bar the user scrolled before opening the preview.
   const scrollOffset = useScrollViewOffset(scrollRef);
-
-  if (segments.length === 0) return null;
 
   return (
     <View style={styles.bar}>

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -94,17 +94,19 @@ function SegmentThumb({
   const thumbnail = useThumbnail(segment.originalFilename);
 
   return (
-    // Sortable.Touchable cooperates with the grid's long-press drag (a plain Pressable
-    // can fire its onPress after a completed drag, popping the preview unexpectedly).
-    <Sortable.Touchable
-      onTap={onSelect}
-      accessibilityLabel="Preview clip"
-      style={[styles.thumb, active && styles.thumbActive]}>
-      {thumbnail ? (
-        <Image source={thumbnail} style={styles.thumbImage} contentFit="cover" />
-      ) : (
-        <SymbolView name="video.fill" size={18} tintColor="rgba(255,255,255,0.8)" />
-      )}
+    <View style={[styles.thumb, active && styles.thumbActive]}>
+      {/* Sortable.Touchable cooperates with the grid's long-press drag (a plain Pressable
+          can fire its onPress after a completed drag, popping the preview unexpectedly). */}
+      <Sortable.Touchable onTap={onSelect} accessibilityLabel="Preview clip" style={styles.thumbTouch}>
+        {thumbnail ? (
+          <Image source={thumbnail} style={styles.thumbImage} contentFit="cover" />
+        ) : (
+          <SymbolView name="video.fill" size={18} tintColor="rgba(255,255,255,0.8)" />
+        )}
+      </Sortable.Touchable>
+
+      {/* Sibling overlay (not a child of the Touchable) so a tap here deletes WITHOUT also
+          firing the Touchable's onTap that opens the preview. */}
       <Pressable
         onPress={onDelete}
         hitSlop={6}
@@ -112,7 +114,7 @@ function SegmentThumb({
         accessibilityLabel="Delete clip">
         <SymbolView name="xmark" size={11} weight="bold" tintColor="#fff" />
       </Pressable>
-    </Sortable.Touchable>
+    </View>
   );
 }
 
@@ -135,6 +137,10 @@ const styles = StyleSheet.create({
     height: THUMB_HEIGHT,
     borderRadius: Spacing.two,
     backgroundColor: 'rgba(255,255,255,0.12)',
+  },
+  thumbTouch: {
+    flex: 1,
+    borderRadius: Spacing.two,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -27,17 +27,27 @@ export function useRecorder(initialDraftId?: string) {
 
   const { data: segments } = useLiveQuery(segmentsForDraft(draftId ?? ''), [draftId]);
 
-  // Drop a draft this session created but left empty (recorded then deleted) so it doesn't
-  // litter Home. Resumed drafts are never touched — their segments may still be loading.
+  // Drop an empty draft on leave so it doesn't litter Home: either one we created this
+  // session and never kept a clip in, or a resumed draft whose every clip was deleted.
+  // A resumed draft we never saw load (segments still []) is left alone — deleting it
+  // would nuke a draft that simply hadn't loaded yet.
   const sessionDraftId = useRef<string | null>(null);
+  const draftIdRef = useRef<string | null>(initialDraftId ?? null);
   const segmentCount = useRef(0);
+  const everHadSegments = useRef(false);
+  useEffect(() => {
+    draftIdRef.current = draftId;
+  }, [draftId]);
   useEffect(() => {
     segmentCount.current = segments.length;
+    if (segments.length > 0) everHadSegments.current = true;
   }, [segments]);
   useEffect(
     () => () => {
-      if (sessionDraftId.current && segmentCount.current === 0) {
-        void deleteDraft(sessionDraftId.current);
+      const id = draftIdRef.current;
+      const safeToDelete = sessionDraftId.current != null || everHadSegments.current;
+      if (id && segmentCount.current === 0 && safeToDelete) {
+        void deleteDraft(id);
       }
     },
     [],


### PR DESCRIPTION
## Summary

Adds draft and clip management to Home and the recorder, with confirmations and optimistic updates throughout.

### Home — draft actions
- **`⋯` menu** on each draft card: an anchored popover (`ActionMenu`) that opens at the button. Generic over a `MenuAction[]`, so future options are one-line additions.
  - **Rename** → enters the existing inline-edit mode.
  - **Delete** → confirm dialog, then optimistic removal (row hides immediately; restores + alerts on failure).
- **Inline rename** shows the new name ahead of the DB write; `renameDraft` accepts `null` to clear a name back to "Untitled".
- **Card layout**: date moved into the subtitle so the `⋯` sits alone, centered; the rename input is pinned to the name's line box so the row never shifts when editing.

### Recorder — clip deletion
- **Trash button** on the preview player, mirroring the close `✕`; deletes the previewed clip.
- **Confirmation** before deleting any clip (preview or segment bar).
- **Segment-bar `✕` fix**: the delete button no longer also opens preview (moved out of `Sortable.Touchable` so its tap is isolated).
- **Empty-draft cleanup**: leaving the recorder drops a draft that ends up empty — including a *resumed* draft whose clips were all deleted — while leaving a not-yet-loaded resumed draft untouched. Fixes the "0-clip draft on Home" case.

### Fixes
- Gate `SegmentBar`'s scroll-offset hooks behind an inner component so `useScrollViewOffset` stops warning on empty drafts.

## Testing
- `tsc --noEmit` and `eslint` clean across all changed files.
- Rename flow (inline + optimistic + persistence) verified on the iOS simulator in an earlier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)