### PR TITLE
feat: word-level captions with subtitle editor

### DIFF
--- a/drizzle/0004_certain_prism.sql
+++ b/drizzle/0004_certain_prism.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `transcripts` ADD `edited_lines` text;--> statement-breakpoint
+ALTER TABLE `transcripts` ADD `edited_at` integer;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,301 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b7dbe636-e6f3-48b9-ac5d-cd05cd317900",
+  "prevId": "b66d4db3-d6b3-4ce1-aaf8-e1151eb03372",
+  "tables": {
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'camera'"
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_server": {
+          "name": "upload_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_token": {
+          "name": "upload_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "segments": {
+      "name": "segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_filename": {
+          "name": "edited_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_duration_ms": {
+          "name": "edited_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trim_start_ms": {
+          "name": "trim_start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trim_end_ms": {
+          "name": "trim_end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segments_project_id_projects_id_fk": {
+          "name": "segments_project_id_projects_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcripts": {
+      "name": "transcripts",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'processing'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lines": {
+          "name": "lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_lines": {
+          "name": "edited_lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_segment_id_segments_id_fk": {
+          "name": "transcripts_segment_id_segments_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781387303622,
       "tag": "0003_fair_baron_zemo",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1781543110024,
+      "tag": "0004_certain_prism",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -5,6 +5,7 @@ import m0000 from './0000_rainy_hex.sql';
 import m0001 from './0001_gifted_quentin_quire.sql';
 import m0002 from './0002_mature_mephistopheles.sql';
 import m0003 from './0003_fair_baron_zemo.sql';
+import m0004 from './0004_certain_prism.sql';
 
   export default {
     journal,
@@ -12,7 +13,8 @@ import m0003 from './0003_fair_baron_zemo.sql';
       m0000,
 m0001,
 m0002,
-m0003
+m0003,
+m0004
     }
   }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "pulse",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/roboto": "^0.4.3",
         "@expo/ui": "~56.0.16",
+        "@shopify/react-native-skia": "2.6.2",
         "drizzle-orm": "^0.45.2",
         "expo": "~56.0.8",
         "expo-audio": "~56.0.12",
@@ -45,6 +47,7 @@
         "react-native-video-trim": "file:modules/react-native-video-trim",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.8.3",
+        "subsrt-ts": "^2.1.2",
         "whisper.rn": "0.6.0"
       },
       "devDependencies": {
@@ -4444,6 +4447,12 @@
       "integrity": "sha512-IJkBtN1o8u9BW5fvSii1MyHPQ7Q0HxbWcVBvOrOzgMLpVtZw7R2w94wBTVR7kZwv3w1JNTESMmLA5Sqn1+Z36A==",
       "license": "MIT AND Apache-2.0"
     },
+    "node_modules/@expo-google-fonts/roboto": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/roboto/-/roboto-0.4.3.tgz",
+      "integrity": "sha512-kX3wmpmu06fN1yOwYWMdjYJWNUYW6xUiAGeHbvPzzSEb3A3j23JelQ3tAgwQNKgEKRq6wtMmzixy2r7y9c8dsA==",
+      "license": "MIT AND OFL-1.1"
+    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
@@ -8044,6 +8053,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shopify/react-native-skia": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@shopify/react-native-skia/-/react-native-skia-2.6.2.tgz",
+      "integrity": "sha512-NzZ3+MRedZAUhguWw9DTCpWFd09Bq+tdGWhimGfJLGckuyoWGyimTiNTmaO2DeeivHTnGdv+eXbw7j/AV3LkRQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "0.41.0",
+        "react-native-skia-android": "147.1.0",
+        "react-native-skia-apple-ios": "147.1.0",
+        "react-native-skia-apple-macos": "147.1.0",
+        "react-native-skia-apple-tvos": "147.1.0",
+        "react-reconciler": "0.31.0"
+      },
+      "bin": {
+        "install-skia": "scripts/install-libs.js",
+        "setup-skia-web": "scripts/setup-canvaskit.js"
+      },
+      "peerDependencies": {
+        "react": ">=19.0",
+        "react-native": ">=0.78",
+        "react-native-reanimated": ">=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "react-native": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -9087,6 +9128,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
@@ -10502,6 +10549,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.0.tgz",
+      "integrity": "sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -21013,6 +21069,30 @@
         "react-native": ">=0.82.0"
       }
     },
+    "node_modules/react-native-skia-android": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-android/-/react-native-skia-android-147.1.0.tgz",
+      "integrity": "sha512-pWA0M0G74AhjEop0HLCkjWJMup2HJxOmuUjfPt6kSDhYeWKVx8AEzWh0Fh19ah78zE/s4hD0Of0Tyem5shhiTg==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-ios": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-ios/-/react-native-skia-apple-ios-147.1.0.tgz",
+      "integrity": "sha512-cr4rWe4Bf0H0TTutUp5cgHt5/Felttl1bh4BAAAsgAeL2F10FAK9urX8spjUshzMwjqXD7rNOWuFzU6ZcNlGKw==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-macos": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-macos/-/react-native-skia-apple-macos-147.1.0.tgz",
+      "integrity": "sha512-Qbv0Y7LgawtRKuGk8gnGeh8nDWwNiu03LcX0mVaQzBBbxFDYvqejanA+AkO3p8gsQb+fsXRc9DAk+U8cBnzZvA==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-skia-apple-tvos": {
+      "version": "147.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-skia-apple-tvos/-/react-native-skia-apple-tvos-147.1.0.tgz",
+      "integrity": "sha512-b+4vILXHPu++t8H41PHLBVsTab2LPqwXNdzgdScyl4+Cu8Ta34aUQW3T469cB0ogAMPdu//KV00w4YVpDZoRUQ==",
+      "license": "MIT"
+    },
     "node_modules/react-native-sortables": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/react-native-sortables/-/react-native-sortables-1.9.4.tgz",
@@ -21261,6 +21341,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.31.0.tgz",
+      "integrity": "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -22539,7 +22634,6 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -23572,6 +23666,15 @@
       "resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.3.tgz",
       "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==",
       "license": "MIT"
+    },
+    "node_modules/subsrt-ts": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/subsrt-ts/-/subsrt-ts-2.1.2.tgz",
+      "integrity": "sha512-45yNlK42Z0pz4lAaNYbR5P60M2jmHl+gfAaiJxDIXsXXqoE7TkDCzl/00HgWyZXKkdIU6s8FiNtRvrlOZb+5Qg==",
+      "license": "MIT",
+      "bin": {
+        "subsrt-ts": "bin/subsrt.js"
+      }
     },
     "node_modules/sudo-prompt": {
       "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
+    "@expo-google-fonts/roboto": "^0.4.3",
     "@expo/ui": "~56.0.16",
+    "@shopify/react-native-skia": "2.6.2",
     "drizzle-orm": "^0.45.2",
     "expo": "~56.0.8",
     "expo-audio": "~56.0.12",
@@ -40,6 +42,7 @@
     "react-native-video-trim": "file:modules/react-native-video-trim",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.8.3",
+    "subsrt-ts": "^2.1.2",
     "whisper.rn": "0.6.0"
   },
   "devDependencies": {

--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -3,7 +3,7 @@ import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { useLocalSearchParams } from 'expo-router';
 import { SymbolView } from 'expo-symbols';
 import { useVideoPlayer, VideoView } from 'expo-video';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, StyleSheet, View } from 'react-native';
 import { shareAsync } from 'expo-sharing';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -19,6 +19,10 @@ import { MergeProgressRing } from '@/features/export/merge-progress-ring';
 import { useSaveToDocuments } from '@/features/export/use-save-to-documents';
 import { useSaveToPhotos } from '@/features/export/use-save-to-photos';
 import { setActiveDraft } from '@/features/transcription/active-draft';
+import { CaptionOverlay } from '@/features/transcription/caption-overlay';
+import { mergedLines } from '@/features/transcription/srt';
+import { useDraftTranscripts } from '@/features/transcription/use-draft-transcripts';
+import type { TranscriptLine } from '@/features/transcription/whisper';
 import { formatClipCount, formatDuration } from '@/utils/format';
 import { effMs } from '@/utils/segment-window';
 
@@ -38,6 +42,11 @@ export default function ExportScreen() {
   // Zero-length clips (failed native reads) can't be concatenated — drop them before merging.
   const clips = segments.filter((s) => effMs(s) > 0);
   const { state, retry } = useExport(clips);
+
+  // Captions stitched onto one draft-wide timeline (same clip order/offsets as the merge), for the
+  // preview overlay.
+  const transcripts = useDraftTranscripts(draftId ?? null);
+  const captionLines = useMemo(() => mergedLines(clips, transcripts), [clips, transcripts]);
 
   // Whether the share sheet is being presented, so we can disable the button and show a spinner.
   const [busy, setBusy] = useState(false);
@@ -78,7 +87,7 @@ export default function ExportScreen() {
 
         {state.status === 'done' && (
           <>
-            <MergedPreview uri={state.outputPath} />
+            <MergedPreview uri={state.outputPath} lines={captionLines} />
             <ThemedText type="subtitle" style={styles.title}>
               Ready to export
             </ThemedText>
@@ -180,11 +189,14 @@ export default function ExportScreen() {
  * render and the player never needs a source swap. Plays once (no loop); tap to pause or
  * replay after it ends.
  */
-function MergedPreview({ uri }: { uri: string }) {
+function MergedPreview({ uri, lines }: { uri: string; lines: TranscriptLine[] }) {
   const player = useVideoPlayer(toFileUri(uri), (p) => {
+    p.timeUpdateEventInterval = 0.1;
     p.play();
   });
   const { isPlaying } = useEvent(player, 'playingChange', { isPlaying: player.playing });
+  const timeUpdate = useEvent(player, 'timeUpdate');
+  const positionMs = (timeUpdate?.currentTime ?? player.currentTime) * 1000;
 
   const togglePlay = () => {
     if (isPlaying) {
@@ -208,6 +220,9 @@ function MergedPreview({ uri }: { uri: string }) {
         contentFit="contain"
         nativeControls={false}
       />
+      <View style={StyleSheet.absoluteFill} pointerEvents="none">
+        <CaptionOverlay lines={lines} positionMs={positionMs} />
+      </View>
       {!isPlaying && (
         <View style={styles.playOverlay} pointerEvents="none">
           <View style={styles.playBadge}>

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -213,6 +213,11 @@ export default function RecorderScreen() {
                 openTrim(seg);
               }}
               onDelete={() => preview.activeId && confirmDeleteSegment(preview.activeId)}
+              onEditCaptions={() => {
+                if (!preview.activeId || !draftId) return;
+                preview.pause();
+                router.push(`/subtitles?segmentId=${preview.activeId}&draftId=${draftId}`);
+              }}
             />
           </View>
         )}

--- a/src/app/subtitles.tsx
+++ b/src/app/subtitles.tsx
@@ -1,0 +1,554 @@
+import { useEvent } from 'expo';
+import { useLocalSearchParams, router } from 'expo-router';
+import { SymbolView } from 'expo-symbols';
+import { useVideoPlayer, VideoView } from 'expo-video';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Keyboard,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+  type LayoutChangeEvent,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { Accent, Spacing } from '@/constants/theme';
+import { getSegment } from '@/db/drafts';
+import type { Segment } from '@/db/schema';
+import {
+  clearEditedTranscript,
+  getTranscriptRow,
+  saveEditedTranscript,
+} from '@/db/transcripts';
+import { CloseButton } from '@/features/recorder/close-button';
+import { CaptionOverlay } from '@/features/transcription/caption-overlay';
+import { useSubtitleEditor, type Cue } from '@/features/transcription/use-subtitle-editor';
+import type { TranscriptLine } from '@/features/transcription/whisper';
+import { useTheme } from '@/hooks/use-theme';
+import { absolutize } from '@/utils/file-store';
+import { effFile } from '@/utils/segment-window';
+
+const NUDGE_CS = 10; // ±100ms
+const CPS_WARN = 17;
+const CPS_BAD = 20;
+const MAX_CHARS = 42;
+
+function parse(json: string | null): TranscriptLine[] {
+  if (!json) return [];
+  try {
+    return JSON.parse(json) as TranscriptLine[];
+  } catch {
+    return [];
+  }
+}
+
+// Collapsed rows show a coarse clock (m:ss); the editor's timing chips show tenths (m:ss.d).
+const clock = (cs: number) => {
+  const total = Math.floor(cs / 100);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+};
+const fine = (cs: number) => `${clock(cs)}.${Math.floor((cs % 100) / 10)}`;
+
+export default function SubtitlesScreen() {
+  const { segmentId, draftId } = useLocalSearchParams<{ segmentId?: string; draftId?: string }>();
+  const [data, setData] = useState<{
+    segment: Segment;
+    initial: TranscriptLine[];
+    autoLines: TranscriptLine[];
+  } | null>(null);
+  const [missing, setMissing] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      if (!segmentId) return setMissing(true);
+      const segment = await getSegment(segmentId);
+      if (!segment) return alive && setMissing(true);
+      const row = await getTranscriptRow(segmentId);
+      const autoLines = parse(row?.lines ?? null);
+      const initial = row?.editedLines ? parse(row.editedLines) : autoLines;
+      if (alive) setData({ segment, initial, autoLines });
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [segmentId]);
+
+  if (missing) {
+    return (
+      <ThemedView style={[styles.fill, styles.centerAll]}>
+        <ThemedText>Captions unavailable for this clip.</ThemedText>
+        <Pressable onPress={() => router.back()} style={styles.linkBtn}>
+          <ThemedText style={{ color: Accent }}>Go back</ThemedText>
+        </Pressable>
+      </ThemedView>
+    );
+  }
+
+  if (!data) {
+    return (
+      <ThemedView style={[styles.fill, styles.centerAll]}>
+        <ActivityIndicator />
+      </ThemedView>
+    );
+  }
+
+  return (
+    <Editor
+      key={segmentId}
+      segmentId={segmentId!}
+      draftId={draftId}
+      segment={data.segment}
+      initial={data.initial}
+      autoLines={data.autoLines}
+    />
+  );
+}
+
+function Editor({
+  segmentId,
+  draftId,
+  segment,
+  initial,
+  autoLines,
+}: {
+  segmentId: string;
+  draftId?: string;
+  segment: Segment;
+  initial: TranscriptLine[];
+  autoLines: TranscriptLine[];
+}) {
+  const insets = useSafeAreaInsets();
+  const theme = useTheme();
+  const editor = useSubtitleEditor(initial);
+
+  const uri = absolutize(effFile(segment));
+  const player = useVideoPlayer(uri, (p) => {
+    p.timeUpdateEventInterval = 0.1;
+    p.loop = false;
+  });
+  const timeUpdate = useEvent(player, 'timeUpdate');
+  const { isPlaying } = useEvent(player, 'playingChange', { isPlaying: player.playing });
+  const positionMs = (timeUpdate?.currentTime ?? player.currentTime) * 1000;
+  const posCs = positionMs / 10;
+
+  const lines = editor.toLines();
+  // The cue under the playhead (highlighted while playing) and the cue the user opened for editing.
+  const playingId = useMemo(() => {
+    const c = editor.cues.find((x) => posCs >= x.t0 && posCs <= x.t1);
+    return c?.id ?? null;
+  }, [editor.cues, posCs]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Best-effort auto-scroll: follow the playing cue, but don't yank the list while the user is
+  // editing an expanded cue.
+  const scrollRef = useRef<ScrollView>(null);
+  const offsets = useRef<Map<string, number>>(new Map());
+  useEffect(() => {
+    if (selectedId || !playingId) return;
+    const y = offsets.current.get(playingId);
+    if (y != null) scrollRef.current?.scrollTo({ y: Math.max(0, y - 96), animated: true });
+  }, [playingId, selectedId]);
+
+  const selectCue = (id: string, t0: number) => {
+    setSelectedId(id);
+    player.pause();
+    player.seekBy(t0 / 100 - player.currentTime);
+  };
+
+  const togglePlay = () => {
+    if (isPlaying) player.pause();
+    else if (player.duration > 0 && player.currentTime >= player.duration - 0.05) player.replay();
+    else player.play();
+  };
+
+  const onSave = async () => {
+    await saveEditedTranscript(segmentId, effFile(segment), editor.toLines(), Date.now());
+    router.back();
+  };
+
+  const onResetToAuto = async () => {
+    await clearEditedTranscript(segmentId);
+    editor.reset(autoLines);
+  };
+
+  return (
+    <ThemedView style={styles.fill}>
+      <View style={[styles.header, { paddingTop: insets.top + Spacing.two }]}>
+        <CloseButton onPress={() => router.back()} />
+        <ThemedText style={styles.headerTitle}>Captions</ThemedText>
+        <Pressable
+          onPress={onSave}
+          disabled={!editor.dirty}
+          accessibilityRole="button"
+          accessibilityLabel="Save captions"
+          style={[styles.saveBtn, { backgroundColor: Accent }, !editor.dirty && styles.disabled]}>
+          <ThemedText style={styles.saveLabel}>Save</ThemedText>
+        </Pressable>
+      </View>
+
+      <View style={styles.previewWrap}>
+        <Pressable style={styles.previewCard} onPress={togglePlay} accessibilityLabel="Toggle playback">
+          <VideoView
+            style={StyleSheet.absoluteFill}
+            player={player}
+            contentFit="contain"
+            nativeControls={false}
+          />
+          <View style={StyleSheet.absoluteFill} pointerEvents="none">
+            <CaptionOverlay lines={lines} positionMs={positionMs} />
+          </View>
+          {!isPlaying && (
+            <View style={styles.playOverlay} pointerEvents="none">
+              <View style={styles.playBadge}>
+                <SymbolView name="play.fill" size={22} tintColor="#fff" />
+              </View>
+            </View>
+          )}
+        </Pressable>
+      </View>
+
+      <ScrollView
+        ref={scrollRef}
+        style={styles.list}
+        contentContainerStyle={{ padding: Spacing.three, paddingBottom: insets.bottom + 120 }}
+        keyboardShouldPersistTaps="handled">
+        {editor.cues.length === 0 && (
+          <ThemedText themeColor="textSecondary" style={styles.empty}>
+            No captions yet. Add a cue at the playhead to start.
+          </ThemedText>
+        )}
+        {editor.cues.map((cue) => (
+          <View
+            key={cue.id}
+            onLayout={(e: LayoutChangeEvent) => offsets.current.set(cue.id, e.nativeEvent.layout.y)}>
+            <CueRow
+              cue={cue}
+              playing={cue.id === playingId}
+              selected={cue.id === selectedId}
+              theme={theme}
+              onSelect={() => selectCue(cue.id, cue.t0)}
+              onText={(t) => editor.setText(cue.id, t)}
+              onNudgeStart={(d) => editor.nudgeStart(cue.id, d)}
+              onNudgeEnd={(d) => editor.nudgeEnd(cue.id, d)}
+              onSetStart={() => editor.setStart(cue.id, posCs)}
+              onSetEnd={() => editor.setEnd(cue.id, posCs)}
+              onSplit={() => editor.splitAt(cue.id, posCs)}
+              onMerge={() => editor.mergeNext(cue.id)}
+              onCollapse={() => {
+                setSelectedId(null);
+                Keyboard.dismiss();
+              }}
+              onDelete={() => {
+                editor.remove(cue.id);
+                setSelectedId(null);
+              }}
+            />
+          </View>
+        ))}
+      </ScrollView>
+
+      <View style={[styles.footer, { paddingBottom: insets.bottom + Spacing.two }]}>
+        <Pressable
+          onPress={() => editor.addCueAt(posCs)}
+          style={[styles.footerBtn, { backgroundColor: theme.backgroundElement }]}>
+          <SymbolView name="plus" size={16} tintColor={theme.text} />
+          <ThemedText>Add cue</ThemedText>
+        </Pressable>
+        <Pressable
+          onPress={onResetToAuto}
+          style={[styles.footerBtn, { backgroundColor: theme.backgroundElement }]}>
+          <SymbolView name="arrow.uturn.backward" size={16} tintColor={theme.text} />
+          <ThemedText>Reset to auto</ThemedText>
+        </Pressable>
+      </View>
+    </ThemedView>
+  );
+}
+
+type CueRowProps = {
+  cue: Cue;
+  playing: boolean;
+  selected: boolean;
+  theme: ReturnType<typeof useTheme>;
+  onSelect: () => void;
+  onText: (t: string) => void;
+  onNudgeStart: (d: number) => void;
+  onNudgeEnd: (d: number) => void;
+  onSetStart: () => void;
+  onSetEnd: () => void;
+  onSplit: () => void;
+  onMerge: () => void;
+  onDelete: () => void;
+  onCollapse: () => void;
+};
+
+function CueRow({
+  cue,
+  playing,
+  selected,
+  theme,
+  onSelect,
+  onText,
+  onNudgeStart,
+  onNudgeEnd,
+  onSetStart,
+  onSetEnd,
+  onSplit,
+  onMerge,
+  onDelete,
+  onCollapse,
+}: CueRowProps) {
+  const chars = cue.text.trim().length;
+  const cps = chars / Math.max(0.01, (cue.t1 - cue.t0) / 100);
+  const over = cps > CPS_BAD || chars > MAX_CHARS;
+  const cpsColor = cps > CPS_BAD ? Accent : cps > CPS_WARN ? '#E5A100' : theme.textSecondary;
+
+  // Collapsed: a calm, readable row — start time + text, accent when it's the playing cue.
+  if (!selected) {
+    return (
+      <Pressable
+        onPress={onSelect}
+        style={[
+          styles.row,
+          { backgroundColor: theme.backgroundElement, borderColor: theme.border },
+          playing && { borderColor: Accent },
+        ]}>
+        <View style={styles.collapsed}>
+          <ThemedText style={[styles.tc, { color: playing ? Accent : theme.textSecondary }]}>
+            {clock(cue.t0)}
+          </ThemedText>
+          <ThemedText
+            numberOfLines={2}
+            style={[styles.collapsedText, !chars && { color: theme.textSecondary }]}>
+            {chars ? cue.text : 'Empty cue'}
+          </ThemedText>
+          {over && <View style={styles.cpsDot} />}
+        </View>
+      </Pressable>
+    );
+  }
+
+  // Expanded: the one cue being edited — text field + timing + actions.
+  return (
+    <View style={[styles.row, styles.rowSelected, { backgroundColor: theme.backgroundElement }]}>
+      <View style={styles.expandedHeader}>
+        <ThemedText style={[styles.tc, styles.rangeText, { color: Accent }]}>
+          {clock(cue.t0)}–{clock(cue.t1)}
+        </ThemedText>
+        <Pressable onPress={onCollapse} hitSlop={8} accessibilityLabel="Done editing cue">
+          <SymbolView name="chevron.up" size={15} weight="semibold" tintColor={theme.textSecondary} />
+        </Pressable>
+      </View>
+
+      <TextInput
+        value={cue.text}
+        onChangeText={onText}
+        placeholder="Caption text"
+        placeholderTextColor={theme.textSecondary}
+        multiline
+        autoFocus
+        style={[styles.input, { color: theme.text }]}
+      />
+
+      <View style={styles.timeRow}>
+        <TimeControl
+          label="In"
+          value={fine(cue.t0)}
+          theme={theme}
+          onMinus={() => onNudgeStart(-NUDGE_CS)}
+          onPlus={() => onNudgeStart(NUDGE_CS)}
+          onPlayhead={onSetStart}
+        />
+        <TimeControl
+          label="Out"
+          value={fine(cue.t1)}
+          theme={theme}
+          onMinus={() => onNudgeEnd(-NUDGE_CS)}
+          onPlus={() => onNudgeEnd(NUDGE_CS)}
+          onPlayhead={onSetEnd}
+        />
+      </View>
+
+      <View style={[styles.actionRow, { borderTopColor: theme.border }]}>
+        <ActionBtn name="scissors" label="Split" theme={theme} onPress={onSplit} />
+        <ActionBtn name="arrow.triangle.merge" label="Merge" theme={theme} onPress={onMerge} />
+        <ActionBtn name="trash" label="Delete" theme={theme} onPress={onDelete} tint={Accent} />
+        <View style={styles.flexSpacer} />
+        <ThemedText style={{ color: cpsColor, fontSize: 12 }}>{cps.toFixed(0)} cps</ThemedText>
+      </View>
+    </View>
+  );
+}
+
+function TimeControl({
+  label,
+  value,
+  theme,
+  onMinus,
+  onPlus,
+  onPlayhead,
+}: {
+  label: string;
+  value: string;
+  theme: ReturnType<typeof useTheme>;
+  onMinus: () => void;
+  onPlus: () => void;
+  onPlayhead: () => void;
+}) {
+  return (
+    <View style={[styles.timeControl, { backgroundColor: theme.backgroundSelected }]}>
+      <ThemedText themeColor="textSecondary" style={styles.timeLabel}>
+        {label}
+      </ThemedText>
+      <Pressable onPress={onMinus} hitSlop={8} style={styles.stepBtn} accessibilityLabel={`${label} earlier`}>
+        <SymbolView name="minus" size={12} weight="semibold" tintColor={theme.text} />
+      </Pressable>
+      <ThemedText style={styles.timeValue}>{value}</ThemedText>
+      <Pressable onPress={onPlus} hitSlop={8} style={styles.stepBtn} accessibilityLabel={`${label} later`}>
+        <SymbolView name="plus" size={12} weight="semibold" tintColor={theme.text} />
+      </Pressable>
+      <Pressable
+        onPress={onPlayhead}
+        hitSlop={8}
+        style={styles.stepBtn}
+        accessibilityLabel={`Set ${label} to playhead`}>
+        <SymbolView name="arrow.down.to.line" size={13} tintColor={Accent} />
+      </Pressable>
+    </View>
+  );
+}
+
+function ActionBtn({
+  name,
+  label,
+  theme,
+  onPress,
+  tint,
+}: {
+  name: string;
+  label: string;
+  theme: ReturnType<typeof useTheme>;
+  onPress: () => void;
+  tint?: string;
+}) {
+  return (
+    <Pressable onPress={onPress} hitSlop={6} accessibilityLabel={label} style={styles.actionBtn}>
+      <SymbolView name={name as never} size={15} tintColor={tint ?? theme.text} />
+      <ThemedText style={[styles.actionLabel, { color: tint ?? theme.text }]}>{label}</ThemedText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  fill: { flex: 1 },
+  centerAll: { alignItems: 'center', justifyContent: 'center', gap: Spacing.two },
+  linkBtn: { padding: Spacing.two },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.three,
+    paddingBottom: Spacing.two,
+  },
+  headerTitle: { fontSize: 17, fontWeight: '700' },
+  saveBtn: { paddingHorizontal: Spacing.three, paddingVertical: Spacing.one + 2, borderRadius: 10 },
+  saveLabel: { color: '#fff', fontWeight: '700' },
+  disabled: { opacity: 0.4 },
+  previewWrap: { alignItems: 'center', paddingVertical: Spacing.two },
+  previewCard: {
+    width: '44%',
+    aspectRatio: 9 / 16,
+    overflow: 'hidden',
+    borderRadius: 12,
+    backgroundColor: '#000',
+  },
+  playOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  playBadge: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingLeft: 3,
+  },
+  list: { flex: 1 },
+  empty: { textAlign: 'center', marginTop: Spacing.five },
+  row: {
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: Spacing.two,
+  },
+  rowSelected: {
+    borderWidth: 1.5,
+    borderColor: Accent,
+    padding: Spacing.three,
+    gap: Spacing.three,
+  },
+  // Collapsed row: time + text on one line.
+  collapsed: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.three,
+    paddingVertical: Spacing.two + 2,
+    paddingHorizontal: Spacing.three,
+  },
+  tc: { fontSize: 13, fontVariant: ['tabular-nums'], width: 38 },
+  expandedHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  rangeText: { width: 'auto', fontWeight: '600' },
+  collapsedText: { flex: 1, fontSize: 15, lineHeight: 20 },
+  cpsDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: Accent },
+  input: { fontSize: 17, lineHeight: 23, minHeight: 24, padding: 0 },
+  timeRow: { flexDirection: 'row', gap: Spacing.two },
+  timeControl: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.one,
+    borderRadius: 10,
+    paddingVertical: Spacing.one,
+    paddingHorizontal: Spacing.two,
+  },
+  timeLabel: { fontSize: 12, width: 24 },
+  timeValue: { flex: 1, fontSize: 13, fontVariant: ['tabular-nums'], textAlign: 'center' },
+  stepBtn: { width: 28, height: 28, alignItems: 'center', justifyContent: 'center' },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.four,
+    paddingTop: Spacing.three,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  actionBtn: { flexDirection: 'row', alignItems: 'center', gap: Spacing.one },
+  actionLabel: { fontSize: 13 },
+  flexSpacer: { flex: 1 },
+  footer: {
+    flexDirection: 'row',
+    gap: Spacing.two,
+    paddingHorizontal: Spacing.three,
+    paddingTop: Spacing.two,
+  },
+  footerBtn: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: Spacing.two,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 48,
+    borderRadius: 12,
+  },
+});

--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -46,6 +46,12 @@ export function segmentsForDraft(projectId: string) {
 /** Every segment in the library — drives the global background transcription engine. */
 export const allSegmentsQuery = db.select().from(segments);
 
+/** Load one segment row by id (e.g. for the subtitle editor's video preview). */
+export async function getSegment(segmentId: string) {
+  const [seg] = await db.select().from(segments).where(eq(segments.id, segmentId));
+  return seg ?? null;
+}
+
 // Mutations — each is a single-row write that autosaves the draft (§3).
 
 export async function createDraft(): Promise<string> {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -50,7 +50,9 @@ export const segments = sqliteTable('segments', {
  * On-device speech-to-text for a clip's audio (whisper.rn). One row per segment, keyed by the
  * EFFECTIVE file it was produced from (`sourceFile`); a destructive edit changes the effective
  * file, which invalidates the stored transcript and triggers a re-run. `lines` is JSON of
- * `Array<{ text, t0, t1 }>` where t0/t1 are centiseconds relative to the clip's audio start.
+ * `Array<{ text, t0, t1, words? }>` where t0/t1 are centiseconds relative to the clip's audio
+ * start. `editedLines` holds the user's hand-edited captions (same JSON shape); when present it
+ * is the effective transcript and locks the row against auto re-transcription / model-switch wipes.
  */
 export const transcripts = sqliteTable('transcripts', {
   segmentId: text('segment_id')
@@ -66,6 +68,10 @@ export const transcripts = sqliteTable('transcripts', {
   language: text('language'),
   text: text('text'),
   lines: text('lines'),
+  // User-edited captions (JSON, same shape as `lines`). Null = no manual edit. Tied to the
+  // current `sourceFile`; a destructive re-edit of the clip clears it (timings would be stale).
+  editedLines: text('edited_lines'),
+  editedAt: integer('edited_at'),
   createdAt: integer('created_at').notNull().default(now),
 });
 

--- a/src/db/transcripts.ts
+++ b/src/db/transcripts.ts
@@ -1,6 +1,6 @@
-import { eq } from 'drizzle-orm';
+import { eq, isNull, sql } from 'drizzle-orm';
 
-import type { TranscriptResult } from '@/features/transcription/whisper';
+import type { TranscriptLine, TranscriptResult } from '@/features/transcription/whisper';
 import { db } from './client';
 import { segments, transcripts } from './schema';
 
@@ -15,25 +15,44 @@ export function transcriptsForDraft(projectId: string) {
       language: transcripts.language,
       text: transcripts.text,
       lines: transcripts.lines,
+      editedLines: transcripts.editedLines,
     })
     .from(transcripts)
     .innerJoin(segments, eq(segments.id, transcripts.segmentId))
     .where(eq(segments.projectId, projectId));
 }
 
-/** Live-queryable: every transcript row (status/model/file) — the engine's needs-check source. */
+/** Live-queryable: every transcript row (status/model/file + edit flag) — the engine's needs-check source. */
 export const allTranscriptsQuery = db
   .select({
     segmentId: transcripts.segmentId,
     sourceFile: transcripts.sourceFile,
     model: transcripts.model,
     status: transcripts.status,
+    editedLines: transcripts.editedLines,
   })
   .from(transcripts);
 
-/** Drop every transcript (e.g. on a model switch, so captions regenerate from scratch). */
-export async function clearAllTranscripts(): Promise<void> {
-  await db.delete(transcripts);
+/** Load a single segment's transcript row (auto `lines`, `editedLines`, status) for the editor. */
+export async function getTranscriptRow(segmentId: string) {
+  const [row] = await db
+    .select({
+      lines: transcripts.lines,
+      editedLines: transcripts.editedLines,
+      status: transcripts.status,
+    })
+    .from(transcripts)
+    .where(eq(transcripts.segmentId, segmentId));
+  return row ?? null;
+}
+
+/**
+ * Drop auto-generated transcripts (e.g. on a model switch, so captions regenerate from scratch),
+ * but PRESERVE rows the user has hand-edited — their captions are tied to the audio, not the
+ * model, so a model switch must not wipe them.
+ */
+export async function clearAutoTranscripts(): Promise<void> {
+  await db.delete(transcripts).where(isNull(transcripts.editedLines));
 }
 
 /** Mark a segment's transcript in-progress for a given effective file + model (insert or replace). */
@@ -47,7 +66,18 @@ export async function markTranscribing(
     .values({ segmentId, sourceFile, model, status: 'processing' })
     .onConflictDoUpdate({
       target: transcripts.segmentId,
-      set: { sourceFile, model, status: 'processing', text: null, lines: null, language: null },
+      // A (re)transcription only reaches here for a fresh clip or after the effective file changed
+      // (a destructive edit) — in both cases any prior hand-edit is stale, so drop it too.
+      set: {
+        sourceFile,
+        model,
+        status: 'processing',
+        text: null,
+        lines: null,
+        language: null,
+        editedLines: null,
+        editedAt: null,
+      },
     });
 }
 
@@ -80,5 +110,50 @@ export async function markTranscriptError(
   await db
     .update(transcripts)
     .set({ sourceFile, model, status: 'error', text: null, lines: null })
+    .where(eq(transcripts.segmentId, segmentId));
+}
+
+/**
+ * Persist the user's hand-edited captions for a segment. Stored alongside the auto `lines` (which
+ * stay intact for "Reset to auto"); once set, `editedLines` is the effective transcript and locks
+ * the row against auto re-transcription and model-switch wipes. Forces status to 'done' so the
+ * captions render regardless of the prior auto state. `editedAt` is passed in (scripts can't call
+ * Date.now()); pass `Date.now()` from the caller.
+ *
+ * Upserts: a clip can be captioned before the background engine has inserted a row (no model
+ * selected, or still queued), and the edit must still stick. `sourceFile` (the segment's effective
+ * file) ties a freshly-inserted row to the right audio so the edit-lock holds; on an existing row
+ * it is left untouched (it already matches) so the stored auto `lines` survive for "Reset to auto".
+ */
+export async function saveEditedTranscript(
+  segmentId: string,
+  sourceFile: string,
+  lines: TranscriptLine[],
+  editedAt: number,
+): Promise<void> {
+  const editedLines = JSON.stringify(lines);
+  await db
+    .insert(transcripts)
+    .values({ segmentId, sourceFile, status: 'done', editedLines, editedAt })
+    .onConflictDoUpdate({
+      target: transcripts.segmentId,
+      set: { status: 'done', editedLines, editedAt },
+    });
+}
+
+/**
+ * Clear a segment's manual edit ("Reset to auto"), unlocking it for the background engine. If the
+ * row has no auto `lines` to fall back on (it was edited before auto-transcription produced any),
+ * re-arm it to 'processing' so the engine regenerates captions rather than leaving it stranded at
+ * an empty 'done'; otherwise keep the stored auto lines + status so they reappear instantly.
+ */
+export async function clearEditedTranscript(segmentId: string): Promise<void> {
+  await db
+    .update(transcripts)
+    .set({
+      editedLines: null,
+      editedAt: null,
+      status: sql`CASE WHEN ${transcripts.lines} IS NULL THEN 'processing' ELSE ${transcripts.status} END`,
+    })
     .where(eq(transcripts.segmentId, segmentId));
 }

--- a/src/features/recorder/preview-modal.tsx
+++ b/src/features/recorder/preview-modal.tsx
@@ -3,6 +3,7 @@ import { VideoView, type VideoPlayer } from 'expo-video';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Spacing } from '@/constants/theme';
+import { CaptionOverlay } from '@/features/transcription/caption-overlay';
 import type { SegmentTranscript } from '@/features/transcription/use-draft-transcripts';
 import { formatDurationPadded } from '@/utils/format';
 
@@ -20,13 +21,8 @@ type Props = {
   onClose: () => void;
   onTrim: () => void;
   onDelete: () => void;
+  onEditCaptions: () => void;
 };
-
-/** The caption line covering the current playback position (whisper t0/t1 are centiseconds). */
-function activeLine(transcript: SegmentTranscript | undefined, captionMs: number) {
-  if (transcript?.status !== 'done') return undefined;
-  return transcript.lines.find((l) => captionMs >= l.t0 * 10 && captionMs <= l.t1 * 10);
-}
 
 /**
  * Floating preview card over the recorder — the camera UI, record button, and segment bar
@@ -45,8 +41,9 @@ export function PreviewModal({
   onClose,
   onTrim,
   onDelete,
+  onEditCaptions,
 }: Props) {
-  const line = activeLine(transcript, captionMs);
+  const captionLines = transcript?.status === 'done' ? transcript.lines : [];
   return (
     <View style={styles.card}>
       <Pressable style={styles.surface} onPress={onTogglePlay} accessibilityLabel="Toggle playback">
@@ -92,16 +89,19 @@ export function PreviewModal({
         <SymbolView name="trash" size={16} weight="semibold" tintColor="#fff" />
       </Pressable>
 
-      <View style={styles.captionRow} pointerEvents="none">
-        {/* No "Transcribing…" / placeholder state — the pill appears only once a caption line is
-            ready for the current playback position, so captions just pop in when available. */}
-        {line && (
-          <View style={styles.captionPill}>
-            <Text style={styles.captionText} numberOfLines={3}>
-              {line.text.trim()}
-            </Text>
-          </View>
-        )}
+      <Pressable
+        onPress={onEditCaptions}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel="Edit captions"
+        style={[styles.badge, styles.captions]}>
+        <SymbolView name="captions.bubble" size={16} weight="semibold" tintColor="#fff" />
+      </Pressable>
+
+      {/* Animated word-level captions over the video (Skia). Renders nothing until a line is
+          ready for the current playback position, so captions just pop in when available. */}
+      <View style={styles.captionLayer} pointerEvents="none">
+        <CaptionOverlay lines={captionLines} positionMs={captionMs} />
       </View>
 
       <View style={styles.timeRow} pointerEvents="none">
@@ -163,26 +163,17 @@ const styles = StyleSheet.create({
   trim: {
     right: Spacing.two + 28 + Spacing.two,
   },
-  // Sits just above the time pill; captions are centered and wrap up to 3 lines.
-  captionRow: {
+  // Left of the trim badge (another 28 + 8pt gap).
+  captions: {
+    right: Spacing.two + 2 * (28 + Spacing.two),
+  },
+  // Covers the card above the time pill; the Skia overlay draws captions near its bottom edge.
+  captionLayer: {
     position: 'absolute',
-    left: Spacing.two,
-    right: Spacing.two,
+    left: 0,
+    right: 0,
+    top: 0,
     bottom: Spacing.two + 28,
-    alignItems: 'center',
-  },
-  captionPill: {
-    paddingHorizontal: Spacing.two,
-    paddingVertical: Spacing.one,
-    borderRadius: 10,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-  },
-  captionText: {
-    color: '#fff',
-    fontSize: 14,
-    lineHeight: 19,
-    fontWeight: '600',
-    textAlign: 'center',
   },
   timeRow: {
     position: 'absolute',

--- a/src/features/transcription/caption-overlay.tsx
+++ b/src/features/transcription/caption-overlay.tsx
@@ -1,0 +1,162 @@
+import { Roboto_700Bold } from '@expo-google-fonts/roboto';
+import { Canvas, RoundedRect, Text as SkiaText, useFont } from '@shopify/react-native-skia';
+import { useMemo, useState } from 'react';
+import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+
+import { Accent } from '@/constants/theme';
+import type { TranscriptLine, TranscriptWord } from './whisper';
+
+const FONT_SIZE = 20;
+const LINE_HEIGHT = FONT_SIZE * 1.3;
+const PAD = 10; // background padding around the text block
+const EDGE = 14; // min gap from the canvas edges
+
+const COLOR_SPOKEN = 'rgba(255,255,255,1)';
+const COLOR_FUTURE = 'rgba(255,255,255,0.45)';
+const COLOR_BG = 'rgba(0,0,0,0.6)';
+
+type Props = {
+  /** Effective caption lines (centiseconds), sorted by start. */
+  lines: TranscriptLine[];
+  /** Current playback position in milliseconds, in the same time base as `lines`. */
+  positionMs: number;
+};
+
+type Placed = { word: TranscriptWord; x: number; y: number };
+
+/** Binary-search the line whose [t0,t1] (centiseconds) contains `posCs`; -1 if none. */
+function findActiveLine(lines: TranscriptLine[], posCs: number): number {
+  let lo = 0;
+  let hi = lines.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const l = lines[mid];
+    if (posCs < l.t0) hi = mid - 1;
+    else if (posCs > l.t1) lo = mid + 1;
+    else return mid;
+  }
+  return -1;
+}
+
+/**
+ * Word-level (karaoke) caption overlay drawn with Skia. The active line is picked by binary
+ * search; within it, words already spoken render solid, upcoming words dim, and the current word
+ * is in the accent color. Lines without `words` fall back to a static line.
+ *
+ * Time sync is the caller's job: feed `positionMs` from expo-video's `timeUpdate` event.
+ */
+export function CaptionOverlay({ lines, positionMs }: Props) {
+  const font = useFont(Roboto_700Bold, FONT_SIZE);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  const posCs = positionMs / 10;
+  const lineIdx = useMemo(() => findActiveLine(lines, posCs), [lines, posCs]);
+  const line = lineIdx >= 0 ? lines[lineIdx] : undefined;
+
+  // The words to render: real word timing when present, else the whole line as one "word".
+  const words: TranscriptWord[] = useMemo(() => {
+    if (!line) return [];
+    return line.words?.length ? line.words : [{ text: line.text, t0: line.t0, t1: line.t1 }];
+  }, [line]);
+
+  // Active word index within the line: the word covering the playhead, else the last one already
+  // started (so the highlight rests on the most recent word during short gaps).
+  const activeWord = useMemo(() => {
+    let idx = -1;
+    for (let i = 0; i < words.length; i++) {
+      if (posCs >= words[i].t0) idx = i;
+      if (posCs >= words[i].t0 && posCs <= words[i].t1) return i;
+    }
+    return idx;
+  }, [words, posCs]);
+
+  // Lay the words out into <=2 centered rows that fit the canvas width.
+  const layout = useMemo(() => {
+    if (!font || size.width === 0 || words.length === 0) {
+      return { placed: [] as Placed[], bg: null as null | { x: number; y: number; w: number; h: number } };
+    }
+    const spaceW = Math.max(
+      4,
+      font.measureText('A A').width - font.measureText('AA').width,
+    );
+    const maxW = size.width - 2 * EDGE;
+
+    // Greedy wrap into rows.
+    const rows: { items: { word: TranscriptWord; w: number }[]; width: number }[] = [
+      { items: [], width: 0 },
+    ];
+    for (const word of words) {
+      const w = font.measureText(word.text).width;
+      const row = rows[rows.length - 1];
+      const add = (row.items.length ? spaceW : 0) + w;
+      if (row.items.length && row.width + add > maxW) {
+        rows.push({ items: [{ word, w }], width: w });
+      } else {
+        row.items.push({ word, w });
+        row.width += add;
+      }
+    }
+
+    const totalH = rows.length * LINE_HEIGHT;
+    const blockTop = Math.max(EDGE, size.height - EDGE - totalH);
+
+    const placed: Placed[] = [];
+    let maxRowW = 0;
+    rows.forEach((row, ri) => {
+      let x = (size.width - row.width) / 2;
+      const baseline = blockTop + ri * LINE_HEIGHT + FONT_SIZE;
+      maxRowW = Math.max(maxRowW, row.width);
+      for (const it of row.items) {
+        placed.push({ word: it.word, x, y: baseline });
+        x += it.w + spaceW;
+      }
+    });
+
+    const bg = {
+      x: (size.width - maxRowW) / 2 - PAD,
+      y: blockTop - PAD / 2,
+      w: maxRowW + 2 * PAD,
+      h: totalH + PAD,
+    };
+    return { placed, bg };
+  }, [font, size.width, size.height, words]);
+
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setSize((s) => (s.width === width && s.height === height ? s : { width, height }));
+  };
+
+  // On the new architecture (Fabric) Skia's <Canvas> doesn't support onLayout, so measure on a
+  // wrapping <View> and let the Canvas fill it.
+  return (
+    <View style={StyleSheet.absoluteFill} onLayout={onLayout} pointerEvents="none">
+      <Canvas style={StyleSheet.absoluteFill}>
+        {line && layout.bg && (
+          <RoundedRect
+            x={layout.bg.x}
+            y={layout.bg.y}
+            width={layout.bg.w}
+            height={layout.bg.h}
+            r={8}
+            color={COLOR_BG}
+          />
+        )}
+        {font &&
+          layout.placed.map((p, i) => {
+            const spoken = i <= activeWord;
+            const isActive = i === activeWord;
+            return (
+              <SkiaText
+                key={`${lineIdx}:${i}`}
+                font={font}
+                text={p.word.text}
+                x={p.x}
+                y={p.y}
+                color={isActive ? Accent : spoken ? COLOR_SPOKEN : COLOR_FUTURE}
+              />
+            );
+          })}
+      </Canvas>
+    </View>
+  );
+}

--- a/src/features/transcription/group-lines.test.ts
+++ b/src/features/transcription/group-lines.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { groupWordsIntoLines } from './group-lines';
+import type { TranscriptWord } from './whisper';
+
+// Build word segments at 50cs (0.5s) each, as whisper would emit them with maxLen: 1.
+const words = (...texts: string[]): TranscriptWord[] =>
+  texts.map((text, i) => ({ text, t0: i * 50, t1: (i + 1) * 50 }));
+
+describe('groupWordsIntoLines', () => {
+  it('keeps a short sentence as one line with its words', () => {
+    const lines = groupWordsIntoLines(words(' Hello', ' there', ' friend.'));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].text).toBe('Hello there friend.');
+    expect(lines[0].t0).toBe(0);
+    expect(lines[0].t1).toBe(150);
+    expect(lines[0].words?.map((w) => w.text)).toEqual(['Hello', 'there', 'friend.']);
+  });
+
+  it('breaks at sentence-ending punctuation', () => {
+    const lines = groupWordsIntoLines(words(' One.', ' Two', ' three.'));
+    expect(lines).toHaveLength(2);
+    expect(lines[0].text).toBe('One.');
+    expect(lines[1].text).toBe('Two three.');
+  });
+
+  it('breaks when a line would exceed the character budget', () => {
+    const long = words(...Array.from({ length: 12 }, () => 'wordword')); // 8 chars each
+    const lines = groupWordsIntoLines(long);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const l of lines) expect(l.text.length).toBeLessThanOrEqual(42);
+  });
+
+  it('cleans the stray space before punctuation', () => {
+    const lines = groupWordsIntoLines(words(' Wait', ' ,', ' what?'));
+    expect(lines[0].text).toBe('Wait, what?');
+  });
+});

--- a/src/features/transcription/group-lines.ts
+++ b/src/features/transcription/group-lines.ts
@@ -1,0 +1,62 @@
+import type { TranscriptLine, TranscriptWord } from './whisper';
+
+// Caption-readability budget (Netflix/BBC-derived). A cue is one short, on-screen line that the
+// overlay may wrap to at most two rows; keeping cues at ~42 chars gives punchy, karaoke-friendly
+// captions that sync tightly with speech.
+const MAX_LINE_CHARS = 42;
+// Hard ceiling on a single cue's on-screen duration (centiseconds). 7s is the standard cap.
+const MAX_DUR_CS = 700;
+
+const SENTENCE_END = /[.!?…]["')\]]?$/;
+
+/** Collapse the stray space whisper leaves before punctuation when words are joined (" ," → ","). */
+function cueText(words: TranscriptWord[]): string {
+  return words
+    .map((w) => w.text)
+    .join(' ')
+    .replace(/\s+([,.!?;:…])/g, '$1')
+    .trim();
+}
+
+function flush(words: TranscriptWord[]): TranscriptLine {
+  return { text: cueText(words), t0: words[0].t0, t1: words[words.length - 1].t1, words };
+}
+
+/**
+ * Fold word-level whisper segments (from a `maxLen: 1` pass) into caption-sized lines, each
+ * carrying its `words[]` for word-level (karaoke) highlighting. A new line starts when the
+ * current word ends a sentence, when appending the next word would exceed the character budget,
+ * or when the cue would run past the max duration. Word `text` is trimmed (whisper prefixes a
+ * space); `t0`/`t1` stay in centiseconds.
+ */
+export function groupWordsIntoLines(segments: TranscriptWord[]): TranscriptLine[] {
+  const lines: TranscriptLine[] = [];
+  let current: TranscriptWord[] = [];
+  let chars = 0;
+
+  for (const seg of segments) {
+    const text = seg.text.trim();
+    if (!text) continue;
+    const word: TranscriptWord = { text, t0: seg.t0, t1: seg.t1 };
+
+    const wouldChars = chars + (current.length ? 1 : 0) + text.length;
+    const wouldDur = current.length ? seg.t1 - current[0].t0 : 0;
+    if (current.length && (wouldChars > MAX_LINE_CHARS || wouldDur > MAX_DUR_CS)) {
+      lines.push(flush(current));
+      current = [];
+      chars = 0;
+    }
+
+    current.push(word);
+    chars += (current.length > 1 ? 1 : 0) + text.length;
+
+    if (SENTENCE_END.test(text)) {
+      lines.push(flush(current));
+      current = [];
+      chars = 0;
+    }
+  }
+
+  if (current.length) lines.push(flush(current));
+  return lines;
+}

--- a/src/features/transcription/needs-transcription.test.ts
+++ b/src/features/transcription/needs-transcription.test.ts
@@ -12,38 +12,49 @@ const done = (over: Partial<TranscriptState> = {}): TranscriptState => ({
 
 describe('needsTranscription', () => {
   it('runs when there is no row yet', () => {
-    expect(needsTranscription('a.mp4', 'tiny.en', undefined, 0, MAX)).toBe(true);
+    expect(needsTranscription('a.mp4', 'tiny.en', undefined, 0, MAX, false)).toBe(true);
   });
 
   it('skips a matching, completed row', () => {
-    expect(needsTranscription('a.mp4', 'tiny.en', done(), 0, MAX)).toBe(false);
+    expect(needsTranscription('a.mp4', 'tiny.en', done(), 0, MAX, false)).toBe(false);
   });
 
   it('re-runs when the effective file changed (destructive edit)', () => {
-    expect(needsTranscription('edited.mp4', 'tiny.en', done(), 0, MAX)).toBe(true);
+    expect(needsTranscription('edited.mp4', 'tiny.en', done(), 0, MAX, false)).toBe(true);
   });
 
   it('re-runs when the model changed', () => {
-    expect(needsTranscription('a.mp4', 'base.en', done(), 0, MAX)).toBe(true);
+    expect(needsTranscription('a.mp4', 'base.en', done(), 0, MAX, false)).toBe(true);
   });
 
   it('resumes a row stranded in processing', () => {
-    expect(needsTranscription('a.mp4', 'tiny.en', done({ status: 'processing' }), 0, MAX)).toBe(true);
+    expect(needsTranscription('a.mp4', 'tiny.en', done({ status: 'processing' }), 0, MAX, false)).toBe(
+      true,
+    );
   });
 
   it('retries an errored row while under the attempt budget', () => {
     const row = done({ status: 'error' });
-    expect(needsTranscription('a.mp4', 'tiny.en', row, 0, MAX)).toBe(true);
-    expect(needsTranscription('a.mp4', 'tiny.en', row, 1, MAX)).toBe(true);
+    expect(needsTranscription('a.mp4', 'tiny.en', row, 0, MAX, false)).toBe(true);
+    expect(needsTranscription('a.mp4', 'tiny.en', row, 1, MAX, false)).toBe(true);
   });
 
   it('gives up on an errored row once the budget is spent', () => {
     const row = done({ status: 'error' });
-    expect(needsTranscription('a.mp4', 'tiny.en', row, MAX, MAX)).toBe(false);
+    expect(needsTranscription('a.mp4', 'tiny.en', row, MAX, MAX, false)).toBe(false);
   });
 
   it('a file change overrides a spent error budget (fresh file, fresh start)', () => {
     const row = done({ status: 'error', sourceFile: 'old.mp4' });
-    expect(needsTranscription('new.mp4', 'tiny.en', row, MAX, MAX)).toBe(true);
+    expect(needsTranscription('new.mp4', 'tiny.en', row, MAX, MAX, false)).toBe(true);
+  });
+
+  it('locks a hand-edited row against a model switch', () => {
+    // Same file, different model — would normally re-run, but the user edit wins.
+    expect(needsTranscription('a.mp4', 'base.en', done(), 0, MAX, true)).toBe(false);
+  });
+
+  it('still re-runs an edited row when the effective file changed (edit is stale)', () => {
+    expect(needsTranscription('edited.mp4', 'tiny.en', done(), 0, MAX, true)).toBe(true);
   });
 });

--- a/src/features/transcription/needs-transcription.ts
+++ b/src/features/transcription/needs-transcription.ts
@@ -10,7 +10,10 @@ export type TranscriptState = {
  * given its current DB row and how many times it has already failed this session?
  *
  * - No row yet → yes.
- * - Row was produced from a different file (a destructive edit changed the effective file) → yes.
+ * - Row was produced from a different file (a destructive edit changed the effective file) → yes
+ *   (this also drops any now-stale hand-edit, whose timings no longer match the new audio).
+ * - Row is hand-edited (and still for this file) → no. The user's captions are locked: a model
+ *   switch must not regenerate over them, since captions are tied to the audio, not the model.
  * - Row was produced by a different model → yes.
  * - Done → no.
  * - Errored → retry only while under the attempt budget.
@@ -24,9 +27,11 @@ export function needsTranscription(
   row: TranscriptState | undefined,
   errorAttempts: number,
   maxAttempts: number,
+  isEdited: boolean,
 ): boolean {
   if (!row) return true;
   if (row.sourceFile !== effectiveFile) return true;
+  if (isEdited) return false; // user-locked for this file
   if (row.model !== modelId) return true;
   if (row.status === 'done') return false;
   if (row.status === 'error') return errorAttempts < maxAttempts;

--- a/src/features/transcription/srt.ts
+++ b/src/features/transcription/srt.ts
@@ -1,0 +1,71 @@
+import { build, parse } from 'subsrt-ts';
+import type { Caption, ContentCaption } from 'subsrt-ts/dist/types/handler';
+
+import type { Segment } from '@/db/schema';
+import { effMs } from '@/utils/segment-window';
+import type { SegmentTranscript } from './use-draft-transcripts';
+import type { TranscriptLine } from './whisper';
+
+// Our `TranscriptLine` times are centiseconds (1/100 s); subsrt captions are milliseconds.
+const csToMs = (cs: number) => Math.round(cs * 10);
+const msToCs = (ms: number) => Math.round(ms / 10);
+
+function linesToCaptions(lines: TranscriptLine[]): ContentCaption[] {
+  return lines.map((l, i) => {
+    const start = csToMs(l.t0);
+    const end = csToMs(l.t1);
+    return {
+      type: 'caption',
+      index: i + 1,
+      start,
+      end,
+      duration: Math.max(0, end - start),
+      content: l.text,
+      text: l.text,
+    };
+  });
+}
+
+/** Serialize caption lines to an SRT document (universal, sharable). */
+export function linesToSrt(lines: TranscriptLine[]): string {
+  return build(linesToCaptions(lines), { format: 'srt' });
+}
+
+/** Parse an SRT document back into caption lines (no word-level data — SRT has none). */
+export function srtToLines(srt: string): TranscriptLine[] {
+  return parse(srt)
+    .filter((c: Caption): c is ContentCaption => c.type === 'caption')
+    .map((c) => ({ text: c.text.trim(), t0: msToCs(c.start), t1: msToCs(c.end) }));
+}
+
+/** Offset a line (and its words) by `offsetCs` centiseconds — used to stitch clips into one timeline. */
+function shiftLine(l: TranscriptLine, offsetCs: number): TranscriptLine {
+  return {
+    text: l.text,
+    t0: l.t0 + offsetCs,
+    t1: l.t1 + offsetCs,
+    words: l.words?.map((w) => ({ text: w.text, t0: w.t0 + offsetCs, t1: w.t1 + offsetCs })),
+  };
+}
+
+/**
+ * Build a single draft-wide caption timeline from per-segment transcripts: each clip's effective
+ * lines are offset by the cumulative effective duration of the clips before it (matching how the
+ * merged export video concatenates them). Times stay in centiseconds.
+ */
+export function mergedLines(
+  segments: Segment[],
+  transcripts: Map<string, SegmentTranscript>,
+): TranscriptLine[] {
+  const out: TranscriptLine[] = [];
+  let offsetMs = 0;
+  for (const s of segments) {
+    const t = transcripts.get(s.id);
+    if (t?.lines.length) {
+      const offsetCs = offsetMs / 10;
+      for (const l of t.lines) out.push(shiftLine(l, offsetCs));
+    }
+    offsetMs += effMs(s);
+  }
+  return out;
+}

--- a/src/features/transcription/use-draft-transcripts.ts
+++ b/src/features/transcription/use-draft-transcripts.ts
@@ -8,22 +8,37 @@ import type { TranscriptLine } from './whisper';
 export type SegmentTranscript = {
   status: 'processing' | 'done' | 'error';
   text: string | null;
+  /** Effective captions for display/export: the user's edit if present, else the auto lines. */
   lines: TranscriptLine[];
+  /** True when the user has hand-edited this segment's captions. */
+  edited: boolean;
 };
+
+function parseLines(json: string | null): TranscriptLine[] {
+  if (!json) return [];
+  try {
+    return JSON.parse(json) as TranscriptLine[];
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Read-only: the transcripts for a draft's segments, keyed by segment id, for rendering captions.
- * Writes are owned by the global background engine (`useLibraryTranscription`); this just observes.
+ * `lines` is the EFFECTIVE transcript (the hand-edit when present, else the auto lines). Writes are
+ * owned by the global background engine (`useLibraryTranscription`) and the subtitle editor.
  */
 export function useDraftTranscripts(draftId: string | null): Map<string, SegmentTranscript> {
   const { data } = useLiveQuery(transcriptsForDraft(draftId ?? ''), [draftId]);
   return useMemo(() => {
     const map = new Map<string, SegmentTranscript>();
     for (const r of data) {
+      const edited = r.editedLines != null;
       map.set(r.segmentId, {
         status: r.status,
         text: r.text,
-        lines: r.lines ? (JSON.parse(r.lines) as TranscriptLine[]) : [],
+        lines: edited ? parseLines(r.editedLines) : parseLines(r.lines),
+        edited,
       });
     }
     return map;

--- a/src/features/transcription/use-library-transcription.ts
+++ b/src/features/transcription/use-library-transcription.ts
@@ -6,7 +6,7 @@ import type { Segment } from '@/db/schema';
 import { selectedModelQuery } from '@/db/settings';
 import {
   allTranscriptsQuery,
-  clearAllTranscripts,
+  clearAutoTranscripts,
   markTranscribing,
   markTranscriptError,
   saveTranscript,
@@ -33,15 +33,20 @@ export type TranscriptionStatus =
   | { kind: 'downloading'; bytesWritten: number; totalBytes: number }
   | { kind: 'transcribing'; done: number; total: number };
 
-type Row = { model: string | null; sourceFile: string; status: 'processing' | 'done' | 'error' };
+type Row = {
+  model: string | null;
+  sourceFile: string;
+  status: 'processing' | 'done' | 'error';
+  edited: boolean;
+};
 
 /**
  * The single, app-wide background transcription engine. Mounted once (see TranscriptionProvider).
  *
  * Driven by the persisted model selection, it keeps every clip in the library captioned:
  * - Selecting a model downloads it (deleting any other), then transcribes the whole library.
- * - Switching models **clears all transcripts** (captions vanish everywhere) and regenerates them
- *   per-segment with the new model — each caption reappears as its clip finishes.
+ * - Switching models **clears auto-generated transcripts** (captions regenerate per-segment with
+ *   the new model) but PRESERVES hand-edited ones — each caption reappears as its clip finishes.
  * - Clearing the model releases the context and deletes the weights.
  * - New clips (recorded/imported anywhere) are picked up automatically.
  *
@@ -61,7 +66,12 @@ export function useLibraryTranscription(): TranscriptionStatus {
   const rowById = useMemo(() => {
     const map = new Map<string, Row>();
     for (const r of transcriptRows) {
-      map.set(r.segmentId, { model: r.model, sourceFile: r.sourceFile, status: r.status });
+      map.set(r.segmentId, {
+        model: r.model,
+        sourceFile: r.sourceFile,
+        status: r.status,
+        edited: r.editedLines != null,
+      });
     }
     return map;
   }, [transcriptRows]);
@@ -96,12 +106,14 @@ export function useLibraryTranscription(): TranscriptionStatus {
     const file = effFile(s);
     const key = `${s.id}:${file}:${m.id}`;
     if (processedRef.current.has(key)) return false; // settled this session
+    const row = rowByIdRef.current.get(s.id);
     return needsTranscription(
       file,
       m.id,
-      rowByIdRef.current.get(s.id),
+      row,
       errorAttemptsRef.current.get(key) ?? 0,
       MAX_TRANSCRIBE_ATTEMPTS,
+      row?.edited ?? false,
     );
   }, []);
 
@@ -124,7 +136,9 @@ export function useLibraryTranscription(): TranscriptionStatus {
         } else if (prevModelIdRef.current !== curId) {
           prevModelIdRef.current = curId;
           processedRef.current.clear();
-          await clearAllTranscripts();
+          // Drop auto captions so they regenerate with the new model, but keep hand-edited rows
+          // (their captions are tied to the audio, not the model).
+          await clearAutoTranscripts();
         }
 
         if (!m) {

--- a/src/features/transcription/use-subtitle-editor.ts
+++ b/src/features/transcription/use-subtitle-editor.ts
@@ -1,0 +1,226 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import type { TranscriptLine, TranscriptWord } from './whisper';
+
+/** One editable caption cue. Times are centiseconds; `words` drives word-level highlighting. */
+export type Cue = {
+  id: string;
+  text: string;
+  t0: number;
+  t1: number;
+  words: TranscriptWord[];
+};
+
+const MIN_DUR_CS = 30; // never let a cue collapse below ~0.3s
+
+/** Split `text` into word tokens, spreading [t0,t1] across them by character length. */
+function distributeWords(text: string, t0: number, t1: number): TranscriptWord[] {
+  const toks = text.trim().split(/\s+/).filter(Boolean);
+  if (!toks.length) return [];
+  const span = Math.max(1, t1 - t0);
+  const totalChars = toks.reduce((a, t) => a + t.length, 0) || toks.length;
+  const words: TranscriptWord[] = [];
+  let cursor = t0;
+  for (const tok of toks) {
+    const dur = Math.round((span * tok.length) / totalChars);
+    const end = Math.min(t1, cursor + dur);
+    words.push({ text: tok, t0: Math.round(cursor), t1: Math.round(end) });
+    cursor = end;
+  }
+  words[words.length - 1].t1 = t1; // snap the last word to the cue end
+  return words;
+}
+
+/** Linearly remap existing word times from the old [o0,o1] span onto the new [n0,n1] span. */
+function rescaleWords(words: TranscriptWord[], o0: number, o1: number, n0: number, n1: number) {
+  const os = Math.max(1, o1 - o0);
+  const ns = n1 - n0;
+  return words.map((w) => ({
+    text: w.text,
+    t0: Math.round(n0 + ((w.t0 - o0) / os) * ns),
+    t1: Math.round(n0 + ((w.t1 - o0) / os) * ns),
+  }));
+}
+
+function lineToCue(l: TranscriptLine, id: string): Cue {
+  return {
+    id,
+    text: l.text,
+    t0: l.t0,
+    t1: l.t1,
+    words: l.words?.length ? l.words.map((w) => ({ ...w })) : distributeWords(l.text, l.t0, l.t1),
+  };
+}
+
+const bySort = (a: Cue, b: Cue) => a.t0 - b.t0 || a.t1 - b.t1;
+
+/** Cues → persistable caption lines (sorted, empties dropped). */
+function cuesToLines(cues: Cue[]): TranscriptLine[] {
+  return [...cues]
+    .sort(bySort)
+    .filter((c) => c.text.trim().length > 0)
+    .map((c) => ({ text: c.text.trim(), t0: c.t0, t1: c.t1, words: c.words }));
+}
+
+const serialize = (cues: Cue[]) => JSON.stringify(cuesToLines(cues));
+
+/**
+ * Editing state for one segment's captions. Seeds cues from the effective lines, keeps them sorted,
+ * and maintains word-level timing across edits (rescale on timing changes, re-distribute on text
+ * changes) so the karaoke overlay keeps working. `dirty` tracks unsaved changes vs. the seed.
+ */
+export function useSubtitleEditor(initial: TranscriptLine[]) {
+  // Monotonic id source for cues created at runtime (add/split). Read ONLY inside event handlers,
+  // never during render — seeded cues get deterministic index ids instead (see `seed`).
+  const idRef = useRef(0);
+  const nextId = useCallback(() => `cue_${idRef.current++}`, []);
+
+  // Pure (ref-free) so it can run inside useState initializers: seed cues replace the whole list,
+  // so index-based ids are unique within the list and never collide with the `cue_*` handler ids.
+  const seed = useCallback(
+    (lines: TranscriptLine[]): Cue[] =>
+      [...lines].sort((a, b) => a.t0 - b.t0).map((l, i) => lineToCue(l, `seed_${i}`)),
+    [],
+  );
+
+  const [cues, setCues] = useState<Cue[]>(() => seed(initial));
+  // Baseline is the SEEDED cues serialized (the seed may synthesize word timing for word-less
+  // lines), so the editor opens clean rather than appearing dirty from that normalization.
+  const [baseline, setBaseline] = useState(() => serialize(seed(initial)));
+
+  const update = useCallback((id: string, fn: (c: Cue) => Cue) => {
+    setCues((cs) => cs.map((c) => (c.id === id ? fn(c) : c)).sort(bySort));
+  }, []);
+
+  const setText = useCallback(
+    (id: string, text: string) =>
+      update(id, (c) => ({ ...c, text, words: distributeWords(text, c.t0, c.t1) })),
+    [update],
+  );
+
+  const setStart = useCallback(
+    (id: string, t0: number) =>
+      update(id, (c) => {
+        const next = Math.min(Math.max(0, Math.round(t0)), c.t1 - MIN_DUR_CS);
+        return { ...c, t0: next, words: rescaleWords(c.words, c.t0, c.t1, next, c.t1) };
+      }),
+    [update],
+  );
+
+  const setEnd = useCallback(
+    (id: string, t1: number) =>
+      update(id, (c) => {
+        const next = Math.max(Math.round(t1), c.t0 + MIN_DUR_CS);
+        return { ...c, t1: next, words: rescaleWords(c.words, c.t0, c.t1, c.t0, next) };
+      }),
+    [update],
+  );
+
+  const nudgeStart = useCallback((id: string, delta: number) => {
+    setCues((cs) =>
+      cs
+        .map((c) => {
+          if (c.id !== id) return c;
+          const next = Math.min(Math.max(0, c.t0 + delta), c.t1 - MIN_DUR_CS);
+          return { ...c, t0: next, words: rescaleWords(c.words, c.t0, c.t1, next, c.t1) };
+        })
+        .sort(bySort),
+    );
+  }, []);
+
+  const nudgeEnd = useCallback((id: string, delta: number) => {
+    setCues((cs) =>
+      cs
+        .map((c) => {
+          if (c.id !== id) return c;
+          const next = Math.max(c.t1 + delta, c.t0 + MIN_DUR_CS);
+          return { ...c, t1: next, words: rescaleWords(c.words, c.t0, c.t1, c.t0, next) };
+        })
+        .sort(bySort),
+    );
+  }, []);
+
+  const remove = useCallback((id: string) => setCues((cs) => cs.filter((c) => c.id !== id)), []);
+
+  /** Insert a new empty cue starting at `atCs` (a ~1.5s default span). */
+  const addCueAt = useCallback(
+    (atCs: number) => {
+      const t0 = Math.max(0, Math.round(atCs));
+      const t1 = t0 + 150;
+      setCues((cs) => [...cs, { id: nextId(), text: '', t0, t1, words: [] }].sort(bySort));
+    },
+    [nextId],
+  );
+
+  /** Split a cue at `atCs`, partitioning its words into the two halves. */
+  const splitAt = useCallback(
+    (id: string, atCs: number) => {
+      setCues((cs) => {
+        const c = cs.find((x) => x.id === id);
+        if (!c || atCs <= c.t0 + MIN_DUR_CS || atCs >= c.t1 - MIN_DUR_CS) return cs;
+        const left = c.words.filter((w) => w.t0 < atCs);
+        const right = c.words.filter((w) => w.t0 >= atCs);
+        const mk = (words: TranscriptWord[], t0: number, t1: number): Cue => ({
+          id: nextId(),
+          text: words.map((w) => w.text).join(' ').trim(),
+          t0,
+          t1,
+          words,
+        });
+        const a = mk(left, c.t0, Math.round(atCs));
+        const b = mk(right, Math.round(atCs), c.t1);
+        return cs.filter((x) => x.id !== id).concat([a, b]).sort(bySort);
+      });
+    },
+    [nextId],
+  );
+
+  /** Merge a cue with the next one in time order. */
+  const mergeNext = useCallback((id: string) => {
+    setCues((cs) => {
+      const sorted = [...cs].sort(bySort);
+      const i = sorted.findIndex((c) => c.id === id);
+      if (i < 0 || i >= sorted.length - 1) return cs;
+      const a = sorted[i];
+      const b = sorted[i + 1];
+      const merged: Cue = {
+        id: a.id,
+        text: `${a.text} ${b.text}`.trim(),
+        t0: a.t0,
+        t1: b.t1,
+        words: [...a.words, ...b.words],
+      };
+      return sorted.filter((c) => c.id !== a.id && c.id !== b.id).concat(merged).sort(bySort);
+    });
+  }, []);
+
+  /** Reseed the editor (e.g. "reset to auto"); marks the editor clean against the new lines. */
+  const reset = useCallback(
+    (lines: TranscriptLine[]) => {
+      const next = seed(lines);
+      setCues(next);
+      setBaseline(serialize(next));
+    },
+    [seed],
+  );
+
+  const toLines = useCallback((): TranscriptLine[] => cuesToLines(cues), [cues]);
+
+  const dirty = useMemo(() => serialize(cues) !== baseline, [cues, baseline]);
+
+  return {
+    cues,
+    dirty,
+    setText,
+    setStart,
+    setEnd,
+    nudgeStart,
+    nudgeEnd,
+    remove,
+    addCueAt,
+    splitAt,
+    mergeNext,
+    reset,
+    toLines,
+  };
+}

--- a/src/features/transcription/whisper.ts
+++ b/src/features/transcription/whisper.ts
@@ -1,15 +1,23 @@
 import { deleteFile, extractAudio } from 'react-native-video-trim';
 import { initWhisper, type WhisperContext } from 'whisper.rn';
 
+import { groupWordsIntoLines } from './group-lines';
 import { ensureModel, modelFileUri } from './model';
 import type { WhisperModel } from './models';
 import { hasSpeech } from './vad';
 
 /**
- * One transcribed line. `t0`/`t1` are whisper.cpp timestamps in **centiseconds** (1/100s)
- * relative to the clip's audio start — divide by 100 for seconds when rendering.
+ * One word of a transcript. `t0`/`t1` are whisper.cpp timestamps in **centiseconds** (1/100s)
+ * relative to the clip's audio start. Words drive word-level (karaoke) caption highlighting.
  */
-export type TranscriptLine = { text: string; t0: number; t1: number };
+export type TranscriptWord = { text: string; t0: number; t1: number };
+
+/**
+ * One transcribed line (caption cue). `t0`/`t1` are **centiseconds** relative to the clip's
+ * audio start — divide by 100 for seconds when rendering. `words` (when present) carries the
+ * per-word timing within the line; older stored rows may omit it and render line-level only.
+ */
+export type TranscriptLine = { text: string; t0: number; t1: number; words?: TranscriptWord[] };
 
 export type TranscriptResult = {
   language: string;
@@ -39,10 +47,11 @@ async function isSilent(wavPath: string): Promise<boolean> {
 let current: { id: string; ctx: WhisperContext } | null = null;
 let loadPromise: Promise<WhisperContext> | null = null;
 
-// Cap on a single caption line's length (characters). Whisper emits whole utterances as one
-// segment; splitting to caption-sized chunks (requires token timestamps) gives short, readable
-// lines that sync tightly with playback instead of one long paragraph.
-const CAPTION_MAX_LEN = 42;
+// `maxLen: 1` makes whisper emit one segment per word, each with its own t0/t1 — the only way
+// whisper.rn surfaces word-level timing (its result exposes segments, not tokens). We then fold
+// those words back into caption-sized lines ourselves (see group-lines.ts), which gives both
+// word-level timing (for karaoke highlighting) and readable, standards-sized cues.
+const WORD_PER_SEGMENT = 1;
 
 /**
  * Build a Whisper context, preferring on-device acceleration. `useGpu` runs inference on the
@@ -113,7 +122,8 @@ export async function transcribeVideo(
     if (await isSilent(wavPath)) return EMPTY_TRANSCRIPT;
 
     const ctx = await loadContext(model);
-    // `tokenTimestamps` is what lets `maxLen` split a long utterance into caption-sized lines.
+    // `tokenTimestamps` is what lets `maxLen` split output by token; with `maxLen: 1` we get one
+    // word per segment (with per-word t0/t1), then regroup into caption lines ourselves.
     // `language` honors the model: 'en' for the English-only models, 'auto' for the multilingual one.
     //
     // Speed knobs for the on-device hot path (captions, not subtitling a film):
@@ -124,7 +134,7 @@ export async function transcribeVideo(
     //   sampling is the slow default; the quality delta on clear speech is negligible for captions.
     const { promise } = ctx.transcribe(wavPath, {
       language: model.lang,
-      maxLen: CAPTION_MAX_LEN,
+      maxLen: WORD_PER_SEGMENT,
       tokenTimestamps: true,
       maxThreads: 6,
       beamSize: 1,
@@ -135,7 +145,7 @@ export async function transcribeVideo(
     return {
       language: result.language,
       text: result.result.trim(),
-      lines: result.segments.map((s) => ({ text: s.text, t0: s.t0, t1: s.t1 })),
+      lines: groupWordsIntoLines(result.segments),
     };
   } finally {
     await deleteFile(wavPath).catch(() => {});


### PR DESCRIPTION
## What

Karaoke-style word-level captions and a full caption editor, plus an edit-aware transcription engine.

- **Word-level timing** — whisper runs `maxLen: 1` (one segment per word) and `group-lines.ts` folds words back into caption-sized cues, so each cue carries per-word `t0`/`t1` for karaoke highlighting.
- **Skia caption overlay** (`caption-overlay.tsx`) — shared by the recorder preview, export preview, and editor; binary-searches the active line and highlights the spoken word.
- **Subtitle editor** (`subtitles.tsx` + `use-subtitle-editor.ts`) — edit text, nudge/set timing to the playhead, split/merge/add/delete cues, with word timing rescaled across edits.
- **Edit-aware engine** — hand-edits are persisted (`edited_lines`/`edited_at`) and locked: a model switch clears only auto transcripts (`clearAutoTranscripts`) and re-transcription skips edited rows, while a destructive file edit still invalidates them.
- **Draft-wide timeline** — `srt.ts` stitches per-clip transcripts onto one timeline for the export preview overlay (foundation for future subtitle upload sidecars).
- Removes the old per-line caption pill in favor of the overlay.

## Review fixes folded in
- `saveEditedTranscript` **upserts** — an edit on a clip with no transcript row (no model selected, or still queued) is no longer silently dropped.
- **Reset-to-auto** re-arms a row that has no auto `lines` to fall back on, instead of stranding it at an empty `done`.

## DB
Migration `0004` adds `transcripts.edited_lines` / `edited_at`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `jest` — 23 passing (group-lines, needs-transcription edit-lock, models)
- [x] Manual: record → edit captions → save → reappear; model switch keeps edits; reset-to-auto

## Follow-up (planned, not in this PR)
Subtitle sidecars (.vtt + .srt) for segment and export uploads — design agreed: both formats, block upload until all clips transcribed.