### PR TITLE
fix(android): bring recorder + export to parity with iOS

### DIFF
--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -1,7 +1,7 @@
 import { CameraView } from 'expo-camera';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
-import { Alert, StyleSheet, Text, View } from 'react-native';
+import { Alert, Platform, StyleSheet, Text, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -142,23 +142,34 @@ export default function RecorderScreen() {
   // Hold the camera until persisted prefs load, so the first frame uses the saved facing.
   if (!prefsReady) return <ThemedView style={styles.fill} />;
 
+  // The camera should be live only when recording is possible: not while a clip preview is
+  // open and not while the Export screen covers the recorder. iOS honors `active={false}` to
+  // pause the session in place; Android's `active` prop is a no-op (it's iOS-only in
+  // expo-camera), so there we unmount the CameraView entirely to actually drop the session
+  // (torch/indicator off, no battery drain). Recording is never in flight when inactive, so
+  // unmounting is safe; `useRecorder`'s unmount effect is the stop backstop regardless.
+  const cameraActive = !previewing && focused;
+  const renderCamera = Platform.OS === 'ios' || cameraActive;
+
   return (
     <View style={styles.fill}>
-      <CameraView
-        ref={cameraRef}
-        style={StyleSheet.absoluteFill}
-        active={!previewing && focused}
-        mode="video"
-        videoQuality="1080p"
-        facing={facing}
-        enableTorch={torch && !previewing}
-        videoStabilizationMode={stabilization}
-        mute={muted}
-        selectedLens={lens}
-        autofocus="on"
-        zoom={zoom}
-        onCameraReady={onCameraReady}
-      />
+      {renderCamera && (
+        <CameraView
+          ref={cameraRef}
+          style={StyleSheet.absoluteFill}
+          active={cameraActive}
+          mode="video"
+          videoQuality="1080p"
+          facing={facing}
+          enableTorch={torch && !previewing}
+          videoStabilizationMode={stabilization}
+          mute={muted}
+          selectedLens={lens}
+          autofocus="on"
+          zoom={zoom}
+          onCameraReady={onCameraReady}
+        />
+      )}
 
       {/* Pinch-to-zoom surface. CameraView can't take children, so this sits between it and
           the overlay; the overlay is box-none, so touches that miss a control land here.

--- a/src/features/recorder/use-recorder-gestures.ts
+++ b/src/features/recorder/use-recorder-gestures.ts
@@ -2,6 +2,7 @@
 // same situation the React-Compiler rules flag in playhead-cursor.tsx.
 /* eslint-disable react-hooks/immutability, react-hooks/refs */
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { Platform } from 'react-native';
 import { Gesture } from 'react-native-gesture-handler';
 import { runOnJS, useSharedValue } from 'react-native-reanimated';
 
@@ -10,9 +11,13 @@ const HOLD_MS = 250;
 /** Granularity of React zoom commits — zoom tracks gestures per-frame in a shared value,
  * but CameraView only re-renders when the quantized value changes (≤200 steps full-range). */
 const ZOOM_QUANTUM = 0.005;
-/** expo-camera's 0–1 zoom spans the device's ENTIRE digital range (~100x+ on recent
- * iPhones, mapped exponentially) — the upper half is unusable digital mush, so cap there. */
-const MAX_ZOOM = 0.5;
+/** Max of expo-camera's 0–1 zoom prop we allow.
+ * iOS maps 0–1 exponentially across the device's ENTIRE digital range (~100x+ on recent
+ * iPhones) — the upper half is unusable digital mush, so cap at 0.5. Android maps 0–1
+ * roughly linearly across the device's supported zoom ratio, so the full range is usable.
+ * The drag/pinch feel (DRAG_FULL_RANGE_PX, PINCH_RANGE below) was tuned to iOS's curve and
+ * still wants an on-device tuning pass on Android. */
+const MAX_ZOOM = Platform.select({ ios: 0.5, default: 1 });
 /** Vertical drag distance (px) spanning the full 0→1 zoom prop range (so roughly one
  * screen height of drag to hit MAX_ZOOM). */
 const DRAG_FULL_RANGE_PX = 800;

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -3,7 +3,7 @@ import { CameraType, CameraView } from 'expo-camera';
 import { launchImageLibraryAsync, VideoExportPreset } from 'expo-image-picker';
 import { usePermissions } from 'expo-media-library';
 import { useEffect, useRef, useState } from 'react';
-import { Alert, Linking } from 'react-native';
+import { Alert, Linking, Platform } from 'react-native';
 import { isValidFile } from 'react-native-video-trim';
 
 import {
@@ -155,12 +155,19 @@ export function useRecorder(initialDraftId?: string) {
     setRecordStartedAt(Date.now());
     setIsRecording(true);
     try {
-      // Pinned capture format (with videoQuality="1080p" on CameraView): HEVC 1080p. Every
-      // segment a device records is format-identical to the rest of the draft, so export
+      // Pinned capture format (with videoQuality="1080p" on CameraView): HEVC 1080p on iOS.
+      // Every segment a device records is format-identical to the rest of the draft, so export
       // always hits the merge engine's zero-re-encode passthrough path — and clips recorded
       // on different devices stay mergeable with each other too. Keep in sync with the
       // selective-merge majority expectations in the RNVT fork.
-      const video = await cameraRef.current.recordAsync({ codec: 'hvc1' });
+      //
+      // `codec` is iOS-only in expo-camera (per the v56 docs); Android records its device
+      // default (typically H.264). Per-device uniformity still holds (same device ⇒ same
+      // format ⇒ fast path on iOS / clean re-encode on Android); cross-platform drafts are
+      // handled by the merge engine's selective path by design.
+      const video = await cameraRef.current.recordAsync(
+        Platform.OS === 'ios' ? { codec: 'hvc1' } : {},
+      );
       if (!video?.uri) return;
 
       let id = draftId;


### PR DESCRIPTION
## Context
The RNVT fork's recent work (AVFoundation passthrough engine, 3-path merge, result flags) landed **iOS-only**, and several app-side assumptions were only ever validated on iOS. On Android the export **merge crashed/produced wrong output** and a few camera behaviors silently diverged. This brings Android to functional + visual parity. Companion fork bump: `morepriyam/react-native-video-trim@d815b06`.

## Changes
**RNVT fork (submodule → d815b06):**
- **Crash fix** — headless `merge()`/`trim()`/`extractAudio()` reached `VideoTrimmerUtil` without the editor's `BaseUtils.init()`, throwing `ExceptionInInitializerError` and failing every export. Init once in the module constructor.
- **Audio-safe concat** — concat hard-mapped `[i:a:0]` on every input, so a muted/silent clip failed the whole merge. Synthesize a silent mono/48k track for audio-less inputs (drop audio if all silent); normalize via `aformat`.
- **Orientation** — target dims came from `MediaMetadataRetriever`, which returns coded dims + rotation=0 for Display-Matrix-rotated files → portrait clips pillarboxed into a landscape canvas. Probe display geometry with **FFprobe** (same engine that scales).
- **Dominant-format target** — was the first clip's size (a landscape clip in slot 0 turned the whole export landscape); now the most-frequent display geometry, matching iOS.
- **Result-shape parity** — emit `usedPassthrough`/`usedFastPath`/`selective=false`.

**App-side (`Platform.OS` guards for iOS-only `CameraView` APIs):**
- `use-recorder`: gate `recordAsync({ codec: 'hvc1' })` to iOS (codec is iOS-only; Android records its H.264 default).
- `recorder`: `active` prop is iOS-only → on Android unmount `CameraView` when previewing/unfocused to actually drop the session.
- `use-recorder-gestures`: zoom cap via `Platform.select` (iOS 0.5 exponential, Android 1.0 linear).

## Testing
Built + ran on a Pixel_7 emulator:
- **All 3 dev samples export** → correct 1080×1920 portrait, aac mono, right durations, landscape outliers letterboxed upright.
- Dominant-format target confirmed via FFprobe probe logs.
- **Save to Photos** (MediaStore) and **Share** (FileProvider chooser) work, no crash.
- Editor opens/renders with upright thumbnails and emits correct transform commands; rotate/flip/speed output validated on host.
- Crash fix confirmed: `extractAudio` (captions), `getFrameAt` (thumbnails), `merge` all run.

## Still needs a physical device (emulator can't)
- Recording (`recordAsync`) — emulator camera returns `ERROR_NO_VALID_DATA`.
- Editor **Save** round-trip — emulator's software codec stalls the re-encode (player/encoder contention).
- Muted-clip merge end-to-end (silent-synthesis path; host-verified).