### PR TITLE
Gesture-driven segment bar: hold-to-edit, drag-to-trash, sticky preview

### DIFF
--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -11,12 +11,13 @@ import { CloseButton } from '@/features/recorder/close-button';
 import { PermissionGate } from '@/features/recorder/permission-gate';
 import { PreviewModal } from '@/features/recorder/preview-modal';
 import { SegmentBar } from '@/features/recorder/segment-bar';
+import { RECORD_BUTTON_SIZE } from '@/features/recorder/track-metrics';
 import { usePreview } from '@/features/recorder/use-preview';
 import { useRecorder } from '@/features/recorder/use-recorder';
 import { useRecorderPermissions } from '@/features/recorder/use-recorder-permissions';
 import { useVideoTrim } from '@/features/recorder/use-video-trim';
 
-const RECORD_SIZE = 76;
+const RECORD_SIZE = RECORD_BUTTON_SIZE;
 
 export default function RecorderScreen() {
   const insets = useSafeAreaInsets();
@@ -51,6 +52,10 @@ export default function RecorderScreen() {
 
   // Trimming = RNVT's full-screen editor, launched from the ✂ button in the preview modal.
   const { openTrim } = useVideoTrim(draftId);
+
+  // True while a clip is being dragged (reorder / drag-to-trash) — hides the record button so
+  // the floating trash above the bar has clear space.
+  const [dragging, setDragging] = useState(false);
 
   const confirmDeleteSegment = (id: string) =>
     Alert.alert('Delete clip?', 'This clip will be removed from the draft.', [
@@ -102,9 +107,11 @@ export default function RecorderScreen() {
               onTrim={() => {
                 const seg = preview.active;
                 if (!seg) return;
-                // Close the preview so returning from the editor lands in record mode and
-                // re-opening the clip plays the fresh edit (the preview loads per activeId).
-                setPreviewId(null);
+                // Stay in the preview on this clip after the editor closes — edits are
+                // usually done together, so this saves a tap. Pause the underlying player
+                // while the editor is open; on save, usePreview reloads the clip's new
+                // effective file (its load effect keys on the edited filename).
+                preview.pause();
                 openTrim(seg);
               }}
               onDelete={() => preview.activeId && confirmDeleteSegment(preview.activeId)}
@@ -115,22 +122,40 @@ export default function RecorderScreen() {
         <View
           style={[styles.bottom, { paddingBottom: insets.bottom + Spacing.three }]}
           pointerEvents="box-none">
-          <Pressable
-            onPress={toggleRecording}
-            disabled={!cameraReady || previewing}
-            accessibilityRole="button"
-            accessibilityLabel={isRecording ? 'Stop recording' : 'Start recording'}
-            style={[styles.recordOuter, { opacity: cameraReady && !previewing ? 1 : 0.4 }]}>
-            <View style={isRecording ? styles.recordInnerActive : styles.recordInner} />
-          </Pressable>
+          {/* Record button is hidden entirely while previewing — the preview surface owns the
+              screen then. During a drag it's faded out (opacity 0, layout kept) so the floating
+              trash above the bar has clear space and nothing shifts. */}
+          {!previewing && (
+            <Pressable
+              onPress={toggleRecording}
+              disabled={!cameraReady || dragging}
+              accessibilityRole="button"
+              accessibilityLabel={isRecording ? 'Stop recording' : 'Start recording'}
+              style={[styles.recordOuter, { opacity: dragging ? 0 : cameraReady ? 1 : 0.4 }]}>
+              <View style={isRecording ? styles.recordInnerActive : styles.recordInner} />
+            </Pressable>
+          )}
 
           <SegmentBar
             segments={segments}
             onReorder={reorderSegments}
-            onDelete={confirmDeleteSegment}
+            // Drag-to-trash deletes immediately (the deliberate drag IS the confirmation) —
+            // no Alert here, unlike the preview modal's 🗑 which still confirms.
+            onDelete={deleteSegment}
+            onDragActiveChange={setDragging}
             onSelect={(id) => {
               if (previewing) preview.selectSegment(id);
               else if (!isRecording) setPreviewId(id);
+            }}
+            onEdit={(id) => {
+              // Hold a thumb → open the editor directly. Does NOT enter preview, so from the
+              // recorder it returns to the recorder; from preview it stays in preview
+              // (same as the ✂ button). Never opens preview as a side effect.
+              if (isRecording) return;
+              const seg = segments.find((s) => s.id === id);
+              if (!seg) return;
+              if (previewing) preview.pause();
+              openTrim(seg);
             }}
             cursor={
               previewing

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -1,20 +1,48 @@
+// The drag-to-trash callbacks imperatively mutate refs + Reanimated shared values from
+// gesture event handlers (not during render) — the controller pattern the React-Compiler
+// immutability/refs rules flag. Disabled for this file, as in use-preview/playhead-cursor.
+/* eslint-disable react-hooks/immutability */
 import { Image } from 'expo-image';
 import { SymbolView } from 'expo-symbols';
+import { useRef } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
-import Animated, { useAnimatedRef, useScrollViewOffset } from 'react-native-reanimated';
+import Animated, {
+  interpolateColor,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useScrollViewOffset,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import Sortable from 'react-native-sortables';
 
 import { Accent, Spacing } from '@/constants/theme';
 import type { Segment } from '@/db/schema';
 import { useThumbnail } from '@/hooks/use-thumbnail';
 import { PlayheadCursor, type Cursor } from './playhead-cursor';
-import { SCRUB_LANE, THUMB_HEIGHT, THUMB_WIDTH, TRACK_GAP } from './track-metrics';
+import {
+  RECORD_BAR_GAP,
+  RECORD_BUTTON_SIZE,
+  SCRUB_LANE,
+  THUMB_HEIGHT,
+  THUMB_WIDTH,
+  TRACK_GAP,
+} from './track-metrics';
+
+// Sits centered on the record button's spot (which is hidden during a drag), a little
+// smaller than it. Size is independent of RECORD_BUTTON_SIZE; the wrapper offset below keeps
+// it centered on the record button regardless.
+const TRASH_SIZE = 56;
 
 type Props = {
   segments: Segment[];
   onReorder: (ids: string[]) => void;
   onDelete: (id: string) => void;
   onSelect: (id: string) => void;
+  onEdit: (id: string) => void;
+  /** Fired true when a drag begins, false when it ends — lets the recorder hide its record
+   *  button so the floating trash above the bar has clear space. */
+  onDragActiveChange?: (active: boolean) => void;
   onNext?: () => void;
   cursor?: Cursor;
 };
@@ -26,16 +54,53 @@ export function SegmentBar(props: Props) {
   return <Bar {...props} />;
 }
 
-function Bar({ segments, onReorder, onDelete, onSelect, onNext, cursor }: Props) {
+function Bar({
+  segments,
+  onReorder,
+  onDelete,
+  onSelect,
+  onEdit,
+  onDragActiveChange,
+  onNext,
+  cursor,
+}: Props) {
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   // Owned here (not in PlayheadCursor) so the offset is already tracked when the cursor
   // mounts on a bar the user scrolled before opening the preview.
   const scrollOffset = useScrollViewOffset(scrollRef);
 
+  // Drag-to-trash. The trash floats above the bar, shown only while dragging; dropping a clip
+  // on it deletes that clip — otherwise the drag just reorders. Hit-testing is done from the
+  // drag's touch position (onDragMove) against the trash's measured window rect.
+  const trashRef = useRef<View>(null);
+  const trashRect = useRef<{ x: number; y: number; w: number; h: number } | null>(null);
+  const draggedKey = useRef<string | null>(null);
+  const overTrash = useRef(false);
+  const vis = useSharedValue(0); // 0→1 trash fade-in during a drag
+  const over = useSharedValue(0); // highlight when a dragged clip hovers the trash
+
+  const measureTrash = () =>
+    trashRef.current?.measureInWindow((x, y, w, h) => {
+      trashRect.current = { x, y, w, h };
+    });
+
+  const trashStyle = useAnimatedStyle(() => ({
+    opacity: vis.value,
+    transform: [{ scale: 0.85 + 0.15 * vis.value + 0.12 * over.value }],
+    backgroundColor: interpolateColor(over.value, [0, 1], ['rgba(0,0,0,0.6)', Accent]),
+    borderColor: interpolateColor(over.value, [0, 1], ['rgba(255,255,255,0.4)', '#fff']),
+  }));
+
   return (
     <View style={styles.bar}>
-      {/* The scrub lane is reserved in BOTH modes so the bar never changes height (and
-          therefore never shifts) when a preview opens. */}
+      {/* Trash drop target — above the bar, fades in during a drag. pointerEvents="none" so it
+          never intercepts touches; it's purely a drop zone hit-tested from the drag position. */}
+      <View style={styles.trashWrap} pointerEvents="none">
+        <Animated.View ref={trashRef} onLayout={measureTrash} style={[styles.trash, trashStyle]}>
+          <SymbolView name="trash.fill" size={22} tintColor="#fff" />
+        </Animated.View>
+      </View>
+
       <View style={styles.viewport}>
         <Animated.ScrollView
           ref={scrollRef}
@@ -50,13 +115,46 @@ function Bar({ segments, onReorder, onDelete, onSelect, onNext, cursor }: Props)
             keyExtractor={(s) => s.id}
             scrollableRef={scrollRef}
             autoScrollDirection="horizontal"
-            onDragEnd={({ data }) => onReorder(data.map((s) => s.id))}
+            // Reorder only from the drag handle (≣) — frees a plain hold on the thumb to
+            // mean "edit" without colliding with the grid's long-press-to-drag.
+            customHandle
+            onDragStart={({ key }) => {
+              draggedKey.current = key;
+              overTrash.current = false;
+              over.value = 0;
+              vis.value = withTiming(1, { duration: 150 });
+              measureTrash();
+              onDragActiveChange?.(true);
+            }}
+            onDragMove={({ touchData }) => {
+              const r = trashRect.current;
+              const inside =
+                !!r &&
+                touchData.absoluteX >= r.x &&
+                touchData.absoluteX <= r.x + r.w &&
+                touchData.absoluteY >= r.y &&
+                touchData.absoluteY <= r.y + r.h;
+              if (inside !== overTrash.current) {
+                overTrash.current = inside;
+                over.value = withTiming(inside ? 1 : 0, { duration: 120 });
+              }
+            }}
+            onDragEnd={({ data }) => {
+              vis.value = withTiming(0, { duration: 150 });
+              over.value = withTiming(0, { duration: 120 });
+              // Dropped on the trash → delete that clip; otherwise persist the new order.
+              if (overTrash.current && draggedKey.current) onDelete(draggedKey.current);
+              else onReorder(data.map((s) => s.id));
+              overTrash.current = false;
+              draggedKey.current = null;
+              onDragActiveChange?.(false);
+            }}
             renderItem={({ item }) => (
               <SegmentThumb
                 segment={item}
                 active={cursor?.activeId === item.id}
                 onSelect={() => onSelect(item.id)}
-                onDelete={() => onDelete(item.id)}
+                onEdit={() => onEdit(item.id)}
               />
             )}
           />
@@ -84,23 +182,25 @@ function SegmentThumb({
   segment,
   active,
   onSelect,
-  onDelete,
+  onEdit,
 }: {
   segment: Segment;
   active: boolean;
   onSelect: () => void;
-  onDelete: () => void;
+  onEdit: () => void;
 }) {
   // Cover the EFFECTIVE clip — the edited file once trimmed, else the pristine original.
   const thumbnail = useThumbnail(segment.editedFilename ?? segment.originalFilename);
 
   return (
     <View style={[styles.thumb, active && styles.thumbActive]}>
-      {/* Sortable.Touchable cooperates with the grid's long-press drag (a plain Pressable
-          can fire its onPress after a completed drag, popping the preview unexpectedly). */}
+      {/* tap = preview · hold = open editor (onLongPress) · drag the ≣ handle = reorder (drop
+          on the trash to delete). Sortable.Touchable cooperates with the grid so a tap can't
+          fire after a drag. */}
       <Sortable.Touchable
         onTap={onSelect}
-        accessibilityLabel="Preview clip"
+        onLongPress={onEdit}
+        accessibilityLabel="Preview clip (hold to edit)"
         style={styles.thumbTouch}>
         {thumbnail ? (
           <Image source={thumbnail} style={styles.thumbImage} contentFit="cover" />
@@ -109,15 +209,10 @@ function SegmentThumb({
         )}
       </Sortable.Touchable>
 
-      {/* Sibling overlay (not a child of the Touchable) so a tap here deletes WITHOUT also
-          firing the Touchable's onTap that opens the preview. */}
-      <Pressable
-        onPress={onDelete}
-        hitSlop={6}
-        style={styles.thumbDelete}
-        accessibilityLabel="Delete clip">
-        <SymbolView name="xmark" size={11} weight="bold" tintColor="#fff" />
-      </Pressable>
+      {/* Drag handle (≣) — the only reorder/drag activator (drag onto the trash to delete). */}
+      <Sortable.Handle style={[styles.handle]}>
+        <SymbolView name="line.3.horizontal" size={11} weight="bold" tintColor="#fff" />
+      </Sortable.Handle>
     </View>
   );
 }
@@ -133,6 +228,27 @@ const styles = StyleSheet.create({
     paddingVertical: Spacing.two,
     borderRadius: Spacing.three,
     backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  trashWrap: {
+    position: 'absolute',
+    // Vertically: align the trash's CENTER with the record button's center. The record
+    // button sits RECORD_BAR_GAP above the bar and is RECORD_BUTTON_SIZE tall, so its center
+    // is (RECORD_BAR_GAP + RECORD_BUTTON_SIZE/2) up; offset this wrapper by a further
+    // TRASH_SIZE/2 so the (smaller) circle's center lands there too. Horizontally: span the
+    // bar (left/right 0) and center the circle with alignItems — robust against the bar's
+    // padding (a plain left:'50%' lands ~one padding off because % is measured from the edge).
+    top: -(RECORD_BAR_GAP + RECORD_BUTTON_SIZE / 2 + TRASH_SIZE / 2),
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  trash: {
+    width: TRASH_SIZE,
+    height: TRASH_SIZE,
+    borderRadius: TRASH_SIZE / 2,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   viewport: { flex: 1, overflow: 'hidden', paddingBottom: SCRUB_LANE },
   content: { alignItems: 'center', paddingRight: Spacing.two },
@@ -160,10 +276,10 @@ const styles = StyleSheet.create({
     bottom: 0,
     borderRadius: Spacing.two,
   },
-  thumbDelete: {
+  handle: {
     position: 'absolute',
     top: 3,
-    right: 3,
+    left: 3,
     width: 18,
     height: 18,
     borderRadius: 9,

--- a/src/features/recorder/track-metrics.ts
+++ b/src/features/recorder/track-metrics.ts
@@ -7,6 +7,10 @@ import { Spacing } from '@/constants/theme';
 export const THUMB_HEIGHT = 64;
 export const THUMB_WIDTH = 48;
 export const TRACK_GAP = Spacing.two;
+/** Record-button diameter + its gap above the bar — shared so the drag-to-trash button can
+ *  sit exactly where the record button is (clean swap as one fades out and the other in). */
+export const RECORD_BUTTON_SIZE = 76;
+export const RECORD_BAR_GAP = Spacing.three;
 /** Horizontal rhythm of the track: one thumb + the grid's column gap. */
 export const STEP = THUMB_WIDTH + TRACK_GAP;
 /** Extra lane below the thumbs the cursor knob hangs into (keeps it off taps/✕/drag). */

--- a/src/features/recorder/use-preview.ts
+++ b/src/features/recorder/use-preview.ts
@@ -76,6 +76,10 @@ export function usePreview(segments: Segment[], anchorId: string | null) {
   })();
   const active = activeIndex >= 0 ? segments[activeIndex] : null;
   const activeId = active?.id ?? null;
+  // The active clip's effective file — changes when it's edited (a new `editedFilename`).
+  // The load effect keys on this so an edit to the CURRENT clip reloads it in place
+  // (e.g. returning from the RNVT editor while still in the preview).
+  const activeFile = active ? effFile(active) : null;
 
   const { isPlaying } = useEvent(player, 'playingChange', { isPlaying: player.playing });
 
@@ -134,7 +138,7 @@ export function usePreview(segments: Segment[], anchorId: string | null) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeId]);
+  }, [activeId, activeFile]);
 
   useEventListener(player, 'statusChange', ({ status }: { status: string }) => {
     if (status === 'error') {
@@ -205,6 +209,12 @@ export function usePreview(segments: Segment[], anchorId: string | null) {
     [player, activeId, active],
   );
 
+  /** Pause playback without changing the selection (e.g. while the RNVT editor is open). */
+  const pause = useCallback(() => {
+    wantPlayRef.current = false;
+    player.pause();
+  }, [player]);
+
   const togglePlay = useCallback(() => {
     if (player.playing) {
       player.pause();
@@ -256,6 +266,7 @@ export function usePreview(segments: Segment[], anchorId: string | null) {
     globalMs,
     totalMs,
     togglePlay,
+    pause,
     selectSegment,
     seekToGlobalMs,
   };


### PR DESCRIPTION
Reworks how clips are managed on the recorder's segment bar.

## Gestures
- **Tap** a thumb → preview
- **Hold** a thumb → open the RNVT editor (returns to the recorder, never opens preview)
- **Drag the ≣ handle** → reorder (handle-only via `customHandle`, so a plain hold is free to mean "edit")
- **Drag onto the trash** → delete

## Drag-to-trash
- Removed the per-thumb ✕. A single trash button floats **centered above the bar**, shown **only while dragging**, highlights when a clip hovers, and deletes the clip dropped on it — **immediately** (the deliberate drag is the confirmation; the preview modal's 🗑 still confirms).
- The **record button is hidden during a drag**, and the trash is sized/positioned to land on its exact spot via shared `RECORD_BUTTON_SIZE` / `RECORD_BAR_GAP` — a clean swap on every screen (verified centered to ~1px).

## Preview
- The **✂ in the preview modal keeps the preview open** after Save/Cancel (edits are usually done together) and reloads the clip's new effective file. Added `usePreview.pause()` for the editor handoff.

## Editor
- `enableCancelDialog`/`enableSaveDialog` off — Save/Cancel dismiss immediately.

## Verification (iOS simulator)
- hold → editor → back to recorder; tap → preview
- drag onto trash deletes (segment count drops); horizontal drag reorders (count unchanged, order changes)
- trash fades in centered on the record button (`602` vs screen-center `603`), record button hidden during drag
- tsc / lint / format clean