### PR TITLE
feat: reliable recorder close, hide Next while reordering, square video previews

### DIFF
--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -1,6 +1,6 @@
 import { useEvent } from 'expo';
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { useState } from 'react';
@@ -53,7 +53,7 @@ export default function ExportScreen() {
   return (
     <ThemedView style={styles.fill}>
       <View style={[styles.header, { paddingTop: insets.top + Spacing.two }]}>
-        <CloseButton onPress={() => router.back()} />
+        <CloseButton />
       </View>
 
       <View style={styles.center}>
@@ -218,7 +218,6 @@ const styles = StyleSheet.create({
   previewCard: {
     width: '70%',
     aspectRatio: 9 / 16,
-    borderRadius: Spacing.three,
     overflow: 'hidden',
     backgroundColor: '#000',
     borderWidth: StyleSheet.hairlineWidth,

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -140,7 +140,7 @@ export default function RecorderScreen() {
             styles.topBar,
             { paddingTop: insets.top + Spacing.two, paddingHorizontal: Spacing.three },
           ]}>
-          <CloseButton onPress={() => router.back()} />
+          <CloseButton />
           <Text style={styles.timerText}>{formatDurationPadded(totalMs)}</Text>
           {/* Mirrors the CloseButton's width so the timer stays optically centered. */}
           <View style={styles.topBarSpacer} />

--- a/src/features/recorder/close-button.tsx
+++ b/src/features/recorder/close-button.tsx
@@ -1,6 +1,7 @@
-import { router } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
 import { Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+
+import { closeToHome } from '@/utils/navigation';
 
 export function CloseButton({
   onPress,
@@ -11,7 +12,7 @@ export function CloseButton({
 }) {
   return (
     <Pressable
-      onPress={onPress ?? (() => router.back())}
+      onPress={onPress ?? closeToHome}
       hitSlop={8}
       accessibilityRole="button"
       accessibilityLabel="Close"

--- a/src/features/recorder/preview-modal.tsx
+++ b/src/features/recorder/preview-modal.tsx
@@ -93,7 +93,6 @@ const styles = StyleSheet.create({
   card: {
     width: '72%',
     aspectRatio: 9 / 16,
-    borderRadius: Spacing.three,
     overflow: 'hidden',
     backgroundColor: '#000',
     borderWidth: StyleSheet.hairlineWidth,

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable react-hooks/immutability */
 import { Image } from 'expo-image';
 import { SymbolView } from 'expo-symbols';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   interpolateColor,
@@ -84,6 +84,11 @@ function Bar({
   // (this and Sortable's autoScroll) don't fight when reordering while previewing.
   const dragScroll = useSharedValue(false);
 
+  // React-side mirror of the drag state, used to hide the → (Next) button while reordering so
+  // the flex:1 viewport reclaims its slot (button + gap) for more room. Item slot positions are
+  // index-based (i * STEP), independent of viewport width, so widening mid-drag is reorder-safe.
+  const [dragActive, setDragActive] = useState(false);
+
   // Scroll the newest clip into view when one is added (record mode only — while previewing the
   // playhead owns scrolling). A length increase is unique to add; reorder/delete never grow it.
   // The actual scroll happens in onContentSizeChange so the new thumb has laid out first.
@@ -161,6 +166,7 @@ function Bar({
               over.value = 0;
               vis.value = withTiming(1, { duration: 150 });
               dragScroll.value = true; // pause playhead-follow so it can't fight the grid autoscroll
+              setDragActive(true); // hide → so the viewport gets its space
               measureTrash();
               onDragActiveChange?.(true);
             }}
@@ -186,6 +192,7 @@ function Bar({
               overTrash.current = false;
               draggedKey.current = null;
               dragScroll.value = false;
+              setDragActive(false); // restore → now the drag is done
               onDragActiveChange?.(false);
             }}
             renderItem={({ item }) => (
@@ -212,7 +219,9 @@ function Bar({
         )}
       </View>
 
-      {onNext && (
+      {/* Hidden while reordering — its slot (button + gap) is handed to the flex:1 viewport for
+          more room; restored on drag end. */}
+      {onNext && !dragActive && (
         <Pressable
           onPress={onNext}
           accessibilityRole="button"

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,14 @@
+import { router } from 'expo-router';
+
+/**
+ * Close a presented screen (recorder / export) reliably.
+ *
+ * `router.back()` dispatches GO_BACK, which throws "The action 'GO_BACK' was not
+ * handled by any navigator" when the screen is the ROOT of the stack — e.g. a cold
+ * start or dev fast-refresh that lands straight on /recorder, with no /index beneath
+ * it to pop to. Guard on canGoBack() and otherwise reset to home so the X always works.
+ */
+export function closeToHome() {
+  if (router.canGoBack()) router.back();
+  else router.replace('/');
+}


### PR DESCRIPTION
- Fix `GO_BACK was not handled` when closing recorder/export: `closeToHome()` pops if possible, else resets to `/`. Now the shared `CloseButton` default.
- Hide the Next (→) button during a reorder drag so the thumbnail viewport reclaims its space; restored on drop. All scroll behaviors verified.
- Remove rounded corners from the recorder preview and final export previews.