### PR TITLE
fix: render icons on Android via cross-platform Icon wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "expo-video": "~56.1.2",
         "expo-web-browser": "~56.0.5",
         "fflate": "^0.8.3",
+        "lucide-react-native": "^1.20.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
@@ -18317,6 +18318,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react-native": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-1.20.0.tgz",
+      "integrity": "sha512-w3eZftxeROhly6EhGFgbus0b2REf0ZH3VwwCE/0h9u1Dap6j+zOXlDTWxr5vCJ1za9349QQhMmdYZfHEvDzXPw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*",
+        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "expo-video": "~56.1.2",
     "expo-web-browser": "~56.0.5",
     "fflate": "^0.8.3",
+    "lucide-react-native": "^1.20.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",

--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -1,7 +1,7 @@
 import { useEvent } from 'expo';
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { useLocalSearchParams } from 'expo-router';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, StyleSheet, View } from 'react-native';
@@ -106,7 +106,7 @@ export default function ExportScreen() {
                   <ActivityIndicator color="#fff" />
                 ) : (
                   <>
-                    <SymbolView name="square.and.arrow.up" size={18} tintColor="#fff" />
+                    <Icon name="square.and.arrow.up" size={18} tintColor="#fff" />
                     <ThemedText style={styles.primaryLabel}>Share</ThemedText>
                   </>
                 )}
@@ -122,12 +122,12 @@ export default function ExportScreen() {
                   <ActivityIndicator color={theme.text} />
                 ) : photos.status === 'saved' ? (
                   <>
-                    <SymbolView name="checkmark" size={18} tintColor={theme.text} />
+                    <Icon name="checkmark" size={18} tintColor={theme.text} />
                     <ThemedText>Saved</ThemedText>
                   </>
                 ) : (
                   <>
-                    <SymbolView name="square.and.arrow.down" size={18} tintColor={theme.text} />
+                    <Icon name="square.and.arrow.down" size={18} tintColor={theme.text} />
                     <ThemedText>Save to Photos</ThemedText>
                   </>
                 )}
@@ -143,12 +143,12 @@ export default function ExportScreen() {
                   <ActivityIndicator color={theme.text} />
                 ) : docs.status === 'saved' ? (
                   <>
-                    <SymbolView name="checkmark" size={18} tintColor={theme.text} />
+                    <Icon name="checkmark" size={18} tintColor={theme.text} />
                     <ThemedText>Saved</ThemedText>
                   </>
                 ) : (
                   <>
-                    <SymbolView name="folder" size={18} tintColor={theme.text} />
+                    <Icon name="folder" size={18} tintColor={theme.text} />
                     <ThemedText>Save to Files</ThemedText>
                   </>
                 )}
