### PR TITLE
feat: adopt more react-native-video-trim features

### DIFF
--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -15,6 +15,7 @@ import { Accent, Spacing } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
 import { segmentsForDraft } from '@/db/drafts';
 import { useExport } from '@/features/export/use-export';
+import { useSaveToDocuments } from '@/features/export/use-save-to-documents';
 import { useSaveToPhotos } from '@/features/export/use-save-to-photos';
 import { formatClipCount, formatDuration } from '@/utils/format';
 import { effMs } from '@/utils/segment-window';
@@ -34,6 +35,7 @@ export default function ExportScreen() {
   // Whether the share sheet is being presented, so we can disable the button and show a spinner.
   const [busy, setBusy] = useState(false);
   const photos = useSaveToPhotos();
+  const docs = useSaveToDocuments();
   const theme = useTheme();
 
   const runShare = async () => {
@@ -111,6 +113,27 @@ export default function ExportScreen() {
                   <>
                     <SymbolView name="square.and.arrow.down" size={18} tintColor={theme.text} />
                     <ThemedText>Save to Photos</ThemedText>
+                  </>
+                )}
+              </Pressable>
+
+              <Pressable
+                onPress={() => void docs.save(toFileUri(state.outputPath))}
+                disabled={docs.status !== 'idle'}
+                accessibilityRole="button"
+                accessibilityLabel="Save to Files"
+                style={[styles.button, { backgroundColor: theme.backgroundElement }]}>
+                {docs.status === 'saving' ? (
+                  <ActivityIndicator color={theme.text} />
+                ) : docs.status === 'saved' ? (
+                  <>
+                    <SymbolView name="checkmark" size={18} tintColor={theme.text} />
+                    <ThemedText>Saved</ThemedText>
+                  </>
+                ) : (
+                  <>
+                    <SymbolView name="folder" size={18} tintColor={theme.text} />
+                    <ThemedText>Save to Files</ThemedText>
                   </>
                 )}
               </Pressable>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -148,6 +148,7 @@ export default function HomeScreen() {
             <DraftCard
               name={pendingRename?.id === item.id ? pendingRename.name : item.name}
               firstSegmentFilename={item.firstSegmentFilename}
+              firstSegmentThumbnail={item.firstSegmentThumbnail}
               segmentCount={item.segmentCount}
               durationMs={item.durationMs}
               lastModified={item.lastModified}

--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -1,6 +1,13 @@
 import { asc, count, desc, eq, sql } from 'drizzle-orm';
 
-import { deleteDraftDir, deleteSegmentFile } from '@/utils/file-store';
+import {
+  absolutize,
+  deleteDraftDir,
+  deleteSegmentFile,
+  editedThumbRelPath,
+  thumbRelPath,
+} from '@/utils/file-store';
+import { generateThumbnailFile } from '@/utils/video';
 import { db } from './client';
 import { projects, segments } from './schema';
 
@@ -15,10 +22,13 @@ export const draftListQuery = db
     segmentCount: count(segments.id),
     // Effective duration = sum of each clip's edited duration (if edited) else its original.
     durationMs: sql<number>`coalesce(sum(coalesce(${segments.editedDurationMs}, ${segments.durationMs})), 0)`,
-    // Cover frame is derived at runtime from the first clip's effective (edited ?? original) file.
+    // Cover frame: the first clip's persisted thumbnail (+ its effective file as a legacy fallback).
     firstSegmentFilename: sql<
       string | null
     >`(select coalesce(edited_filename, original_filename) from ${segments} where ${segments.projectId} = ${projects.id} order by sort_order limit 1)`,
+    firstSegmentThumbnail: sql<
+      string | null
+    >`(select thumbnail from ${segments} where ${segments.projectId} = ${projects.id} order by sort_order limit 1)`,
   })
   .from(projects)
   .leftJoin(segments, eq(segments.projectId, projects.id))
@@ -43,7 +53,7 @@ export async function createDraft(): Promise<string> {
 
 export async function addSegment(
   draftId: string,
-  segment: { id: string; originalFilename: string; durationMs: number },
+  segment: { id: string; originalFilename: string; durationMs: number; thumbnail?: string | null },
 ): Promise<void> {
   const [{ value: order }] = await db
     .select({ value: count() })
@@ -56,6 +66,7 @@ export async function addSegment(
     order,
     originalFilename: segment.originalFilename,
     durationMs: segment.durationMs,
+    thumbnail: segment.thumbnail ?? null,
   });
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, draftId));
 }
