### PR TITLE
feat: pause background audio while recording (audio focus)

### DIFF
--- a/app.json
+++ b/app.json
@@ -61,13 +61,22 @@
         {
           "photosPermission": "Allow Pulse to access your photos to import videos into your drafts.",
           "savePhotosPermission": "Allow Pulse to save exported videos to your photo library.",
-          "granularPermissions": ["photo", "video"]
+          "granularPermissions": [
+            "photo",
+            "video"
+          ]
         }
       ],
       [
         "expo-image-picker",
         {
           "photosPermission": "Allow Pulse to access your photos to import videos into your drafts."
+        }
+      ],
+      [
+        "expo-audio",
+        {
+          "microphonePermission": false
         }
       ]
     ],

--- a/docs/pulse-feature-gaps.md
+++ b/docs/pulse-feature-gaps.md
@@ -34,9 +34,17 @@
 
 ---
 
-### A2. Audio focus — pause background audio while recording
+### A2. Audio focus — pause background audio while recording — ✅ RESOLVED on iOS (2026-06-15); Android pending validation
 
-**What:** When recording starts, pause whatever the user is playing (Spotify / YouTube / podcast) instead of mixing it in; restore on stop. Current `pulse-new` only sets `mute` on `CameraView` (no background-audio ducking).
+**What:** When the recorder is open with a live mic, pause whatever the user is playing (Spotify / YouTube / podcast) instead of mixing it in; restore on leave. Previously `pulse-new` only set `mute` on `CameraView` (no background-audio ducking).
+
+**Resolved in `pulse-new` — pure-JS, no native module.** The original needed a custom Swift/Kotlin module because its older `expo-audio` couldn't request exclusive focus cross-platform. **SDK 56 closes that gap:** `setAudioModeAsync`'s unified `interruptionMode: 'doNotMix'` requests focus directly (the deprecated `interruptionModeAndroid` is gone, so the [#34025](https://github.com/expo/expo/issues/34025) "both keys crash Android" trap can't be hit). iOS checklist 1–5 confirmed on-device — including the resume the original needed `.notifyOthersOnDeactivation` for.
+- **Hook** — [src/features/recorder/use-audio-focus.ts](../src/features/recorder/use-audio-focus.ts): idempotent `acquire()` / `release()` wrapping `setAudioModeAsync({ interruptionMode: 'doNotMix' })` + `setIsAudioActiveAsync(...)`; both swallow errors so an audio-session failure never breaks recording.
+- **Wiring** — [src/app/recorder.tsx](../src/app/recorder.tsx): acquires when `focused && !muted && prefsReady`, releases on blur/mute/unmount. Tied to **screen focus, not per segment**, so the AVAudioSession isn't toggled mid-draft (that toggling caused the original's "mic dies on segment 2" bug — re-validated, no recurrence). Gated on `!muted` because a muted clip has no audio track to protect.
+- **Config** — `expo-audio` added with `microphonePermission: false` in [app.json](../app.json) so it doesn't override the camera plugin's mic prompt; `RECORD_AUDIO` was already declared. Native module → required a rebuild + `pod install` (done).
+- **Android still pending:** the original documented `setIsAudioActiveAsync` as a no-op on Android in an older version; SDK 56 docs claim `interruptionMode` now works there, but it's **untested on a real Android device**. If it fails, the fallback below is one step away.
+
+**How the original did it** — custom native module [tmp/pulse/modules/audio-focus/](../tmp/pulse/modules/audio-focus/), driven by [tmp/pulse/hooks/useAudioSession.ts](../tmp/pulse/hooks/useAudioSession.ts):
 
 **How the original did it** — custom native module [tmp/pulse/modules/audio-focus/](../tmp/pulse/modules/audio-focus/), driven by [tmp/pulse/hooks/useAudioSession.ts](../tmp/pulse/hooks/useAudioSession.ts):
 - TS surface: `requestAudioFocus()` / `abandonAudioFocus()`.
@@ -44,7 +52,7 @@
 - **Android** ([AudioFocusModule.kt](../tmp/pulse/modules/audio-focus/android/src/main/java/expo/modules/audiofocus/AudioFocusModule.kt)): `AudioManager` `AUDIOFOCUS_GAIN_TRANSIENT` (O+ `AudioFocusRequest`, legacy stream API below) so other apps pause.
 - Tied into the recorder's focus/blur lifecycle (orig §4.7) — the same dance that fixed the "mic dies on segment 2" iOS bug.
 
-**For `pulse-new`:** deferred per the original plan, which suggested trying an **`expo-audio` audio-mode** (`shouldDuckAndroid` / `interruptionMode`) before re-porting a native module. Worth checking whether expo-audio alone gets it on SDK 56; fall back to the tiny native module if not. **Re-validate the segment-2 mic bug regardless** — it's the original's most fragile behavior.
+**Fallback (only if Android validation fails):** port this module's two functions (`requestAudioFocus` / `abandonAudioFocus`) and call them from `use-audio-focus.ts` alongside `setAudioModeAsync`, exactly as the original's `useAudioSession.ts` did.
 
 ---
 
@@ -100,7 +108,7 @@
 | Feature | Bucket | Original source | `pulse-new` |
 | --- | --- | --- | --- |
 | `.pulse` draft export/import | ✅ done | `utils/draftTransfer.ts` + drafts list | ✅ ZIP bundle (`features/draft-transfer/*`) + multi-select |
-| Audio focus (pause bg audio) | A — gap | `modules/audio-focus/*` + `useAudioSession` | ✗ (only `mute`) |
+| Audio focus (pause bg audio) | ✅ iOS (Android pending) | `modules/audio-focus/*` + `useAudioSession` | ✅ pure-JS `expo-audio` `doNotMix` (`use-audio-focus`) — no native module |
 | Onboarding tour | A — gap | `app/onboarding.tsx` + `useFirstTimeOpen` | ✗ (planned last) |
 | Persisted camera facing/stabilization/mute | ✅ done | `useCameraFacing` / `useVideoStabilization` | ✅ `settings` table + `use-recorder` hydrate/persist |
 | Duration presets + max-length cap | B — dropped | `TimeSelectorButton` + `RecordingProgressBar` | ✗ (no cap, by choice) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/ui": "~56.0.16",
         "drizzle-orm": "^0.45.2",
         "expo": "~56.0.8",
+        "expo-audio": "~56.0.12",
         "expo-camera": "~56.0.7",
         "expo-constants": "~56.0.16",
         "expo-device": "~56.0.4",
@@ -13534,6 +13535,18 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "56.0.12",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-56.0.12.tgz",
+      "integrity": "sha512-ne2UIO/HsQoBL9e+tGs5N9Sf3NyW5sJMm4sDkexbSJRc2IchLDG+9Msu/+l5N4RlZ8SiF42wRyWsh/Usg+SwOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "expo-asset": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@expo/ui": "~56.0.16",
     "drizzle-orm": "^0.45.2",
     "expo": "~56.0.8",
+    "expo-audio": "~56.0.12",
     "expo-camera": "~56.0.7",
     "expo-constants": "~56.0.16",
     "expo-device": "~56.0.4",

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -16,6 +16,7 @@ import { PreviewModal } from '@/features/recorder/preview-modal';
 import { RecordButton } from '@/features/recorder/record-button';
 import { SegmentBar } from '@/features/recorder/segment-bar';
 import { RECORD_BUTTON_SIZE } from '@/features/recorder/track-metrics';
+import { useAudioFocus } from '@/features/recorder/use-audio-focus';
 import { usePreview } from '@/features/recorder/use-preview';
 import { useRecorder } from '@/features/recorder/use-recorder';
 import { useRecorderGestures } from '@/features/recorder/use-recorder-gestures';
@@ -103,6 +104,17 @@ export default function RecorderScreen() {
       return () => setFocused(false);
     }, []),
   );
