### PR TITLE
feat: persist recorder camera preferences across launches

### DIFF
--- a/docs/pulse-feature-gaps.md
+++ b/docs/pulse-feature-gaps.md
@@ -50,16 +50,16 @@
 
 ---
 
-### A4. Persisted camera preferences
+### A4. Persisted camera preferences — ✅ RESOLVED (2026-06-14)
 
-**What:** Remember the user's camera choices across launches. `pulse-new` resets **facing** (→ back) and **stabilization** (→ off) on every cold start.
+**What:** Remember the user's camera choices across launches.
 
 **How the original did it** — small AsyncStorage-backed hooks:
 - [tmp/pulse/hooks/useCameraFacing.ts](../tmp/pulse/hooks/useCameraFacing.ts) — persists `cameraFacing` `"front"|"back"`.
 - [tmp/pulse/hooks/useVideoStabilization.ts](../tmp/pulse/hooks/useVideoStabilization.ts) — persists `videoStabilizationMode` `"on"|"off"`.
 - (Also `deleteDraftAfterUpload` via [useDeleteDraftPreference.ts](../tmp/pulse/hooks/useDeleteDraftPreference.ts) — upload-coupled, out of scope here.)
 
-**For `pulse-new`:** trivial — persist the recorder's `facing` / stabilization-mode / `selectedLens` state to the `settings` table on change, hydrate on mount. Low effort, real UX win.
+**Resolved in `pulse-new`:** **facing**, **stabilization**, and **mic/mute** now persist app-wide via the `settings` key/value table. `getRecorderPrefs`/`setSetting` in [src/db/settings.ts](../src/db/settings.ts); the recorder hydrates on mount and writes each pref on change in [src/features/recorder/use-recorder.ts](../src/features/recorder/use-recorder.ts), holding the camera render until prefs load ([src/app/recorder.tsx](../src/app/recorder.tsx)) so there's no back→front flash. `torch` stays session-only and `lens` stays per-facing (unpersisted) by design.
 
 ---
 
@@ -92,7 +92,7 @@
 | `.pulse` draft export/import | A — gap | `utils/draftTransfer.ts` + drafts list | ✗ |
 | Audio focus (pause bg audio) | A — gap | `modules/audio-focus/*` + `useAudioSession` | ✗ (only `mute`) |
 | Onboarding tour | A — gap | `app/onboarding.tsx` + `useFirstTimeOpen` | ✗ (planned last) |