@@ -72,8 +83,10 @@ export async function deleteSegment(segmentId: string): Promise<void> {
     .from(segments)
     .where(eq(segments.originalFilename, seg.originalFilename));
   if (stillReferenced === 0) deleteSegmentFile(seg.originalFilename);
-  // The edited file is per-segment (never shared) — always safe to delete with the row.
+  // The edited file and both thumbnails are per-segment (never shared) — delete with the row.
   if (seg.editedFilename) deleteSegmentFile(seg.editedFilename);
+  deleteSegmentFile(thumbRelPath(seg.projectId, segmentId));
+  deleteSegmentFile(editedThumbRelPath(seg.projectId, segmentId));
 
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
@@ -90,9 +103,13 @@ export async function setEdited(
   if (seg.editedFilename && seg.editedFilename !== editedFilename) {
     deleteSegmentFile(seg.editedFilename);
   }
+  // Cover the edited file's first frame at the distinct edited-thumb path (the pristine thumb
+  // stays on disk untouched, ready for a reset).
+  const thumbRel = editedThumbRelPath(seg.projectId, segmentId);
+  const ok = await generateThumbnailFile(absolutize(editedFilename), absolutize(thumbRel));
   await db
     .update(segments)
-    .set({ editedFilename, editedDurationMs })
+    .set({ editedFilename, editedDurationMs, thumbnail: ok ? thumbRel : seg.thumbnail })
     .where(eq(segments.id, segmentId));
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
@@ -102,9 +119,13 @@ export async function resetEdit(segmentId: string): Promise<void> {
   const [seg] = await db.select().from(segments).where(eq(segments.id, segmentId));
   if (!seg) return;
   if (seg.editedFilename) deleteSegmentFile(seg.editedFilename);
+  // Revert the cover to the pristine original's thumbnail; drop the now-orphaned edited thumb.
+  deleteSegmentFile(editedThumbRelPath(seg.projectId, segmentId));
+  const thumbRel = thumbRelPath(seg.projectId, segmentId);
+  const ok = await generateThumbnailFile(absolutize(seg.originalFilename), absolutize(thumbRel));
   await db
     .update(segments)
-    .set({ editedFilename: null, editedDurationMs: null })
+    .set({ editedFilename: null, editedDurationMs: null, thumbnail: ok ? thumbRel : null })
     .where(eq(segments.id, segmentId));
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }

--- a/src/db/migrate.tsx
+++ b/src/db/migrate.tsx
@@ -1,5 +1,7 @@
 import { useMigrations } from 'drizzle-orm/expo-sqlite/migrator';
+import { useEffect, useRef } from 'react';
 import { ActivityIndicator } from 'react-native';
+import { cleanFiles } from 'react-native-video-trim';
 
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
@@ -10,6 +12,18 @@ const centered = { flex: 1, alignItems: 'center', justifyContent: 'center', gap:
 
 export function MigrationGate({ children }: { children: React.ReactNode }) {
   const { success, error } = useMigrations(db, migrations);
+
+  // Sweep RNVT's output cache once on launch — editor outputs are already moved into draft dirs
+  // (importTrimmedFile) and merge outputs are produced on-demand at export, so nothing in use is
+  // live at startup. Reclaims the copies RNVT leaves behind on every trim/merge.
+  const swept = useRef(false);
+  useEffect(() => {
+    if (!success || swept.current) return;
+    swept.current = true;
+    void cleanFiles()
+      .then((n) => console.log(`[cleanup] removed ${n} stale RNVT output file(s)`))
+      .catch(() => {});
+  }, [success]);
 
   if (error) {
     return (

--- a/src/dev/seed.ts
+++ b/src/dev/seed.ts
@@ -4,8 +4,8 @@ import { Asset } from 'expo-asset';
 import { db } from '@/db/client';
 import { addSegment } from '@/db/drafts';
 import { projects } from '@/db/schema';
-import { absolutize, copyIntoSegments, deleteDraftDir } from '@/utils/file-store';
-import { getDurationMs } from '@/utils/video';
+import { absolutize, copyIntoSegments, deleteDraftDir, thumbRelPath } from '@/utils/file-store';
+import { generateThumbnailFile, getDurationMs } from '@/utils/video';
 
 // Dev-only helpers (§1.0b): seed one curated draft of bundled sample clips so the timeline
 // editor is exercisable on a simulator with no camera. Gate every caller behind `__DEV__`.
@@ -79,7 +79,14 @@ export async function seedDraft(): Promise<string | undefined> {
     const segmentId = `${SEED_DRAFT_ID}-${i}`;
     const originalFilename = await copyIntoSegments(asset.localUri, SEED_DRAFT_ID, segmentId);
     const durationMs = await getDurationMs(absolutize(originalFilename));
-    await addSegment(SEED_DRAFT_ID, { id: segmentId, originalFilename, durationMs });
+    const thumbRel = thumbRelPath(SEED_DRAFT_ID, segmentId);
+    const ok = await generateThumbnailFile(absolutize(originalFilename), absolutize(thumbRel));
+    await addSegment(SEED_DRAFT_ID, {
+      id: segmentId,
+      originalFilename,
+      durationMs,
+      thumbnail: ok ? thumbRel : null,
+    });
   }
 
   return SEED_DRAFT_ID;

--- a/src/features/export/use-save-to-documents.ts
+++ b/src/features/export/use-save-to-documents.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { Alert } from 'react-native';
+import { saveToDocuments } from 'react-native-video-trim';
+
+export type SaveStatus = 'idle' | 'saving' | 'saved';
+
+/**
+ * Saves an exported video to a user-chosen location via the system document picker
+ * (RNVT `saveToDocuments`). No photo-library permission needed. A cancelled picker resolves
+ * unsuccessfully and quietly returns to idle.
+ */
+export function useSaveToDocuments() {
+  const [status, setStatus] = useState<SaveStatus>('idle');
+
+  async function save(fileUri: string) {
+    if (status !== 'idle') return;
+    setStatus('saving');
+    try {
+      const res = await saveToDocuments(fileUri);
+      if (res.success) {
+        setStatus('saved');
+        Alert.alert('Saved to Files', 'Your video is in the Files app.');
+      } else {
+        setStatus('idle');
+      }
+    } catch (e) {
+      setStatus('idle');
+      Alert.alert('Save failed', e instanceof Error ? e.message : 'Could not save the video.');
+    }
+  }
+
+  return { status, save };
+}

--- a/src/features/home/draft-card.tsx
+++ b/src/features/home/draft-card.tsx
@@ -7,6 +7,7 @@ import type { Anchor } from '@/components/action-menu';
 import { ThemedText } from '@/components/themed-text';
 import { Spacing } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useThumbnail } from '@/hooks/use-thumbnail';
 import { formatClipCount, formatDuration, formatRelativeDate } from '@/utils/format';
 
@@ -14,8 +15,10 @@ const NAME_MAX_LENGTH = 40;
 
 type Props = {
   name: string | null;
-  /** Relative path of the draft's first clip; the cover frame is derived from it at runtime. */
+  /** Relative path of the draft's first clip; the cover frame's legacy runtime fallback. */
   firstSegmentFilename?: string | null;
+  /** Relative path of the first clip's persisted jpeg thumbnail (preferred cover frame). */
+  firstSegmentThumbnail?: string | null;
   segmentCount: number;
   durationMs: number;
   lastModified: number;
@@ -32,6 +35,7 @@ type Props = {
 export function DraftCard({
   name,
   firstSegmentFilename,
+  firstSegmentThumbnail,
   segmentCount,
   durationMs,
   lastModified,
@@ -42,7 +46,8 @@ export function DraftCard({
   onSubmitName,
 }: Props) {
   const theme = useTheme();
-  const thumbnail = useThumbnail(firstSegmentFilename);
+  const isDark = useColorScheme() === 'dark';
+  const thumbnail = useThumbnail(firstSegmentThumbnail, firstSegmentFilename);
   const moreRef = useRef<View>(null);
 
   return (
@@ -53,9 +58,18 @@ export function DraftCard({
         styles.card,
         { backgroundColor: theme.backgroundElement, opacity: pressed && !editing ? 0.6 : 1 },
       ]}>
-      <View style={[styles.thumb, { backgroundColor: theme.backgroundSelected }]}>
+      <View
+        style={[
+          styles.thumb,
+          {
+            backgroundColor: theme.backgroundSelected,
+            borderColor: theme.border,
+            // Opposite-tone shadow so it reads in both modes: black in light, white in dark.
+            shadowColor: isDark ? '#fff' : '#000',
+          },
+        ]}>
         {thumbnail ? (
-          <Image source={thumbnail} style={StyleSheet.absoluteFill} contentFit="cover" />
+          <Image source={thumbnail} style={styles.thumbImage} contentFit="cover" />
         ) : (
           <SymbolView name="video.fill" size={18} tintColor={theme.textSecondary} />
         )}
@@ -116,10 +130,20 @@ const styles = StyleSheet.create({
   thumb: {
     width: 44,
     height: 60,
-    borderRadius: Spacing.two,
     alignItems: 'center',
     justifyContent: 'center',
-    overflow: 'hidden',
+    // Lift the cover off the card so it pops a little. A hairline ring carries the separation
+    // in dark mode (where a black shadow is invisible against the dark card); the shadow does
+    // the lifting in light mode.
+    borderWidth: StyleSheet.hairlineWidth,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.15,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  thumbImage: {
+    width: '100%',
+    height: '100%',
   },
   body: {
     flex: 1,

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -236,8 +236,8 @@ function SegmentThumb({
   onSelect: () => void;
   onEdit: () => void;
 }) {
-  // Cover the EFFECTIVE clip — the edited file once trimmed, else the pristine original.
-  const thumbnail = useThumbnail(segment.editedFilename ?? segment.originalFilename);
+  // Persisted jpeg cover; falls back to the EFFECTIVE clip (edited ?? original) for legacy rows.
+  const thumbnail = useThumbnail(segment.thumbnail, segment.editedFilename ?? segment.originalFilename);
 
   // Effective (post-trim) clip length, the same number the playhead and export use. A failed
   // native read stores 0ms (the clip is skipped on playback) — show nothing rather than 00:00.

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -4,6 +4,7 @@ import { launchImageLibraryAsync, VideoExportPreset } from 'expo-image-picker';
 import { usePermissions } from 'expo-media-library';
 import { useEffect, useRef, useState } from 'react';
 import { Alert, Linking } from 'react-native';
+import { isValidFile } from 'react-native-video-trim';
 
 import {
   addSegment,
@@ -13,8 +14,8 @@ import {
   reorderSegments,
   segmentsForDraft,
 } from '@/db/drafts';
-import { absolutize, copyIntoSegments, persistRecording } from '@/utils/file-store';
-import { getDurationMs } from '@/utils/video';
+import { absolutize, copyIntoSegments, persistRecording, thumbRelPath } from '@/utils/file-store';
+import { generateThumbnailFile, getDurationMs } from '@/utils/video';
 
 export const STABILIZATION_MODES = ['off', 'standard', 'cinematic', 'auto'] as const;
 export type StabilizationMode = (typeof STABILIZATION_MODES)[number];
@@ -134,7 +135,9 @@ export function useRecorder(initialDraftId?: string) {
       const segmentId = `${id}-${Date.now()}`;
       const originalFilename = await persistRecording(video.uri, id, segmentId);
       const durationMs = await getDurationMs(absolutize(originalFilename));
-      await addSegment(id, { id: segmentId, originalFilename, durationMs });
+      const thumbRel = thumbRelPath(id, segmentId);
+      const ok = await generateThumbnailFile(absolutize(originalFilename), absolutize(thumbRel));
+      await addSegment(id, { id: segmentId, originalFilename, durationMs, thumbnail: ok ? thumbRel : null });
     } catch {
       // interrupted mid-record — drop the clip
     } finally {
@@ -173,6 +176,15 @@ export function useRecorder(initialDraftId?: string) {
       const picked = result.assets?.[0];
       if (result.canceled || !picked) return;
 
+      // Reject corrupt / zero-length picks before they enter the draft (one native probe,
+      // reused below for the duration). A thrown probe is non-fatal — fall through and let
+      // copy + getDurationMs decide.
+      const info = await isValidFile(picked.uri).catch(() => null);
+      if (info && !info.isValid) {
+        Alert.alert('Import failed', 'That file isn’t a supported video.');
+        return;
+      }
+
       let id = draftId;
       if (!id) {
         id = await createDraft();
@@ -182,8 +194,11 @@ export function useRecorder(initialDraftId?: string) {
 
       const segmentId = `${id}-${Date.now()}`;
       const originalFilename = await copyIntoSegments(picked.uri, id, segmentId);
-      const durationMs = await getDurationMs(absolutize(originalFilename));
-      await addSegment(id, { id: segmentId, originalFilename, durationMs });
+      const durationMs =
+        info && info.duration > 0 ? info.duration : await getDurationMs(absolutize(originalFilename));
+      const thumbRel = thumbRelPath(id, segmentId);
+      const ok = await generateThumbnailFile(absolutize(originalFilename), absolutize(thumbRel));
+      await addSegment(id, { id: segmentId, originalFilename, durationMs, thumbnail: ok ? thumbRel : null });
     } catch (e) {
       Alert.alert('Import failed', e instanceof Error ? e.message : 'Could not import the video.');
     }

--- a/src/hooks/use-thumbnail.ts
+++ b/src/hooks/use-thumbnail.ts
@@ -4,23 +4,28 @@ import { useEffect, useState } from 'react';
 import { absolutize } from '@/utils/file-store';
 import { generateThumbnail } from '@/utils/video';
 
+type Thumb = { uri: string } | VideoThumbnail | undefined;
+
 /**
- * First-frame thumbnail for a stored clip (relative path; generation is cached per uri
- * in utils/video). `undefined` while loading or when there is no file.
+ * Cover frame for a stored clip. Prefers the persisted jpeg (`thumbRel`, written at record/edit
+ * time) rendered straight from disk — no player. Falls back to runtime first-frame extraction
+ * from `videoRelFallback` for legacy rows persisted before disk thumbnails existed (null column).
+ * `undefined` while the fallback loads or when there is nothing to show.
  */
-export function useThumbnail(relPath?: string | null): VideoThumbnail | undefined {
-  const [thumbnail, setThumbnail] = useState<VideoThumbnail>();
+export function useThumbnail(thumbRel?: string | null, videoRelFallback?: string | null): Thumb {
+  const [fallback, setFallback] = useState<VideoThumbnail>();
 
   useEffect(() => {
-    if (!relPath) return;
+    if (thumbRel || !videoRelFallback) return;
     let alive = true;
-    void generateThumbnail(absolutize(relPath)).then((t) => {
-      if (alive) setThumbnail(t);
+    void generateThumbnail(absolutize(videoRelFallback)).then((t) => {
+      if (alive) setFallback(t);
     });
     return () => {
       alive = false;
     };
-  }, [relPath]);
+  }, [thumbRel, videoRelFallback]);
 
-  return relPath ? thumbnail : undefined;
+  if (thumbRel) return { uri: absolutize(thumbRel) };
+  return videoRelFallback ? fallback : undefined;
 }

--- a/src/utils/file-store.ts
+++ b/src/utils/file-store.ts
@@ -15,6 +15,20 @@ export function editedSegmentRelPath(draftId: string, segmentId: string): string
   return `drafts/${draftId}/segments/${segmentId}.edited.mp4`;
 }
 
+/** The pristine clip's persisted jpeg thumbnail (relative path). */
+export function thumbRelPath(draftId: string, segmentId: string): string {
+  return `drafts/${draftId}/segments/${segmentId}.thumb.jpg`;
+}
+
+/**
+ * The edited clip's persisted jpeg thumbnail (relative path). A *distinct* path from the
+ * original's so the rendered URI changes when the cover changes — otherwise expo-image would
+ * serve the stale pre-edit frame from its cache for an identical URI.
+ */
+export function editedThumbRelPath(draftId: string, segmentId: string): string {
+  return `drafts/${draftId}/segments/${segmentId}.edited.thumb.jpg`;
+}
+
 export function absolutize(relPath: string): string {
   return new File(Paths.document, ...relPath.split('/')).uri;
 }

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -1,6 +1,11 @@
+import { File } from 'expo-file-system';
 import { createVideoPlayer, VideoThumbnail } from 'expo-video';
+import { getFrameAt, isValidFile } from 'react-native-video-trim';
 
 type Player = ReturnType<typeof createVideoPlayer>;
+
+// getFrameAt / the camera return bare fs paths; expo's File wants a file:// URI.
+const toFileUri = (path: string) => (path.startsWith('/') ? `file://${path}` : path);
 
 /** Resolves once the player is ready to read metadata / frames (or errors / times out). */
 function whenReady(player: Player): Promise<void> {
@@ -18,8 +23,35 @@ function whenReady(player: Player): Promise<void> {
   });
 }
 
-// VideoThumbnail is a native SharedRef with no file URI, so we derive first frames at
-// runtime rather than persisting them. Cached by uri to avoid regenerating on re-render.
+/**
+ * Extract the first frame of a clip as a jpeg via RNVT's native `getFrameAt` and move it to
+ * `destAbsUri` (its persisted home in the draft dir). Returns false on failure, leaving the
+ * caller to store a null thumbnail (the runtime `generateThumbnail` fallback then covers it).
+ */
+export async function generateThumbnailFile(
+  videoAbsUri: string,
+  destAbsUri: string,
+): Promise<boolean> {
+  try {
+    const { outputPath } = await getFrameAt(videoAbsUri, {
+      time: 0,
+      format: 'jpeg',
+      quality: 80,
+      maxWidth: 192,
+      maxHeight: 256,
+    });
+    const dest = new File(destAbsUri);
+    if (dest.exists) dest.delete();
+    await new File(toFileUri(outputPath)).move(dest);
+    return true;
+  } catch (e) {
+    console.warn('[video] thumbnail file failed for', videoAbsUri, e);
+    return false;
+  }
+}
+
+// VideoThumbnail is a native SharedRef with no file URI. Legacy fallback for rows persisted
+// before disk thumbnails existed (null `thumbnail` column). Cached by uri.
 const thumbnailCache = new Map<string, VideoThumbnail>();
 
 /** First-frame thumbnail for a clip, cached by uri. Undefined on failure. */
@@ -43,17 +75,16 @@ export async function generateThumbnail(uri: string): Promise<VideoThumbnail | u
   }
 }
 
-/** Native clip duration in ms — trust the decoded asset, not a JS timer. 0 on failure. */
+/**
+ * Native clip duration in ms via RNVT's `isValidFile` probe — no player to spin up. 0 on an
+ * invalid/unreadable file (the clip is then skipped on playback and merge).
+ */
 export async function getDurationMs(uri: string): Promise<number> {
-  let player: Player | undefined;
   try {
-    player = createVideoPlayer(uri);
-    await whenReady(player);
-    return Math.round(player.duration * 1000);
+    const info = await isValidFile(uri);
+    return info.isValid && info.duration > 0 ? info.duration : 0;
   } catch (e) {
     console.warn('[video] duration failed for', uri, e);
     return 0;
-  } finally {
-    player?.release();
   }
 }


### PR DESCRIPTION
Adopts four previously-unused react-native-video-trim capabilities. No new deps; uses the existing rnvt submodule.

## Changes

### Thumbnails — `getFrameAt`
Persist a jpeg cover per segment to disk (`getFrameAt` → moved into the draft dir, path stored in the existing `segments.thumbnail` column), replacing the per-clip `expo-video` player that spun up on every render and couldn't persist its `SharedRef`. Covers now render from disk and survive relaunch.
- Generated at record / import / seed time and refreshed on `setEdited` / reverted on `resetEdit`.
- Edited thumbs use a **distinct** path from originals so the rendered URI changes when the cover changes (otherwise expo-image serves the stale pre-edit frame).
- Legacy runtime fallback kept for rows persisted before this (null `thumbnail`).

### Durations — `isValidFile`
`getDurationMs` now uses the native `isValidFile` probe instead of a player (signature unchanged → all callers untouched). Import path also rejects corrupt / unsupported picks before they enter a draft.

### Export — `saveToDocuments`
New "Save to Files" action on the export screen alongside Share / Save to Photos (new `use-save-to-documents` hook; no photo-library permission needed).

### Startup — `cleanFiles`
Fire-and-forget sweep of rnvt's leaked output cache once after migrations succeed (safe: editor outputs are already moved into draft dirs, merge outputs are produced on-demand at export).

### Home cover styling
Square-corner draft cover with a subtle opposite-tone shadow (black in light, white in dark) + hairline ring so it pops in both themes.

## Verification
`tsc --noEmit` and ESLint pass. Runtime behavior (native rnvt calls) verified manually on a dev build: thumbnails persist across relaunch, edited-clip thumbs update, bad imports rejected, Save to Files works, and the startup sweep logs a non-zero cleaned count without touching draft files.