### PR TITLE
Refine on-device speech model catalog + fix VAD download

### DIFF
--- a/src/features/transcription/model-switcher-modal.tsx
+++ b/src/features/transcription/model-switcher-modal.tsx
@@ -143,7 +143,12 @@ export function ModelSwitcherModal({
                     active && { borderColor: theme.accent },
                   ]}>
                   <View style={styles.rowText}>
-                    <ThemedText type="smallBold">{m.label}</ThemedText>
+                    <View style={styles.rowTitle}>
+                      <ThemedText type="smallBold">{m.label}</ThemedText>
+                      <ThemedText type="small" themeColor="textSecondary">
+                        {m.name}
+                      </ThemedText>
+                    </View>
                     <ThemedText type="small" themeColor="textSecondary">
                       {m.note} · {sizeMb(m.approxBytes)}
                     </ThemedText>
@@ -208,6 +213,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
   },
   rowText: { flex: 1, gap: 2 },
+  rowTitle: { flexDirection: 'row', alignItems: 'baseline', gap: Spacing.two, flexWrap: 'wrap' },
   delete: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/features/transcription/models.test.ts
+++ b/src/features/transcription/models.test.ts
@@ -13,7 +13,7 @@ describe('model catalog', () => {
   it('builds the Hugging Face GGML url from the filename', () => {
     const m = getModel('base.en')!;
     expect(modelUrl(m)).toBe(
-      'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin',
+      'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en-q5_1.bin',
     );
   });
 
@@ -24,6 +24,8 @@ describe('model catalog', () => {
       expect(m.lang).toBe(expected);
     }
     expect(getModel('large-v3-turbo-q5_0')!.lang).toBe('auto');
+    // The small multilingual model is the affordable non-English option — it must detect language.
+    expect(getModel('small-q5_1')!.lang).toBe('auto');
   });
 
   it('only the large model crosses the confirm-before-download threshold', () => {

--- a/src/features/transcription/models.ts
+++ b/src/features/transcription/models.ts
@@ -7,6 +7,11 @@ const BASE_URL = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/';
 export type WhisperModel = {
   id: string;
   label: string;
+  /**
+   * The underlying Whisper checkpoint name (e.g. `tiny.en`, `large-v3-turbo`), shown muted in the
+   * picker so it's transparent which actual model — and quantization — the friendly label maps to.
+   */
+  name: string;
   filename: string;
   /** Approximate on-disk size, for the size label and a download-completeness floor. */
   approxBytes: number;
@@ -24,33 +29,46 @@ export const MODELS: WhisperModel[] = [
   {
     id: 'tiny.en',
     label: 'Tiny (English)',
-    filename: 'ggml-tiny.en.bin',
-    approxBytes: 78 * 1024 * 1024,
-    note: 'Fastest · lowest accuracy',
+    name: 'tiny.en · q5_1',
+    filename: 'ggml-tiny.en-q5_1.bin',
+    approxBytes: 31 * 1024 * 1024,
+    note: 'Fastest · English only',
     lang: 'en',
   },
   {
     id: 'base.en',
     label: 'Base (English)',
-    filename: 'ggml-base.en.bin',
-    approxBytes: 148 * 1024 * 1024,
-    note: 'Balanced',
+    name: 'base.en · q5_1',
+    filename: 'ggml-base.en-q5_1.bin',
+    approxBytes: 57 * 1024 * 1024,
+    note: 'Balanced · English only',
     lang: 'en',
   },
   {
     id: 'small.en-q5_1',
     label: 'Small (English)',
+    name: 'small.en · q5_1',
     filename: 'ggml-small.en-q5_1.bin',
     approxBytes: 190 * 1024 * 1024,
-    note: 'Better accuracy · a bit slower',
+    note: 'Most accurate · English only',
     lang: 'en',
+  },
+  {
+    id: 'small-q5_1',
+    label: 'Small (Multilingual)',
+    name: 'small · q5_1',
+    filename: 'ggml-small-q5_1.bin',
+    approxBytes: 181 * 1024 * 1024,
+    note: 'Any language · balanced',
+    lang: 'auto',
   },
   {
     id: 'large-v3-turbo-q5_0',
     label: 'Large Turbo',
+    name: 'large-v3-turbo · q5_0',
     filename: 'ggml-large-v3-turbo-q5_0.bin',
     approxBytes: 574 * 1024 * 1024,
-    note: 'Best · multilingual · large download',
+    note: 'Any language · best quality',
     lang: 'auto',
   },
 ];

--- a/src/features/transcription/vad.ts
+++ b/src/features/transcription/vad.ts
@@ -10,15 +10,16 @@ import { initWhisperVad, type WhisperVadContext } from 'whisper.rn';
  * expose the whisper.cpp no-speech / logprob / entropy thresholds that would suppress this, so we
  * run a Silero VAD pass first and skip Whisper entirely on clips with no detected speech.
  *
- * The VAD model is a tiny (~1.5 MB) Silero GGML build from the same whisper.cpp repo as the speech
- * models. It lives under `vad/` — NOT `models/` — so the single-speech-model-on-disk cleanup
+ * The VAD model is a tiny (~865 KB) Silero GGML build hosted in the `ggml-org/whisper-vad` repo
+ * (the speech models live in `ggerganov/whisper.cpp` — silero is no longer mirrored there). It
+ * lives under `vad/` — NOT `models/` — so the single-speech-model-on-disk cleanup
  * (`deleteModelsExcept`) never wipes it on a model switch.
  */
 const VAD_URL =
-  'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-silero-v5.1.2.bin';
-const VAD_FILENAME = 'ggml-silero-v5.1.2.bin';
-// Completeness floor for a partial/interrupted download (the real file is ~1.5 MB).
-const VAD_MIN_BYTES = 1024 * 1024;
+  'https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v6.2.0.bin';
+const VAD_FILENAME = 'ggml-silero-v6.2.0.bin';
+// Completeness floor for a partial/interrupted download (the real file is ~865 KB).
+const VAD_MIN_BYTES = 512 * 1024;
 
 function vadDir(): Directory {
   return new Directory(Paths.document, 'vad');


### PR DESCRIPTION
## Why

Two issues in the on-device transcription setup:

1. **VAD download was silently broken.** The silero VAD model is no longer mirrored in `ggerganov/whisper.cpp`, so the download 404'd, the speech pre-gate failed open, and hallucination suppression was effectively off (with no visible error, by design).
2. **The model catalog was inconsistent and had a coverage gap.** `tiny.en`/`base.en` shipped as full f16 weights while `small.en` was already quantized, and the only non-English option was the 574 MB Large Turbo.

## Changes

**VAD fix** (`vad.ts`)
- Point at the relocated `ggml-org/whisper-vad` repo and bump to **silero v6.2.0**.
- Lower the completeness floor to match the real ~865 KB file (the old 1 MB floor would have rejected a good download).

**Catalog** (`models.ts`, `models.test.ts`, `model-switcher-modal.tsx`)
- Quantize `tiny.en` → q5_1 (78 → **31 MB**) and `base.en` → q5_1 (148 → **57 MB**).
- Add **Small (Multilingual)** (`small-q5_1`, 181 MB, language auto-detect) to fill the gap below Large Turbo.
- Sharpen picker notes into two clear axes: English speed ladder (Fastest / Balanced / Most accurate) and any-language quality pair (balanced / best quality).
- Surface each model's underlying Whisper **checkpoint name + quantization** in the picker row.

## Notes
- `id`s are unchanged, so existing selections persist; an existing tiny/base user re-downloads the smaller quantized file once and the old `.bin` is pruned.
- All 6 model + VAD URLs verified live (HF returns 302 → CDN).
- Core ML / ANE acceleration was evaluated and **dropped**: whisper.rn ignores Core ML when `useGpu` is on, so it would mean trading whole-pipeline Metal + Flash Attention for an ANE encoder + CPU decoder plus a native unzip dep — an A/B tradeoff that risks a regression.

## Verification
- `tsc --noEmit` clean; `jest models.test.ts` 4/4.
- **Still needs an on-device/simulator smoke test** for the download + inference path (unit tests cover catalog data only): confirm each model downloads, captions generate, and the multilingual model detects a non-English language.