-| Persisted camera facing/stabilization | A — gap | `useCameraFacing` / `useVideoStabilization` | ✗ (resets) |
+| Persisted camera facing/stabilization/mute | ✅ done | `useCameraFacing` / `useVideoStabilization` | ✅ `settings` table + `use-recorder` hydrate/persist |
 | Duration presets + max-length cap | B — dropped | `TimeSelectorButton` + `RecordingProgressBar` | ✗ (no cap, by choice) |
 | Undo / redo segments | B — dropped | `Undo/RedoSegmentButton` + `useDraftManager` | ✗ (by choice) |
 

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -38,6 +38,7 @@ export default function RecorderScreen() {
     isRecording,
     recordStartedAt,
     cameraReady,
+    prefsReady,
     facing,
     torch,
     stabilization,
@@ -126,6 +127,8 @@ export default function RecorderScreen() {
   if (!permissions.granted) {
     return <PermissionGate blocked={permissions.blocked} onRequest={permissions.request} />;
   }
+  // Hold the camera until persisted prefs load, so the first frame uses the saved facing.
+  if (!prefsReady) return <ThemedView style={styles.fill} />;
 
   return (
     <View style={styles.fill}>

--- a/src/db/settings.ts
+++ b/src/db/settings.ts
@@ -1,9 +1,19 @@
 import { eq } from 'drizzle-orm';
+import type { CameraType } from 'expo-camera';
+
+// Type-only import — erased at runtime, so this does NOT create a circular dependency
+// with use-recorder.ts (which imports the value helpers below).
+import type { StabilizationMode } from '@/features/recorder/use-recorder';
 
 import { db } from './client';
 import { settings } from './schema';
 
 const SELECTED_MODEL_KEY = 'transcription.model';
+
+/** Persisted recorder preferences (camera-wide, not per-draft). */
+export const CAMERA_FACING_KEY = 'camera.facing';
+export const CAMERA_STABILIZATION_KEY = 'camera.stabilization';
+export const CAMERA_MUTED_KEY = 'camera.muted';
 
 /** Live-queryable: the selected transcription model id (a single settings row). */
 export const selectedModelQuery = db
@@ -21,4 +31,47 @@ export async function setSelectedModel(id: string | null): Promise<void> {
     .insert(settings)
     .values({ key: SELECTED_MODEL_KEY, value: id })
     .onConflictDoUpdate({ target: settings.key, set: { value: id } });
+}
+
+/** One-shot read of a single settings value (`null` if unset). */
+export async function getSetting(key: string): Promise<string | null> {
+  const rows = await db
+    .select({ value: settings.value })
+    .from(settings)
+    .where(eq(settings.key, key));
+  return rows[0]?.value ?? null;
+}
+
+/** Upsert a single settings value. */
+export async function setSetting(key: string, value: string): Promise<void> {
+  await db
+    .insert(settings)
+    .values({ key, value })
+    .onConflictDoUpdate({ target: settings.key, set: { value } });
+}
+
+export type RecorderPrefs = {
+  facing: CameraType;
+  stabilization: StabilizationMode;
+  muted: boolean;
+};
+
+// Local validation list (kept in sync with STABILIZATION_MODES in use-recorder.ts) so we can
+// reject corrupt/legacy stored values without a runtime import from the recorder module.
+const STABILIZATION_VALUES: readonly StabilizationMode[] = ['off', 'standard', 'cinematic', 'auto'];
+
+/** Read the persisted recorder preferences, falling back to defaults for missing/unexpected values. */
+export async function getRecorderPrefs(): Promise<RecorderPrefs> {
+  const [facing, stabilization, muted] = await Promise.all([
+    getSetting(CAMERA_FACING_KEY),
+    getSetting(CAMERA_STABILIZATION_KEY),
+    getSetting(CAMERA_MUTED_KEY),
+  ]);
+  return {
+    facing: facing === 'front' ? 'front' : 'back',
+    stabilization: STABILIZATION_VALUES.includes(stabilization as StabilizationMode)
+      ? (stabilization as StabilizationMode)
+      : 'off',
+    muted: muted === 'true',
+  };
 }

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -14,6 +14,13 @@ import {
   reorderSegments,
   segmentsForDraft,
 } from '@/db/drafts';
+import {
+  CAMERA_FACING_KEY,
+  CAMERA_MUTED_KEY,
+  CAMERA_STABILIZATION_KEY,
+  getRecorderPrefs,
+  setSetting,
+} from '@/db/settings';
 import { absolutize, copyIntoSegments, persistRecording, thumbRelPath } from '@/utils/file-store';
 import { generateThumbnailFile, getDurationMs } from '@/utils/video';
 
@@ -39,6 +46,9 @@ export function useRecorder(initialDraftId?: string) {
   // undefined = the camera's default wide lens; physical lens names come from the device.
   const [lens, setLens] = useState<string | undefined>(undefined);
   const [availableLenses, setAvailableLenses] = useState<string[]>([]);
+  // False until persisted prefs (facing/stabilization/mute) are loaded — the screen holds the
+  // camera render until then so the first frame uses the saved facing (no back→front flash).
+  const [prefsReady, setPrefsReady] = useState(false);
 
   const { data: segments } = useLiveQuery(segmentsForDraft(draftId ?? ''), [draftId]);
 
@@ -87,6 +97,34 @@ export function useRecorder(initialDraftId?: string) {
     },
     [],
   );
+
+  // Hydrate persisted camera prefs once on mount, then mark ready so the camera can render.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const prefs = await getRecorderPrefs();
+      if (cancelled) return;
+      setFacing(prefs.facing);
+      setStabilization(prefs.stabilization);
+      setMuted(prefs.muted);
+      setPrefsReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist each pref on change. Gated on prefsReady so we never write a default over a stored
+  // value before hydration completes (the one write-back of the just-loaded value is harmless).
+  useEffect(() => {
+    if (prefsReady) void setSetting(CAMERA_FACING_KEY, facing);
+  }, [facing, prefsReady]);
+  useEffect(() => {
+    if (prefsReady) void setSetting(CAMERA_STABILIZATION_KEY, stabilization);
+  }, [stabilization, prefsReady]);
+  useEffect(() => {
+    if (prefsReady) void setSetting(CAMERA_MUTED_KEY, String(muted));
+  }, [muted, prefsReady]);
 
   // Physical lenses differ per facing (front is usually just the one), so re-query on flip.
   useEffect(() => {
@@ -137,7 +175,12 @@ export function useRecorder(initialDraftId?: string) {
       const durationMs = await getDurationMs(absolutize(originalFilename));
       const thumbRel = thumbRelPath(id, segmentId);
       const ok = await generateThumbnailFile(absolutize(originalFilename), absolutize(thumbRel));
-      await addSegment(id, { id: segmentId, originalFilename, durationMs, thumbnail: ok ? thumbRel : null });
+      await addSegment(id, {
+        id: segmentId,
+        originalFilename,
+        durationMs,
+        thumbnail: ok ? thumbRel : null,
+      });
     } catch {
       // interrupted mid-record — drop the clip
     } finally {
@@ -195,10 +238,17 @@ export function useRecorder(initialDraftId?: string) {
       const segmentId = `${id}-${Date.now()}`;
       const originalFilename = await copyIntoSegments(picked.uri, id, segmentId);
       const durationMs =
-        info && info.duration > 0 ? info.duration : await getDurationMs(absolutize(originalFilename));
+        info && info.duration > 0
+          ? info.duration
+          : await getDurationMs(absolutize(originalFilename));
       const thumbRel = thumbRelPath(id, segmentId);
       const ok = await generateThumbnailFile(absolutize(originalFilename), absolutize(thumbRel));
-      await addSegment(id, { id: segmentId, originalFilename, durationMs, thumbnail: ok ? thumbRel : null });
+      await addSegment(id, {
+        id: segmentId,
+        originalFilename,
+        durationMs,
+        thumbnail: ok ? thumbRel : null,
+      });
     } catch (e) {
       Alert.alert('Import failed', e instanceof Error ? e.message : 'Could not import the video.');
     }
@@ -255,6 +305,7 @@ export function useRecorder(initialDraftId?: string) {
     isRecording,
     recordStartedAt,
     cameraReady,
+    prefsReady,
     facing,
     torch,
     stabilization,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
-  "exclude": ["node_modules", "modules"]
+  "exclude": ["node_modules", "modules", "tmp"]
 }


### PR DESCRIPTION
Facing, stabilization mode, and mic/mute now survive cold starts via the settings key/value table (getRecorderPrefs/setSetting). The recorder hydrates on mount and writes each pref on change, holding the camera render until prefs load so the first frame uses the saved facing (no back->front flash).

- src/db/settings.ts: generic getSetting/setSetting + getRecorderPrefs
- src/features/recorder/use-recorder.ts: hydrate + persist effects, prefsReady
- src/app/recorder.tsx: gate camera render on prefsReady
- tsconfig.json: exclude tmp/ reference clone from typecheck
- docs/pulse-feature-gaps.md: mark A4 resolved