@@ -159,7 +159,7 @@ export default function ExportScreen() {
 
         {state.status === 'error' && (
           <>
-            <SymbolView name="exclamationmark.triangle.fill" size={64} tintColor={Accent} />
+            <Icon name="exclamationmark.triangle.fill" size={64} tintColor={Accent} />
             <ThemedText type="subtitle" style={styles.title}>
               Export failed
             </ThemedText>
@@ -173,7 +173,7 @@ export default function ExportScreen() {
                 accessibilityRole="button"
                 accessibilityLabel="Try again"
                 style={[styles.button, styles.primary]}>
-                <SymbolView name="arrow.clockwise" size={18} tintColor="#fff" />
+                <Icon name="arrow.clockwise" size={18} tintColor="#fff" />
                 <ThemedText style={styles.primaryLabel}>Try again</ThemedText>
               </Pressable>
             </View>
@@ -226,7 +226,7 @@ function MergedPreview({ uri, lines }: { uri: string; lines: TranscriptLine[] })
       {!isPlaying && (
         <View style={styles.playOverlay} pointerEvents="none">
           <View style={styles.playBadge}>
-            <SymbolView name="play.fill" size={24} tintColor="#fff" />
+            <Icon name="play.fill" size={24} tintColor="#fff" />
           </View>
         </View>
       )}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,6 +1,6 @@
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { router } from 'expo-router';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { useState } from 'react';
 import { ActivityIndicator, Alert, FlatList, Pressable, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -186,7 +186,7 @@ export default function HomeScreen() {
               {transferState === 'importing' ? (
                 <ActivityIndicator size="small" color={theme.textSecondary} />
               ) : (
-                <SymbolView
+                <Icon
                   name="square.and.arrow.down"
                   size={20}
                   tintColor={busy ? theme.textSecondary : theme.text}
@@ -206,7 +206,7 @@ export default function HomeScreen() {
                 accessibilityRole="button"
                 accessibilityLabel="Select drafts to export"
                 style={({ pressed }) => [styles.headerButton, pressed && styles.headerButtonPressed]}>
-                <SymbolView name="square.and.arrow.up" size={20} tintColor={theme.text} />
+                <Icon name="square.and.arrow.up" size={20} tintColor={theme.text} />
                 <ThemedText type="smallBold" style={styles.headerButtonLabel}>
                   Export
                 </ThemedText>
@@ -218,8 +218,8 @@ export default function HomeScreen() {
               accessibilityRole="button"
               accessibilityLabel="On-device AI"
               style={({ pressed }) => [styles.headerButton, pressed && styles.headerButtonPressed]}>
-              <SymbolView
-                name="sparkles"
+              <Icon
+                name="wand.and.stars"
                 size={20}
                 tintColor={selectedModel ? theme.accent : theme.textSecondary}
               />
@@ -243,7 +243,7 @@ export default function HomeScreen() {
 
       {visibleDrafts.length === 0 ? (
         <View style={styles.empty}>
-          <SymbolView name="video.badge.plus" size={52} tintColor={theme.textSecondary} />
+          <Icon name="video.badge.plus" size={52} tintColor={theme.textSecondary} />
           <ThemedText style={styles.emptyTitle}>No drafts yet</ThemedText>
           <ThemedText themeColor="textSecondary" style={styles.emptyHint}>
             Tap + to record your first video.
@@ -305,7 +305,7 @@ export default function HomeScreen() {
           {transferState === 'exporting' ? (
             <ActivityIndicator color={theme.onAccent} />
           ) : (
-            <SymbolView name="square.and.arrow.up" size={26} weight="semibold" tintColor={theme.onAccent} />
+            <Icon name="square.and.arrow.up" size={26} weight="semibold" tintColor={theme.onAccent} />
           )}
         </Pressable>
       ) : (
@@ -321,7 +321,7 @@ export default function HomeScreen() {
               opacity: pressed ? 0.85 : 1,
             },
           ]}>
-          <SymbolView name="plus" size={28} weight="semibold" tintColor={theme.onAccent} />
+          <Icon name="plus" size={28} weight="semibold" tintColor={theme.onAccent} />
         </Pressable>
       )}
 

--- a/src/app/subtitles.tsx
+++ b/src/app/subtitles.tsx
@@ -1,6 +1,6 @@
 import { useEvent } from 'expo';
 import { useLocalSearchParams, router } from 'expo-router';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -206,7 +206,7 @@ function Editor({
           {!isPlaying && (
             <View style={styles.playOverlay} pointerEvents="none">
               <View style={styles.playBadge}>
-                <SymbolView name="play.fill" size={22} tintColor="#fff" />
+                <Icon name="play.fill" size={22} tintColor="#fff" />
               </View>
             </View>
           )}
@@ -257,13 +257,13 @@ function Editor({
         <Pressable
           onPress={() => editor.addCueAt(posCs)}
           style={[styles.footerBtn, { backgroundColor: theme.backgroundElement }]}>
-          <SymbolView name="plus" size={16} tintColor={theme.text} />
+          <Icon name="plus" size={16} tintColor={theme.text} />
           <ThemedText>Add cue</ThemedText>
         </Pressable>
         <Pressable
           onPress={onResetToAuto}
           style={[styles.footerBtn, { backgroundColor: theme.backgroundElement }]}>
-          <SymbolView name="arrow.uturn.backward" size={16} tintColor={theme.text} />
+          <Icon name="arrow.uturn.backward" size={16} tintColor={theme.text} />
           <ThemedText>Reset to auto</ThemedText>
         </Pressable>
       </View>
@@ -342,7 +342,7 @@ function CueRow({
           {clock(cue.t0)}–{clock(cue.t1)}
         </ThemedText>
         <Pressable onPress={onCollapse} hitSlop={8} accessibilityLabel="Done editing cue">
-          <SymbolView name="chevron.up" size={15} weight="semibold" tintColor={theme.textSecondary} />
+          <Icon name="chevron.up" size={15} weight="semibold" tintColor={theme.textSecondary} />
         </Pressable>
       </View>
 
@@ -407,18 +407,18 @@ function TimeControl({
         {label}
       </ThemedText>
       <Pressable onPress={onMinus} hitSlop={8} style={styles.stepBtn} accessibilityLabel={`${label} earlier`}>
-        <SymbolView name="minus" size={12} weight="semibold" tintColor={theme.text} />
+        <Icon name="minus" size={12} weight="semibold" tintColor={theme.text} />
       </Pressable>
       <ThemedText style={styles.timeValue}>{value}</ThemedText>
       <Pressable onPress={onPlus} hitSlop={8} style={styles.stepBtn} accessibilityLabel={`${label} later`}>
-        <SymbolView name="plus" size={12} weight="semibold" tintColor={theme.text} />
+        <Icon name="plus" size={12} weight="semibold" tintColor={theme.text} />
       </Pressable>
       <Pressable
         onPress={onPlayhead}
         hitSlop={8}
         style={styles.stepBtn}
         accessibilityLabel={`Set ${label} to playhead`}>
-        <SymbolView name="arrow.down.to.line" size={13} tintColor={Accent} />
+        <Icon name="arrow.down.to.line" size={13} tintColor={Accent} />
       </Pressable>
     </View>
   );
@@ -439,7 +439,7 @@ function ActionBtn({
 }) {
   return (
     <Pressable onPress={onPress} hitSlop={6} accessibilityLabel={label} style={styles.actionBtn}>
-      <SymbolView name={name as never} size={15} tintColor={tint ?? theme.text} />
+      <Icon name={name as never} size={15} tintColor={tint ?? theme.text} />
       <ThemedText style={[styles.actionLabel, { color: tint ?? theme.text }]}>{label}</ThemedText>
     </Pressable>
   );

--- a/src/components/action-menu.tsx
+++ b/src/components/action-menu.tsx
@@ -1,4 +1,5 @@
-import { SymbolView, type SymbolViewProps } from 'expo-symbols';
+import type { SymbolViewProps } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { Modal, Pressable, StyleSheet, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -75,7 +76,7 @@ export function ActionMenu({ visible, anchor, actions, onClose }: Props) {
                     pressed && { backgroundColor: theme.backgroundSelected },
                   ]}>
                   <ThemedText style={[styles.rowLabel, { color: tint }]}>{action.label}</ThemedText>
-                  <SymbolView name={action.icon} size={18} tintColor={tint} />
+                  <Icon name={action.icon} size={18} tintColor={tint} />
                 </Pressable>
               );
             })}

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,0 +1,136 @@
+import { SymbolView, type SymbolViewProps } from 'expo-symbols';
+import {
+  ArrowDownToLine,
+  ArrowRight,
+  Ban,
+  Camera,
+  Captions,
+  Check,
+  ChevronUp,
+  Circle,
+  CircleCheck,
+  CircleSlash,
+  CircleX,
+  Download,
+  Ellipsis,
+  Film,
+  Folder,
+  GripHorizontal,
+  type LucideIcon,
+  Merge,
+  Mic,
+  MicOff,
+  Minus,
+  Orbit,
+  Pencil,
+  Play,
+  Plus,
+  RotateCw,
+  Scissors,
+  Share,
+  Sparkles,
+  SwitchCamera,
+  Trash2,
+  TriangleAlert,
+  Undo2,
+  Video,
+  WandSparkles,
+  X,
+  Zap,
+  ZapOff,
+} from 'lucide-react-native';
+import { Platform, type StyleProp, type ViewStyle } from 'react-native';
+
+export type IconName = SymbolViewProps['name'];
+type SymbolWeight = SymbolViewProps['weight'];
+
+/**
+ * SF Symbol → Lucide glyph. SF Symbols (expo-symbols) are Apple-only, so on Android we
+ * render the closest Lucide equivalent. Keep this in sync with every `name` passed to <Icon>.
+ */
+const ANDROID_GLYPHS: Partial<Record<string, LucideIcon>> = {
+  'arrow.clockwise': RotateCw,
+  'arrow.down.to.line': ArrowDownToLine,
+  'arrow.right': ArrowRight,
+  'arrow.triangle.merge': Merge,
+  'arrow.triangle.2.circlepath.camera': SwitchCamera,
+  'arrow.uturn.backward': Undo2,
+  'bolt.fill': Zap,
+  'bolt.slash.fill': ZapOff,
+  'camera.fill': Camera,
+  'captions.bubble': Captions,
+  'captions.bubble.fill': Captions,
+  'checkmark': Check,
+  'checkmark.circle.fill': CircleCheck,
+  'chevron.up': ChevronUp,
+  'circle.slash': CircleSlash,
+  'ellipsis': Ellipsis,
+  'exclamationmark.triangle.fill': TriangleAlert,
+  'film': Film,
+  'folder': Folder,
+  'gyroscope': Orbit,
+  'line.3.horizontal': GripHorizontal,
+  'mic.fill': Mic,
+  'mic.slash.fill': MicOff,
+  'minus': Minus,
+  'pencil': Pencil,
+  'play.fill': Play,
+  'plus': Plus,
+  'scissors': Scissors,
+  'sparkles': Sparkles,
+  'square.and.arrow.down': Download,
+  'square.and.arrow.up': Share,
+  'trash': Trash2,
+  'trash.fill': Trash2,
+  'video.badge.plus': Video,
+  'video.fill': Video,
+  'wand.and.stars': WandSparkles,
+  'xmark': X,
+  'xmark.circle.fill': CircleX,
+};
+
+// SF Symbol weights don't map 1:1 to stroke width; approximate so heavier glyphs read bolder.
+function strokeWidthFor(weight?: SymbolWeight): number {
+  switch (weight) {
+    case 'bold':
+    case 'heavy':
+    case 'black':
+    case 'semibold':
+      return 2.5;
+    case 'medium':
+      return 2.25;
+    case 'light':
+    case 'thin':
+    case 'ultraLight':
+      return 1.5;
+    default:
+      return 2;
+  }
+}
+
+type Props = {
+  name: IconName;
+  size?: number;
+  weight?: SymbolWeight;
+  tintColor?: string;
+  style?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Cross-platform icon. Renders a native SF Symbol on iOS and the mapped Lucide glyph on
+ * Android (where SF Symbols don't exist). Drop-in for the props we used on <Icon>.
+ */
+export function Icon({ name, size = 24, weight, tintColor, style }: Props) {
+  if (Platform.OS === 'ios') {
+    return <SymbolView name={name} size={size} weight={weight} tintColor={tintColor} style={style} />;
+  }
+
+  const Glyph = ANDROID_GLYPHS[name as string];
+  if (!Glyph) {
+    if (__DEV__) {
+      console.warn(`[Icon] No Android mapping for SF Symbol "${String(name)}" — add it to ANDROID_GLYPHS.`);
+    }
+    return <Circle size={size} color={tintColor ?? '#888'} strokeWidth={strokeWidthFor(weight)} style={style} />;
+  }
+  return <Glyph size={size} color={tintColor ?? '#000'} strokeWidth={strokeWidthFor(weight)} style={style} />;
+}

--- a/src/features/home/draft-card.tsx
+++ b/src/features/home/draft-card.tsx
@@ -1,5 +1,5 @@
 import { Image } from 'expo-image';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { useRef } from 'react';
 import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 
@@ -76,7 +76,7 @@ export function DraftCard({
         {thumbnail ? (
           <Image source={thumbnail} style={styles.thumbImage} contentFit="cover" />
         ) : (
-          <SymbolView name="video.fill" size={18} tintColor={theme.textSecondary} />
+          <Icon name="video.fill" size={18} tintColor={theme.textSecondary} />
         )}
       </View>
 
@@ -106,7 +106,7 @@ export function DraftCard({
 
       {selectionMode ? (
         <View style={styles.more} accessibilityRole="checkbox" accessibilityState={{ checked: selected }}>
-          <SymbolView
+          <Icon
             name={selected ? 'checkmark.circle.fill' : 'circle'}
             size={22}
             tintColor={selected ? theme.accent : theme.textSecondary}
@@ -126,7 +126,7 @@ export function DraftCard({
             accessibilityRole="button"
             accessibilityLabel="Draft options"
             style={({ pressed }) => [styles.more, { opacity: pressed ? 0.5 : 1 }]}>
-            <SymbolView name="ellipsis" size={18} tintColor={theme.textSecondary} />
+            <Icon name="ellipsis" size={18} tintColor={theme.textSecondary} />
           </Pressable>
         )
       )}

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -1,6 +1,6 @@
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { useCallback, useRef, useState } from 'react';
 import {
   type FlatList,
@@ -109,7 +109,7 @@ export function OnboardingScreen() {
               <Image source={item.image} style={styles.logo} contentFit="contain" />
             ) : (
               <View style={[styles.iconCard, { backgroundColor: theme.backgroundElement }]}>
-                <SymbolView name={item.symbol ?? 'sparkles'} size={56} tintColor={theme.accent} />
+                <Icon name={item.symbol ?? 'sparkles'} size={56} tintColor={theme.accent} />
               </View>
             )}
             <ThemedText style={styles.title}>{item.title}</ThemedText>
@@ -122,7 +122,7 @@ export function OnboardingScreen() {
                         <View style={[styles.recordDot, { backgroundColor: theme.accent }]} />
                       </View>
                     ) : bullet.icon ? (
-                      <SymbolView name={bullet.icon} size={19} tintColor={theme.accent} />
+                      <Icon name={bullet.icon} size={19} tintColor={theme.accent} />
                     ) : (
                       <View style={[styles.bulletDot, { backgroundColor: theme.accent }]} />
                     )}

--- a/src/features/recorder/camera-controls.tsx
+++ b/src/features/recorder/camera-controls.tsx
@@ -1,5 +1,6 @@
 import { CameraType } from 'expo-camera';
-import { SymbolView, SymbolViewProps } from 'expo-symbols';
+import type { SymbolViewProps } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { Accent, Spacing } from '@/constants/theme';
@@ -102,7 +103,7 @@ function ControlButton({
       accessibilityLabel={label}
       style={({ pressed }) => [styles.wrap, { opacity: disabled ? 0.35 : pressed ? 0.7 : 1 }]}>
       <View style={styles.button}>
-        <SymbolView name={icon} size={24} weight="medium" tintColor={tint} />
+        <Icon name={icon} size={24} weight="medium" tintColor={tint} />
       </View>
       {caption && <Text style={[styles.caption, { color: tint }]}>{caption}</Text>}
     </Pressable>

--- a/src/features/recorder/close-button.tsx
+++ b/src/features/recorder/close-button.tsx
@@ -1,4 +1,4 @@
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { Pressable, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 
 import { closeToHome } from '@/utils/navigation';
@@ -17,7 +17,7 @@ export function CloseButton({
       accessibilityRole="button"
       accessibilityLabel="Close"
       style={[styles.button, style]}>
-      <SymbolView name="xmark" size={22} weight="semibold" tintColor="#fff" />
+      <Icon name="xmark" size={22} weight="semibold" tintColor="#fff" />
     </Pressable>
   );
 }

--- a/src/features/recorder/import-button.tsx
+++ b/src/features/recorder/import-button.tsx
@@ -1,4 +1,4 @@
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { Pressable, StyleSheet } from 'react-native';
 
 /**
@@ -15,7 +15,7 @@ export function ImportButton({ onPress, disabled }: { onPress: () => void; disab
       accessibilityRole="button"
       accessibilityLabel="Import video"
       style={({ pressed }) => [styles.button, { opacity: disabled ? 0.35 : pressed ? 0.7 : 1 }]}>
-      <SymbolView name="plus" size={24} weight="medium" tintColor="#000" />
+      <Icon name="plus" size={24} weight="medium" tintColor="#000" />
     </Pressable>
   );
 }

--- a/src/features/recorder/permission-gate.tsx
+++ b/src/features/recorder/permission-gate.tsx
@@ -1,4 +1,4 @@
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { Pressable, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -21,7 +21,7 @@ export function PermissionGate({
       <CloseButton
         style={{ position: 'absolute', top: insets.top + Spacing.two, left: Spacing.four }}
       />
-      <SymbolView name="camera.fill" size={48} tintColor={Accent} />
+      <Icon name="camera.fill" size={48} tintColor={Accent} />
       <ThemedText style={styles.title}>Camera access needed</ThemedText>
       <ThemedText themeColor="textSecondary" style={styles.body}>
         Pulse records video with your camera and microphone.

--- a/src/features/recorder/preview-modal.tsx
+++ b/src/features/recorder/preview-modal.tsx
@@ -1,4 +1,4 @@
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { VideoView, type VideoPlayer } from 'expo-video';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -56,7 +56,7 @@ export function PreviewModal({
         {!isPlaying && (
           <View style={styles.playOverlay} pointerEvents="none">
             <View style={styles.playBadge}>
-              <SymbolView name="play.fill" size={24} tintColor="#fff" />
+              <Icon name="play.fill" size={24} tintColor="#fff" />
             </View>
           </View>
         )}
@@ -68,7 +68,7 @@ export function PreviewModal({
         accessibilityRole="button"
         accessibilityLabel="Close preview"
         style={[styles.badge, styles.close]}>
-        <SymbolView name="xmark" size={14} weight="semibold" tintColor="#fff" />
+        <Icon name="xmark" size={14} weight="semibold" tintColor="#fff" />
       </Pressable>
 
       <Pressable
@@ -77,7 +77,7 @@ export function PreviewModal({
         accessibilityRole="button"
         accessibilityLabel="Edit clip"
         style={[styles.badge, styles.trim]}>
-        <SymbolView name="scissors" size={16} weight="semibold" tintColor="#fff" />
+        <Icon name="scissors" size={16} weight="semibold" tintColor="#fff" />
       </Pressable>
 
       <Pressable
@@ -86,7 +86,7 @@ export function PreviewModal({
         accessibilityRole="button"
         accessibilityLabel="Delete clip"
         style={[styles.badge, styles.delete]}>
-        <SymbolView name="trash" size={16} weight="semibold" tintColor="#fff" />
+        <Icon name="trash" size={16} weight="semibold" tintColor="#fff" />
       </Pressable>
 
       <Pressable
@@ -95,7 +95,7 @@ export function PreviewModal({
         accessibilityRole="button"
         accessibilityLabel="Edit captions"
         style={[styles.badge, styles.captions]}>
-        <SymbolView name="captions.bubble" size={16} weight="semibold" tintColor="#fff" />
+        <Icon name="captions.bubble" size={16} weight="semibold" tintColor="#fff" />
       </Pressable>
 
       {/* Animated word-level captions over the video (Skia). Renders nothing until a line is

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -3,7 +3,7 @@
 // immutability/refs rules flag. Disabled for this file, as in use-preview/playhead-cursor.
 /* eslint-disable react-hooks/immutability */
 import { Image } from 'expo-image';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import { useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
@@ -133,7 +133,7 @@ function Bar({
             never intercepts touches; it's purely a drop zone hit-tested from the drag position. */}
         <View style={styles.trashWrap} pointerEvents="none">
           <Animated.View ref={trashRef} onLayout={measureTrash} style={[styles.trash, trashStyle]}>
-            <SymbolView name="trash.fill" size={22} tintColor="#fff" />
+            <Icon name="trash.fill" size={22} tintColor="#fff" />
           </Animated.View>
         </View>
 
@@ -233,7 +233,7 @@ function Bar({
             accessibilityRole="button"
             accessibilityLabel="Next"
             style={({ pressed }) => [styles.next, { opacity: pressed ? 0.85 : 1 }]}>
-            <SymbolView name="arrow.right" size={22} weight="semibold" tintColor="#fff" />
+            <Icon name="arrow.right" size={22} weight="semibold" tintColor="#fff" />
           </Pressable>
         )}
       </View>
@@ -283,7 +283,7 @@ function SegmentThumb({
         {thumbnail ? (
           <Image source={thumbnail} style={styles.thumbImage} contentFit="cover" />
         ) : (
-          <SymbolView name="video.fill" size={18} tintColor="rgba(255,255,255,0.8)" />
+          <Icon name="video.fill" size={18} tintColor="rgba(255,255,255,0.8)" />
         )}
       </Sortable.Touchable>
 

--- a/src/features/transcription/model-switcher-modal.tsx
+++ b/src/features/transcription/model-switcher-modal.tsx
@@ -1,5 +1,5 @@
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
-import { SymbolView } from 'expo-symbols';
+import { Icon } from '@/components/icon';
 import {
   ActivityIndicator,
   Alert,
@@ -102,7 +102,7 @@ export function ModelSwitcherModal({
               </ThemedText>
             </View>
             <Pressable onPress={onClose} hitSlop={8} accessibilityLabel="Close">
-              <SymbolView name="xmark.circle.fill" size={28} tintColor={theme.textSecondary} />
+              <Icon name="xmark.circle.fill" size={28} tintColor={theme.textSecondary} />
             </Pressable>
           </View>
 
@@ -117,7 +117,7 @@ export function ModelSwitcherModal({
 
           {/* First (and currently only) feature. Future on-device features slot in as new sections. */}
           <View style={styles.section}>
-            <SymbolView
+            <Icon
               name="captions.bubble.fill"
               size={18}
               tintColor={selectedId ? theme.accent : theme.textSecondary}
@@ -154,7 +154,7 @@ export function ModelSwitcherModal({
                     </ThemedText>
                   </View>
                   {active && (
-                    <SymbolView name="checkmark.circle.fill" size={24} tintColor={theme.accent} />
+                    <Icon name="checkmark.circle.fill" size={24} tintColor={theme.accent} />
                   )}
                 </Pressable>
               );
@@ -170,7 +170,7 @@ export function ModelSwitcherModal({
               hitSlop={8}
               accessibilityRole="button"
               style={styles.delete}>
-              <SymbolView name="trash" size={16} tintColor={theme.accent} />
+              <Icon name="trash" size={16} tintColor={theme.accent} />
               <ThemedText type="small" themeColor="accent" style={styles.deleteText}>
                 Remove model & free up space
               </ThemedText>


### PR DESCRIPTION
## Problem
Every icon in the app rendered **blank on Android**. The whole UI used `SymbolView` from `expo-symbols`, which draws Apple **SF Symbols** — an iOS-only technology with no Android equivalent. All 48 icon usages showed nothing on Android.

## Fix
- Add [`src/components/icon.tsx`](src/components/icon.tsx): a cross-platform `<Icon>` that renders the native `SymbolView` on **iOS** (pixel-identical to before) and the closest mapped **`lucide-react-native`** glyph on **Android**. It forwards `size`/`tintColor`/`style` and approximates SF weight → Lucide `strokeWidth`, with a dev warning + fallback for any unmapped name.
- Migrate all **48 `SymbolView` usages across 14 files** to `<Icon>` (drop-in; type-only `SymbolViewProps` imports stayed).
- Map all 37 distinct SF names in use (e.g. `play.fill`→Play, `square.and.arrow.up`→Share, `trash`→Trash2, `arrow.triangle.2.circlepath.camera`→SwitchCamera).
- Use a distinct, AI-coded `wand.and.stars` → `WandSparkles` glyph for the AI **Model** button (both platforms).

## Verification
- `tsc --noEmit`: 0 errors
- Android: clean build, installed and launched on emulator — icons render correctly (Import, Model wand, empty-state camera, record button all visible).

## Notes
- Lucide icons are outline-style, so SF `.fill` glyphs render as outlines on Android (not solid). Can selectively fill specific ones if desired.