### PR TITLE
feat(recorder): running timer + reach-the-ends playhead scrub

### DIFF
--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -1,7 +1,7 @@
 import { CameraView } from 'expo-camera';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, StyleSheet, View } from 'react-native';
+import { Alert, StyleSheet, Text, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -20,7 +20,9 @@ import { usePreview } from '@/features/recorder/use-preview';
 import { useRecorder } from '@/features/recorder/use-recorder';
 import { useRecorderGestures } from '@/features/recorder/use-recorder-gestures';
 import { useRecorderPermissions } from '@/features/recorder/use-recorder-permissions';
+import { useRecordingTimer } from '@/features/recorder/use-recording-timer';
 import { useVideoTrim } from '@/features/recorder/use-video-trim';
+import { formatDurationPadded } from '@/utils/format';
 
 export default function RecorderScreen() {
   const insets = useSafeAreaInsets();
@@ -31,6 +33,7 @@ export default function RecorderScreen() {
     draftId,
     segments,
     isRecording,
+    recordStartedAt,
     cameraReady,
     facing,
     torch,
@@ -60,6 +63,10 @@ export default function RecorderScreen() {
   if (previewId != null && segments.length === 0) setPreviewId(null);
   const preview = usePreview(segments, previewId);
   const previewing = previewId != null;
+
+  // Top running timer: always the live draft total — saved clips plus wall-clock while
+  // recording. During preview the playhead position is shown inside the preview card instead.
+  const totalMs = useRecordingTimer(segments, recordStartedAt);
 
   // Trimming = RNVT's full-screen editor, launched from the ✂ button in the preview modal.
   const { openTrim } = useVideoTrim(draftId);
@@ -128,8 +135,15 @@ export default function RecorderScreen() {
       </GestureDetector>
 
       <View style={[StyleSheet.absoluteFill, styles.overlay]} pointerEvents="box-none">
-        <View style={{ paddingTop: insets.top + Spacing.two, paddingHorizontal: Spacing.three }}>
+        <View
+          style={[
+            styles.topBar,
+            { paddingTop: insets.top + Spacing.two, paddingHorizontal: Spacing.three },
+          ]}>
           <CloseButton onPress={() => router.back()} />
+          <Text style={styles.timerText}>{formatDurationPadded(totalMs)}</Text>
+          {/* Mirrors the CloseButton's width so the timer stays optically centered. */}
+          <View style={styles.topBarSpacer} />
         </View>
 
         <CameraControls
@@ -149,6 +163,8 @@ export default function RecorderScreen() {
             <PreviewModal
               player={preview.player}
               isPlaying={preview.isPlaying}
+              positionMs={preview.globalMs}
+              totalMs={preview.totalMs}
               onTogglePlay={preview.togglePlay}
               onClose={() => setPreviewId(null)}
               onTrim={() => {
@@ -242,6 +258,22 @@ export default function RecorderScreen() {
 const styles = StyleSheet.create({
   fill: { flex: 1, backgroundColor: '#000' },
   overlay: { justifyContent: 'space-between' },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  timerText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: 0.5,
+    textShadowColor: 'rgba(0,0,0,0.6)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 3,
+  },
+  topBarSpacer: { width: 40 },
   previewArea: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   bottom: { alignItems: 'center', gap: Spacing.three },
   // Full-width row; the record button is centered by the row itself, so its position can't

--- a/src/features/recorder/playhead-cursor.tsx
+++ b/src/features/recorder/playhead-cursor.tsx
@@ -153,10 +153,10 @@ export function PlayheadCursor({
       const vw = viewportW.value;
       if (vw <= 0) return;
       const dt = (frame.timeSincePreviousFrame ?? 16) / 1000;
-      const knob = Math.min(
-        Math.max(baseKnobScreen.value + fingerTransX.value, KNOB_PAD),
-        vw - KNOB_PAD,
-      );
+      const raw = baseKnobScreen.value + fingerTransX.value;
+      // Edge-zone auto-scroll trigger uses the wider KNOB_PAD band (clamping the finger to the
+      // zone's outer edge also caps the scroll velocity at MAX).
+      const knob = Math.min(Math.max(raw, KNOB_PAD), vw - KNOB_PAD);
       let v = 0;
       if (knob < KNOB_PAD + EDGE_ZONE) v = -MAX_SCROLL_SPEED * (1 - (knob - KNOB_PAD) / EDGE_ZONE);
       else if (knob > vw - KNOB_PAD - EDGE_ZONE)
@@ -164,8 +164,13 @@ export function PlayheadCursor({
       const maxScroll = Math.max(0, contentW.value - vw);
       const nextOffset = Math.min(Math.max(scrollOffset.value + v * dt, 0), maxScroll);
       if (nextOffset !== scrollOffset.value) scrollTo(scrollRef, nextOffset, 0, false);
+      // Seek position uses a tighter KNOB/2 clamp — just enough to keep the knob fully on-screen
+      // (SCRUB_INSET = KNOB/2). With the wider KNOB_PAD the playhead stopped (KNOB_PAD - SCRUB_INSET)
+      // px short of each end, so it never reached globalMs 0 / totalMs and the preview started a
+      // little into the first clip. KNOB/2 lets contentX reach 0 and maxContentX exactly.
+      const knobSeek = Math.min(Math.max(raw, KNOB / 2), vw - KNOB / 2);
       // content-x (the playhead/seek position) = knob screen-x − inset + offset.
-      const contentX = Math.min(Math.max(knob - SCRUB_INSET + nextOffset, 0), maxContentX.value);
+      const contentX = Math.min(Math.max(knobSeek - SCRUB_INSET + nextOffset, 0), maxContentX.value);
       cursorX.value = contentX; // drives the knob render (cursorX − scrollOffset)
       sinceSeek.value += dt;
       if (sinceSeek.value >= SCRUB_INTERVAL_MS / 1000) {

--- a/src/features/recorder/preview-modal.tsx
+++ b/src/features/recorder/preview-modal.tsx
@@ -1,12 +1,16 @@
 import { SymbolView } from 'expo-symbols';
 import { VideoView, type VideoPlayer } from 'expo-video';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Spacing } from '@/constants/theme';
+import { formatDurationPadded } from '@/utils/format';
 
 type Props = {
   player: VideoPlayer;
   isPlaying: boolean;
+  // Draft-global playhead position and total, for the time readout pill.
+  positionMs: number;
+  totalMs: number;
   onTogglePlay: () => void;
   onClose: () => void;
   onTrim: () => void;
@@ -22,6 +26,8 @@ type Props = {
 export function PreviewModal({
   player,
   isPlaying,
+  positionMs,
+  totalMs,
   onTogglePlay,
   onClose,
   onTrim,
@@ -71,6 +77,14 @@ export function PreviewModal({
         style={[styles.badge, styles.delete]}>
         <SymbolView name="trash" size={16} weight="semibold" tintColor="#fff" />
       </Pressable>
+
+      <View style={styles.timeRow} pointerEvents="none">
+        <View style={styles.timePill}>
+          <Text style={styles.timeText}>
+            {formatDurationPadded(positionMs)} / {formatDurationPadded(totalMs)}
+          </Text>
+        </View>
+      </View>
     </View>
   );
 }
@@ -123,5 +137,25 @@ const styles = StyleSheet.create({
   // Left of the delete badge (28 wide + an 8pt gap).
   trim: {
     right: Spacing.two + 28 + Spacing.two,
+  },
+  timeRow: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: Spacing.two,
+    alignItems: 'center',
+  },
+  timePill: {
+    paddingHorizontal: Spacing.two,
+    paddingVertical: 4,
+    borderRadius: 12,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+  },
+  timeText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+    letterSpacing: 0.3,
   },
 });

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -27,6 +27,9 @@ export function useRecorder(initialDraftId?: string) {
   const cameraRef = useRef<CameraView>(null);
   const [draftId, setDraftId] = useState<string | null>(initialDraftId ?? null);
   const [isRecording, setIsRecording] = useState(false);
+  // Wall-clock start of the active recording, for the live running timer in the UI. Mirrors
+  // recordCallAtRef (which stays a ref for the MIN_RECORD_MS stop-guard); null when idle.
+  const [recordStartedAt, setRecordStartedAt] = useState<number | null>(null);
   const [cameraReady, setCameraReady] = useState(false);
   const [facing, setFacing] = useState<CameraType>('back');
   const [torch, setTorch] = useState(false);
@@ -110,6 +113,7 @@ export function useRecorder(initialDraftId?: string) {
     }
     isRecordingRef.current = true;
     recordCallAtRef.current = Date.now();
+    setRecordStartedAt(Date.now());
     setIsRecording(true);
     try {
       // Pinned capture format (with videoQuality="1080p" on CameraView): HEVC 1080p. Every
@@ -137,6 +141,7 @@ export function useRecorder(initialDraftId?: string) {
       isRecordingRef.current = false;
       holdInitiatedRef.current = false;
       setIsRecording(false);
+      setRecordStartedAt(null);
     }
   }
 
@@ -233,6 +238,7 @@ export function useRecorder(initialDraftId?: string) {
     draftId,
     segments,
     isRecording,
+    recordStartedAt,
     cameraReady,
     facing,
     torch,

--- a/src/features/recorder/use-recording-timer.ts
+++ b/src/features/recorder/use-recording-timer.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import type { Segment } from '@/db/schema';
+import { effMs } from '@/utils/segment-window';
+
+// Running total time for the recorder's top timer. While idle this is just the sum of saved
+// clip durations; while recording it adds the wall-clock elapsed since `recordStartedAt`,
+// ticking every 100ms. On stop the new clip's precise file duration lands in `segments` and
+// the live estimate is dropped — a sub-second snap that's expected.
+export function useRecordingTimer(
+  segments: Segment[],
+  recordStartedAt: number | null,
+): number {
+  const savedTotal = segments.reduce((sum, s) => sum + effMs(s), 0);
+  // Only the interval mutates `now`; elapsed is derived in render. A stale `now` (idle, or the
+  // first 100ms of a fresh recording) yields a negative diff that the clamp floors to 0.
+  const [now, setNow] = useState(0);
+
+  useEffect(() => {
+    if (recordStartedAt == null) return;
+    const id = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(id);
+  }, [recordStartedAt]);
+
+  if (recordStartedAt == null) return savedTotal;
+  return savedTotal + Math.max(0, now - recordStartedAt);
+}


### PR DESCRIPTION
Adds a running total-time timer to the recorder top bar and fixes the preview playhead so it can scrub all the way to each end.

- **Top timer**: live draft total — sum of saved clip durations plus wall-clock elapsed while recording (`useRecordingTimer`).
- **Preview pill**: shows `position / total` playhead time inside the preview card.
- **Playhead scrub**: the seek position now uses a `KNOB/2` clamp (vs the wider `KNOB_PAD` band, which stays for the auto-scroll trigger), so the playhead reaches `globalMs = 0` and `totalMs` exactly instead of stopping a few px short and starting the preview slightly into the first clip.