+
+  // Audio focus: while the recorder is on screen capturing with a live mic, pause other apps'
+  // audio (Spotify / podcasts) rather than mixing it in; restore on leave or mute. Gated on the
+  // mic being live — a muted clip has no audio track, so there's nothing to seize focus for.
+  // Tied to screen focus (not per segment) to avoid toggling the session mid-draft.
+  const audioFocus = useAudioFocus();
+  useEffect(() => {
+    if (focused && !muted && prefsReady) void audioFocus.acquire();
+    else void audioFocus.release();
+  }, [focused, muted, prefsReady, audioFocus]);
+  useEffect(() => () => void audioFocus.release(), [audioFocus]);
 
   const { zoom, holdActive, buttonGesture, pinchGesture, resetZoom } = useRecorderGestures({
     onToggle: toggleRecording,

--- a/src/features/recorder/use-audio-focus.ts
+++ b/src/features/recorder/use-audio-focus.ts
@@ -1,0 +1,57 @@
+import { setAudioModeAsync, setIsAudioActiveAsync } from 'expo-audio';
+import { useCallback, useRef } from 'react';
+
+/**
+ * Audio focus for recording: while the recorder is on screen with the mic live, claim
+ * exclusive audio focus so other apps (Spotify / YouTube / podcasts) PAUSE instead of mixing
+ * into the capture; hand it back on leave so they resume.
+ *
+ * SDK 56's unified `interruptionMode: 'doNotMix'` is meant to request focus on both platforms
+ * (the deprecated per-platform `interruptionModeAndroid` is gone, so the old
+ * https://github.com/expo/expo/issues/34025 "both keys crash Android" trap can't be hit here).
+ * Two behaviours the original Pulse found broken in an older expo-audio still need on-device
+ * confirmation — if either fails we fall back to a tiny native module (`requestAudioFocus` /
+ * `abandonAudioFocus`), see docs/pulse-feature-gaps.md §A2:
+ *   - Android: `setIsAudioActiveAsync` was a no-op (never called `AudioManager.requestAudioFocus`).
+ *   - iOS: resume needs `setActive(false, .notifyOthersOnDeactivation)`.
+ *
+ * Engage on screen focus / release on blur (NOT per segment) so the AVAudioSession isn't
+ * toggled mid-draft — that toggling is what caused the original's "mic dies on segment 2" bug.
+ * Callers gate `acquire` on `!muted` (a muted clip has no audio track, so seizing the user's
+ * playback would be pointless). Both calls are idempotent and never throw — an audio-session
+ * failure must not break recording.
+ */
+export function useAudioFocus() {
+  const heldRef = useRef(false);
+
+  const acquire = useCallback(async () => {
+    if (heldRef.current) return;
+    heldRef.current = true;
+    try {
+      await setAudioModeAsync({
+        allowsRecording: true,
+        playsInSilentMode: true,
+        interruptionMode: 'doNotMix',
+      });
+      await setIsAudioActiveAsync(true);
+    } catch {
+      // session unavailable — recording continues, audio just mixes
+    }
+  }, []);
+
+  const release = useCallback(async () => {
+    if (!heldRef.current) return;
+    heldRef.current = false;
+    try {
+      await setIsAudioActiveAsync(false);
+      await setAudioModeAsync({
+        allowsRecording: false,
+        interruptionMode: 'mixWithOthers',
+      });
+    } catch {
+      // best-effort restore — other apps resume on their own once focus lapses
+    }
+  }, []);
+
+  return { acquire, release };
+}


### PR DESCRIPTION
## What

When the recorder is open with a live mic, pause whatever the user is playing (Spotify / podcast / YouTube) instead of mixing it into the capture; restore on leave. Closes the **A2 audio-focus gap** vs. the original Pulse.

## How

Pure-JS via `expo-audio`'s SDK 56 unified `interruptionMode: 'doNotMix'` — **no native module**, unlike the original (which needed ~40 lines of Swift/Kotlin because its older expo-audio couldn't request focus cross-platform).

- **`use-audio-focus.ts`** — idempotent `acquire()`/`release()` over `setAudioModeAsync` + `setIsAudioActiveAsync`; errors swallowed so an audio-session failure can never break recording.
- **`recorder.tsx`** — engages on screen **focus**, releases on blur/mute/unmount. Tied to focus, *not per segment*, so the `AVAudioSession` isn't toggled mid-draft (the original's "mic dies on segment 2" bug). Gated on `!muted` — a muted clip has no audio track to protect, so the existing mute toggle doubles as the master switch.
- **`app.json`** — `expo-audio` added with `microphonePermission: false` so it doesn't override the camera plugin's mic prompt; `RECORD_AUDIO` was already declared.

## Testing

Validated **on a real iOS device** (background audio pauses on open, resumes on leave, mute gate works, no segment-2 mic regression).

⚠️ **Android pending** — the original documented `setIsAudioActiveAsync` as a no-op on Android; SDK 56 docs claim `interruptionMode` now works there, but it's untested on-device. If it fails, the fallback (port the original's `requestAudioFocus`/`abandonAudioFocus`, ~20 lines, one platform) is noted in `docs/pulse-feature-gaps.md` §A2.

> Native build required (`expo-audio` is native) — reviewers need `pod install` + a dev-client rebuild.