### PR TITLE
feat(recorder): handle phone calls and app-exit during recording

### DIFF
--- a/modules/expo-call-detector/android/build.gradle
+++ b/modules/expo-call-detector/android/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'expo.modules.calldetector'
+version = '0.1.0'
+
+android {
+  namespace "expo.modules.calldetector"
+  defaultConfig {
+    versionCode 1
+    versionName "0.1.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+}

--- a/modules/expo-call-detector/android/src/main/AndroidManifest.xml
+++ b/modules/expo-call-detector/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/expo-call-detector/android/src/main/java/expo/modules/calldetector/CallDetectorModule.kt
+++ b/modules/expo-call-detector/android/src/main/java/expo/modules/calldetector/CallDetectorModule.kt
@@ -1,0 +1,28 @@
+package expo.modules.calldetector
+
+import androidx.core.os.bundleOf
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+// Android stub: call detection is not implemented here yet (the equivalent is TelephonyManager /
+// TelephonyCallback, which needs the READ_PHONE_STATE permission). It reports "no call" so the
+// recorder behaves exactly as before on Android — the mic just isn't auto-dropped during a call
+// yet. iOS (CallKit) is the implemented platform; wire this up when Android needs the behaviour.
+class CallDetectorModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("CallDetector")
+
+    Events("onCallStateChange")
+
+    Function("isCallActive") { false }
+
+    // No-op on Android (no UIBackgroundTask equivalent; background capture is a separate concern).
+    // Return a sentinel id; endBackgroundTask ignores it.
+    Function("beginBackgroundTask") { -1 }
+    Function("endBackgroundTask") { _: Int -> }
+
+    OnStartObserving {
+      sendEvent("onCallStateChange", bundleOf("isActive" to false))
+    }
+  }
+}

--- a/modules/expo-call-detector/expo-module.config.json
+++ b/modules/expo-call-detector/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["CallDetectorModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.calldetector.CallDetectorModule"]
+  }
+}

--- a/modules/expo-call-detector/ios/CallDetector.podspec
+++ b/modules/expo-call-detector/ios/CallDetector.podspec
@@ -5,9 +5,9 @@ Pod::Spec.new do |s|
   s.description    = 'Local Expo module: reports active-call state so the recorder can drop the mic during calls, plus iOS background-task helpers to finalize a clip when backgrounded.'
   s.author         = 'Pulse'
   s.homepage       = 'https://docs.expo.dev/modules/'
+  # iOS only: CallKit's CXCallObserver and UIApplication background tasks aren't on the tvOS SDK.
   s.platforms      = {
-    :ios => '16.4',
-    :tvos => '16.4'
+    :ios => '16.4'
   }
   s.source         = { git: '' }
   s.static_framework = true

--- a/modules/expo-call-detector/ios/CallDetector.podspec
+++ b/modules/expo-call-detector/ios/CallDetector.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |s|
+  s.name           = 'CallDetector'
+  s.version        = '1.0.0'
+  s.summary        = 'Phone/VoIP call detection (CXCallObserver) + background-task helpers'
+  s.description    = 'Local Expo module: reports active-call state so the recorder can drop the mic during calls, plus iOS background-task helpers to finalize a clip when backgrounded.'
+  s.author         = 'Pulse'
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platforms      = {
+    :ios => '16.4',
+    :tvos => '16.4'
+  }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/modules/expo-call-detector/ios/CallDetectorModule.swift
+++ b/modules/expo-call-detector/ios/CallDetectorModule.swift
@@ -15,23 +15,45 @@ final class CallObserverDelegate: NSObject, CXCallObserverDelegate {
 
 public class CallDetectorModule: Module {
   private let delegate = CallObserverDelegate()
-  // Created on first use; CXCallObserver holds its delegate weakly, so the module owns both.
-  private lazy var callObserver: CXCallObserver = {
-    let observer = CXCallObserver()
-    observer.setDelegate(self.delegate, queue: nil) // nil => deliver on the main queue
-    return observer
-  }()
+  // Created eagerly in OnCreate (NOT lazily): isCallActive() is a synchronous Function that runs on
+  // the JS thread, while OnStartObserving runs on the module thread — a lazy first-touch from both
+  // is an unsynchronized race that could construct two observers. CXCallObserver holds its delegate
+  // weakly, so the module owns both.
+  private var callObserver: CXCallObserver?
 
   // A call (ringing, dialing, or connected) holds the mic until it has ended. Telephony outranks
   // the app for the microphone, so any non-ended call means we must not capture audio.
   private var isCallActive: Bool {
-    callObserver.calls.contains { !$0.hasEnded }
+    callObserver?.calls.contains { !$0.hasEnded } ?? false
+  }
+
+  // Background tasks we've begun but not yet ended, guarded by a lock. iOS may fire a task's
+  // expiration handler before JS calls endBackgroundTask, so we track which ids are still live and
+  // end each exactly once — calling UIApplication.endBackgroundTask twice on the same id is an
+  // unbalanced end that iOS warns about.
+  private var activeTasks = Set<Int>()
+  private let tasksLock = NSLock()
+
+  private func endTask(_ rawId: Int) {
+    tasksLock.lock()
+    let wasActive = activeTasks.remove(rawId) != nil
+    tasksLock.unlock()
+    guard wasActive else { return }
+    let taskId = UIBackgroundTaskIdentifier(rawValue: rawId)
+    guard taskId != .invalid else { return }
+    UIApplication.shared.endBackgroundTask(taskId)
   }
 
   public func definition() -> ModuleDefinition {
     Name("CallDetector")
 
     Events("onCallStateChange")
+
+    OnCreate {
+      let observer = CXCallObserver()
+      observer.setDelegate(self.delegate, queue: nil) // nil => deliver on the main queue
+      self.callObserver = observer
+    }
 
     // Synchronous snapshot for the very first render, before any event has been delivered.
     Function("isCallActive") { () -> Bool in
@@ -45,16 +67,17 @@ public class CallDetectorModule: Module {
     Function("beginBackgroundTask") { () -> Int in
       var taskId: UIBackgroundTaskIdentifier = .invalid
       taskId = UIApplication.shared.beginBackgroundTask(withName: "PulseFinalizeRecording") {
-        UIApplication.shared.endBackgroundTask(taskId)
-        taskId = .invalid
+        self.endTask(taskId.rawValue)
       }
-      return taskId.rawValue
+      let rawId = taskId.rawValue
+      self.tasksLock.lock()
+      self.activeTasks.insert(rawId)
+      self.tasksLock.unlock()
+      return rawId
     }
 
     Function("endBackgroundTask") { (rawId: Int) in
-      let taskId = UIBackgroundTaskIdentifier(rawValue: rawId)
-      guard taskId != .invalid else { return }
-      UIApplication.shared.endBackgroundTask(taskId)
+      self.endTask(rawId)
     }
 
     OnStartObserving {
@@ -62,10 +85,8 @@ public class CallDetectorModule: Module {
         guard let self else { return }
         self.sendEvent("onCallStateChange", ["isActive": self.isCallActive])
       }
-      // Touch the lazy observer so it's created and its delegate attached, then emit the current
-      // state immediately — CXCallObserver only pushes future *changes*, so a call already in
-      // progress when the listener attaches would otherwise be missed.
-      _ = self.callObserver
+      // Emit the current state immediately — CXCallObserver only pushes future *changes*, so a call
+      // already in progress when the listener attaches would otherwise be missed.
       self.sendEvent("onCallStateChange", ["isActive": self.isCallActive])
     }
 

--- a/modules/expo-call-detector/ios/CallDetectorModule.swift
+++ b/modules/expo-call-detector/ios/CallDetectorModule.swift
@@ -1,0 +1,76 @@
+import CallKit
+import ExpoModulesCore
+import UIKit
+
+// CXCallObserver requires an NSObject delegate, which an Expo `Module` is not — so this thin
+// object holds the observer's delegate role and forwards every call-state change back to the
+// module through a closure.
+final class CallObserverDelegate: NSObject, CXCallObserverDelegate {
+  var onChange: (() -> Void)?
+
+  func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
+    onChange?()
+  }
+}
+
+public class CallDetectorModule: Module {
+  private let delegate = CallObserverDelegate()
+  // Created on first use; CXCallObserver holds its delegate weakly, so the module owns both.
+  private lazy var callObserver: CXCallObserver = {
+    let observer = CXCallObserver()
+    observer.setDelegate(self.delegate, queue: nil) // nil => deliver on the main queue
+    return observer
+  }()
+
+  // A call (ringing, dialing, or connected) holds the mic until it has ended. Telephony outranks
+  // the app for the microphone, so any non-ended call means we must not capture audio.
+  private var isCallActive: Bool {
+    callObserver.calls.contains { !$0.hasEnded }
+  }
+
+  public func definition() -> ModuleDefinition {
+    Name("CallDetector")
+
+    Events("onCallStateChange")
+
+    // Synchronous snapshot for the very first render, before any event has been delivered.
+    Function("isCallActive") { () -> Bool in
+      self.isCallActive
+    }
+
+    // Background-execution helpers so the recorder can finish writing a clip to disk after the app
+    // is backgrounded mid-recording — iOS otherwise suspends within ~5s and can truncate a large
+    // file copy. JS holds a task across the finalize+persist and ends it when done. Both are safe
+    // to call from any thread; the expiration handler ends the task if iOS runs out of patience.
+    Function("beginBackgroundTask") { () -> Int in
+      var taskId: UIBackgroundTaskIdentifier = .invalid
+      taskId = UIApplication.shared.beginBackgroundTask(withName: "PulseFinalizeRecording") {
+        UIApplication.shared.endBackgroundTask(taskId)
+        taskId = .invalid
+      }
+      return taskId.rawValue
+    }
+
+    Function("endBackgroundTask") { (rawId: Int) in
+      let taskId = UIBackgroundTaskIdentifier(rawValue: rawId)
+      guard taskId != .invalid else { return }
+      UIApplication.shared.endBackgroundTask(taskId)
+    }
+
+    OnStartObserving {
+      self.delegate.onChange = { [weak self] in
+        guard let self else { return }
+        self.sendEvent("onCallStateChange", ["isActive": self.isCallActive])
+      }
+      // Touch the lazy observer so it's created and its delegate attached, then emit the current
+      // state immediately — CXCallObserver only pushes future *changes*, so a call already in
+      // progress when the listener attaches would otherwise be missed.
+      _ = self.callObserver
+      self.sendEvent("onCallStateChange", ["isActive": self.isCallActive])
+    }
+
+    OnStopObserving {
+      self.delegate.onChange = nil
+    }
+  }
+}

--- a/modules/expo-call-detector/src/CallDetector.types.ts
+++ b/modules/expo-call-detector/src/CallDetector.types.ts
@@ -1,0 +1,8 @@
+export type CallStateChangePayload = {
+  /** True while a phone / VoIP call is active (ringing, dialing, or connected). */
+  isActive: boolean;
+};
+
+export type CallDetectorModuleEvents = {
+  onCallStateChange: (params: CallStateChangePayload) => void;
+};

--- a/modules/expo-call-detector/src/CallDetectorModule.ts
+++ b/modules/expo-call-detector/src/CallDetectorModule.ts
@@ -1,0 +1,15 @@
+import { NativeModule, requireNativeModule } from 'expo';
+
+import { CallDetectorModuleEvents } from './CallDetector.types';
+
+declare class CallDetectorModule extends NativeModule<CallDetectorModuleEvents> {
+  /** Synchronous snapshot of whether a call is active right now (for the first render). */
+  isCallActive(): boolean;
+  /** Start an iOS background task so work can continue briefly after backgrounding. Returns its id
+   * (pass to endBackgroundTask). No-op sentinel (-1) on Android/web. */
+  beginBackgroundTask(): number;
+  /** End a background task started with beginBackgroundTask. */
+  endBackgroundTask(taskId: number): void;
+}
+
+export default requireNativeModule<CallDetectorModule>('CallDetector');

--- a/modules/expo-call-detector/src/CallDetectorModule.web.ts
+++ b/modules/expo-call-detector/src/CallDetectorModule.web.ts
@@ -13,4 +13,6 @@ class CallDetectorModule extends NativeModule<CallDetectorModuleEvents> {
   endBackgroundTask(_taskId: number): void {}
 }
 
-export default registerWebModule(CallDetectorModule, 'CallDetectorModule');
+// Registered under 'CallDetector' to match Name("CallDetector") on native and the
+// requireNativeModule('CallDetector') lookup, so the name is consistent across platforms.
+export default registerWebModule(CallDetectorModule, 'CallDetector');

--- a/modules/expo-call-detector/src/CallDetectorModule.web.ts
+++ b/modules/expo-call-detector/src/CallDetectorModule.web.ts
@@ -1,0 +1,16 @@
+import { registerWebModule, NativeModule } from 'expo';
+
+import { CallDetectorModuleEvents } from './CallDetector.types';
+
+// No telephony on web — report "no call" so the recorder behaves normally.
+class CallDetectorModule extends NativeModule<CallDetectorModuleEvents> {
+  isCallActive(): boolean {
+    return false;
+  }
+  beginBackgroundTask(): number {
+    return -1;
+  }
+  endBackgroundTask(_taskId: number): void {}
+}
+
+export default registerWebModule(CallDetectorModule, 'CallDetectorModule');

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -158,8 +158,13 @@ export default function RecorderScreen() {
       const hay = `${String((e as { message?: unknown })?.message ?? '')} ${String(e)}`;
       if (!hay.includes('-11800') && !hay.includes('!pri') && !hay.includes('561017449')) return;
       reportMicPriorityError();
+      // Clustered errors must not let an earlier timer flip `recovering` off mid-bounce — restart it.
+      clearTimeout(recoverTimerRef.current ?? undefined);
       setRecovering(true);
-      recoverTimerRef.current = setTimeout(() => setRecovering(false), 150);
+      recoverTimerRef.current = setTimeout(() => {
+        recoverTimerRef.current = null;
+        setRecovering(false);
+      }, 150);
     },
     [reportMicPriorityError],
   );

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -38,6 +38,7 @@ import { setActiveDraft } from '@/features/transcription/active-draft';
 import { setRecordingActive } from '@/features/transcription/recording-signal';
 import { useDraftTranscripts } from '@/features/transcription/use-draft-transcripts';
 import { formatDurationPadded } from '@/utils/format';
+import { closeToHome } from '@/utils/navigation';
 
 // Ask for the full multi-camera device on the back so 0.5x / 1x / Tele are all reachable via
 // zoom; the front falls back to its single wide lens automatically.
@@ -67,8 +68,11 @@ export default function RecorderScreen() {
     torch,
     stabilization,
     muted,
+    callActive,
+    appActive,
     onCameraReady,
     toggleRecording,
+    finalizeRecording,
     importClip,
     startHoldRecording,
     endHoldRecording,
@@ -128,12 +132,13 @@ export default function RecorderScreen() {
   // Audio focus: while the recorder is on screen capturing with a live mic, pause other apps'
   // audio (Spotify / podcasts) rather than mixing it in; restore on leave or mute. Gated on the
   // mic being live — a muted clip has no audio track, so there's nothing to seize focus for.
-  // Tied to screen focus (not per segment) to avoid toggling the session mid-draft.
+  // Also released while a call is active: we must yield the audio session to telephony, not fight
+  // it for focus. Tied to screen focus (not per segment) to avoid toggling the session mid-draft.
   const audioFocus = useAudioFocus();
   useEffect(() => {
-    if (focused && !muted && prefsReady) void audioFocus.acquire();
+    if (focused && appActive && !muted && !callActive && prefsReady) void audioFocus.acquire();
     else void audioFocus.release();
-  }, [focused, muted, prefsReady, audioFocus]);
+  }, [focused, appActive, muted, callActive, prefsReady, audioFocus]);
   useEffect(() => () => void audioFocus.release(), [audioFocus]);
 
   const device = useCameraDevice(facing, { physicalDevices: PHYSICAL_DEVICES });
@@ -233,7 +238,17 @@ export default function RecorderScreen() {
   // session in place on BOTH platforms (no Android unmount dance needed), dropping torch and
   // battery drain. Recording is never in flight when inactive; useRecorder's unmount effect is
   // the stop backstop regardless.
-  const cameraActive = !previewing && focused;
+  // Stop the session while backgrounded too (not just on preview / screen blur): iOS would
+  // otherwise auto-resume the capture session on foreground with the mic still attached — straight
+  // into a call that started in the background (the -11800 freeze). Restarting only once
+  // `appActive` is true lets call detection re-poll first, so the mic isn't resumed into a call.
+  // `|| isRecording` keeps the session alive while a clip is being finalized on background, so the
+  // segment saves before we explicitly tear the session down.
+  const cameraActive = !previewing && focused && (appActive || isRecording);
+
+  // Close: finalize any in-flight clip (saving it into the draft) before navigating home, so the
+  // segment isn't lost when the camera unmounts.
+  const handleClose = () => void finalizeRecording().then(closeToHome);
 
   return (
     <View style={styles.fill}>
@@ -272,7 +287,7 @@ export default function RecorderScreen() {
             styles.topBar,
             { paddingTop: insets.top + Spacing.two, paddingHorizontal: Spacing.three },
           ]}>
-          <CloseButton />
+          <CloseButton onPress={handleClose} />
           <Text style={styles.timerText}>{formatDurationPadded(totalMs)}</Text>
           {/* Mirrors the CloseButton's width so the timer stays optically centered. */}
           <View style={styles.topBarSpacer} />
@@ -283,7 +298,11 @@ export default function RecorderScreen() {
           torch={torch}
           stabilization={stabilization}
           muted={muted}
-          disabled={previewing}
+          callActive={callActive}
+          // Lock every camera control while a clip is recording — flip / torch / stabilization /
+          // mute can't change mid-clip (audio state is fixed at record start, and the others would
+          // disrupt or stop capture). Mirrors the lens selector, which is already locked here.
+          disabled={previewing || isRecording}
           onFlip={flipCamera}
           onToggleTorch={toggleTorch}
           onCycleStabilization={cycleStabilization}

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -1,5 +1,5 @@
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 import Animated, { runOnJS, useAnimatedReaction } from 'react-native-reanimated';
@@ -70,6 +70,7 @@ export default function RecorderScreen() {
     muted,
     callActive,
     appActive,
+    reportMicPriorityError,
     onCameraReady,
     toggleRecording,
     finalizeRecording,
@@ -140,6 +141,28 @@ export default function RecorderScreen() {
     else void audioFocus.release();
   }, [focused, appActive, muted, callActive, prefsReady, audioFocus]);
   useEffect(() => () => void audioFocus.release(), [audioFocus]);
+
+  // Prediction can lose a race: on a cold-open / resume into an in-progress call the call snapshot
+  // can read stale, the mic attaches, and AVFoundation throws -11800 / '!pri' — which leaves the
+  // capture session FROZEN (it doesn't self-recover). So we react to the error directly: drop the
+  // mic (reportMicPriorityError rebuilds the output video-only) AND bounce the session off→on for a
+  // tick to force a clean restart out of the failed state. `recovering` drives the bounce.
+  const [recovering, setRecovering] = useState(false);
+  const recoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => clearTimeout(recoverTimerRef.current ?? undefined), []);
+  const onCameraError = useCallback(
+    (e: unknown) => {
+      console.error('[Camera]', e);
+      // VisionCamera wraps the native error; the AVFoundation domain/code and '!pri' four-char code
+      // survive in the stringified message, so match on those rather than a brittle wrapper code.
+      const hay = `${String((e as { message?: unknown })?.message ?? '')} ${String(e)}`;
+      if (!hay.includes('-11800') && !hay.includes('!pri') && !hay.includes('561017449')) return;
+      reportMicPriorityError();
+      setRecovering(true);
+      recoverTimerRef.current = setTimeout(() => setRecovering(false), 150);
+    },
+    [reportMicPriorityError],
+  );
 
   const device = useCameraDevice(facing, { physicalDevices: PHYSICAL_DEVICES });
 
@@ -244,7 +267,8 @@ export default function RecorderScreen() {
   // `appActive` is true lets call detection re-poll first, so the mic isn't resumed into a call.
   // `|| isRecording` keeps the session alive while a clip is being finalized on background, so the
   // segment saves before we explicitly tear the session down.
-  const cameraActive = !previewing && focused && (appActive || isRecording);
+  // `!recovering` drops the session for one bounce after a mic-priority error so it rebuilds cleanly.
+  const cameraActive = !previewing && focused && (appActive || isRecording) && !recovering;
 
   // Close: finalize any in-flight clip (saving it into the draft) before navigating home, so the
   // segment isn't lost when the camera unmounts.
@@ -267,7 +291,7 @@ export default function RecorderScreen() {
           // device support so it never throws; tap-to-focus stays snappy via `responsiveness`.
           enableSmoothAutoFocus={device?.supportsSmoothAutoFocus ?? false}
           onStarted={onCameraReady}
-          onError={(e) => console.error('[Camera]', e)}
+          onError={onCameraError}
         />
       )}
 

--- a/src/features/recorder/camera-controls.tsx
+++ b/src/features/recorder/camera-controls.tsx
@@ -26,6 +26,8 @@ type Props = {
   torch: boolean;
   stabilization: StabilizationMode;
   muted: boolean;
+  // A phone call holds the mic — audio is forced off and the toggle is locked while it lasts.
+  callActive?: boolean;
   disabled?: boolean;
   onFlip: () => void;
   onToggleTorch: () => void;
@@ -38,6 +40,7 @@ export function CameraControls({
   torch,
   stabilization,
   muted,
+  callActive = false,
   disabled = false,
   onFlip,
   onToggleTorch,
@@ -68,10 +71,19 @@ export function CameraControls({
         onPress={onCycleStabilization}
       />
       <ControlButton
-        icon={muted ? 'mic.slash.fill' : 'mic.fill'}
-        label={muted ? 'Unmute recording audio' : 'Mute recording audio'}
-        tint={muted ? Accent : '#fff'}
-        disabled={disabled}
+        icon={muted || callActive ? 'mic.slash.fill' : 'mic.fill'}
+        label={
+          callActive
+            ? 'Microphone unavailable during a call'
+            : muted
+              ? 'Unmute recording audio'
+              : 'Mute recording audio'
+        }
+        // Surface WHY the mic is off during a call so it doesn't look like a bug; the toggle is
+        // locked because the OS, not the user, owns the mic while telephony has it.
+        caption={callActive ? 'On call' : undefined}
+        tint={muted || callActive ? Accent : '#fff'}
+        disabled={disabled || callActive}
         onPress={onToggleMute}
       />
     </View>

--- a/src/features/recorder/use-call-state.ts
+++ b/src/features/recorder/use-call-state.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { AppState } from 'react-native';
+
+import CallDetector from '../../../modules/expo-call-detector/src/CallDetectorModule';
+
+/**
+ * Tracks whether a phone / VoIP call is active and whether the app is foregrounded — both gate the
+ * recorder's mic. iOS gives telephony top priority for the microphone, so capturing with the mic
+ * live during a call throws the AVFoundation -11800 / '!pri' error that freezes the capture session.
+ *
+ * Two signals, ONE AppState listener so they always update in the same render:
+ *  - callActive: live from CallKit's CXCallObserver (our local expo-call-detector module). The
+ *    native delegate does NOT fire while the app is suspended, so a call that *starts* while the
+ *    app is backgrounded is invisible until resume — we therefore re-poll the live state on
+ *    foreground (isCallActive() reads CXCallObserver.calls directly).
+ *  - appActive: false while backgrounded. VisionCamera has no lifecycle handling of its own, so
+ *    iOS auto-resumes the capture session on foreground with the mic still attached — straight into
+ *    a call that began in the background. The recorder stops the session while backgrounded (via
+ *    `isActive`) and only restarts it once foreground, by which point callActive has been re-polled,
+ *    so the mic is never resumed into an in-progress call.
+ */
+export function useCallState() {
+  const [callActive, setCallActive] = useState(() => CallDetector.isCallActive());
+  const [appActive, setAppActive] = useState(() => AppState.currentState === 'active');
+
+  useEffect(() => {
+    const callSub = CallDetector.addListener('onCallStateChange', ({ isActive }) =>
+      setCallActive(isActive),
+    );
+    const appSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        // Re-poll on resume: a call that began while the app was suspended delivered no event.
+        // Set both together so the render that restarts the camera already knows about the call.
+        setCallActive(CallDetector.isCallActive());
+        setAppActive(true);
+      } else if (state === 'background') {
+        setAppActive(false);
+      }
+      // 'inactive' is left untouched — it fires for transient overlays (Control Center, the call
+      // banner) where we don't want to tear the session down.
+    });
+    return () => {
+      callSub.remove();
+      appSub.remove();
+    };
+  }, []);
+
+  return { callActive, appActive };
+}

--- a/src/features/recorder/use-call-state.ts
+++ b/src/features/recorder/use-call-state.ts
@@ -8,7 +8,7 @@ import CallDetector from '../../../modules/expo-call-detector/src/CallDetectorMo
  * recorder's mic. iOS gives telephony top priority for the microphone, so capturing with the mic
  * live during a call throws the AVFoundation -11800 / '!pri' error that freezes the capture session.
  *
- * Two signals, ONE AppState listener so they always update in the same render:
+ * Signals:
  *  - callActive: live from CallKit's CXCallObserver (our local expo-call-detector module). The
  *    native delegate does NOT fire while the app is suspended, so a call that *starts* while the
  *    app is backgrounded is invisible until resume — we therefore re-poll the live state on
@@ -18,20 +18,31 @@ import CallDetector from '../../../modules/expo-call-detector/src/CallDetectorMo
  *    a call that began in the background. The recorder stops the session while backgrounded (via
  *    `isActive`) and only restarts it once foreground, by which point callActive has been re-polled,
  *    so the mic is never resumed into an in-progress call.
+ *  - micBlocked: the prediction above can still lose a race — on a cold-open / resume into an
+ *    *in-progress* call, CXCallObserver.calls may not have synced on the first foreground frame, so
+ *    the snapshot reads "no call" and the mic attaches → -11800. We can't out-predict the OS here,
+ *    so we react to ground truth: when the capture session reports the '!pri' error (see
+ *    reportMicPriorityError), force the mic off until the next authoritative call-state event proves
+ *    it safe. That event fires reliably when the call ends, and an isActive=true correction keeps
+ *    the mic gated anyway — so clearing on ANY event is safe.
  */
 export function useCallState() {
-  const [callActive, setCallActive] = useState(() => CallDetector.isCallActive());
+  const [rawCallActive, setRawCallActive] = useState(() => CallDetector.isCallActive());
   const [appActive, setAppActive] = useState(() => AppState.currentState === 'active');
+  const [micBlocked, setMicBlocked] = useState(false);
 
   useEffect(() => {
-    const callSub = CallDetector.addListener('onCallStateChange', ({ isActive }) =>
-      setCallActive(isActive),
-    );
+    const callSub = CallDetector.addListener('onCallStateChange', ({ isActive }) => {
+      setRawCallActive(isActive);
+      // Any authoritative event supersedes the error override: a still-up call (isActive=true) keeps
+      // the mic gated through rawCallActive; a call that ended (isActive=false) makes audio safe.
+      setMicBlocked(false);
+    });
     const appSub = AppState.addEventListener('change', (state) => {
       if (state === 'active') {
         // Re-poll on resume: a call that began while the app was suspended delivered no event.
         // Set both together so the render that restarts the camera already knows about the call.
-        setCallActive(CallDetector.isCallActive());
+        setRawCallActive(CallDetector.isCallActive());
         setAppActive(true);
       } else if (state === 'background') {
         setAppActive(false);
@@ -45,5 +56,11 @@ export function useCallState() {
     };
   }, []);
 
-  return { callActive, appActive };
+  return {
+    // A mic-priority error means telephony owns the mic right now, regardless of what the snapshot
+    // predicted — treat it as an active call so the mic is dropped and stays dropped.
+    callActive: rawCallActive || micBlocked,
+    appActive,
+    reportMicPriorityError: () => setMicBlocked(true),
+  };
 }

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -64,7 +64,7 @@ export function useRecorder(initialDraftId?: string) {
   // we drop the mic for the call's duration (see enableAudio). appActive: false while backgrounded —
   // the camera session is stopped then (see cameraActive in recorder.tsx) so iOS can't auto-resume
   // the mic into a call that began in the background.
-  const { callActive, appActive } = useCallState();
+  const { callActive, appActive, reportMicPriorityError } = useCallState();
 
   // The mic config the session SHOULD have. `cameraReady` gates it so a cold open comes up
   // video-only first (call detection lands before the mic is ever requested); dropped while a call
@@ -427,6 +427,7 @@ export function useRecorder(initialDraftId?: string) {
     muted,
     callActive,
     appActive,
+    reportMicPriorityError,
     onCameraReady: () => setCameraReady(true),
     toggleRecording,
     finalizeRecording,

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -346,6 +346,10 @@ export function useRecorder(initialDraftId?: string) {
         durationMs,
         thumbnail: ok ? thumbRel : null,
       });
+      // Same as the recording path: reflect the new segment synchronously so a close/unmount that
+      // races the live query can't see an "empty" draft and delete the just-imported clip.
+      everHadSegments.current = true;
+      segmentCount.current = Math.max(segmentCount.current, 1);
     } catch (e) {
       Alert.alert('Import failed', e instanceof Error ? e.message : 'Could not import the video.');
     }

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -2,7 +2,7 @@ import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { launchImageLibraryAsync, VideoExportPreset } from 'expo-image-picker';
 import { usePermissions } from 'expo-media-library';
 import { useEffect, useRef, useState } from 'react';
-import { Alert, Linking } from 'react-native';
+import { Alert, AppState, Linking } from 'react-native';
 import { isValidFile } from 'react-native-video-trim';
 import {
   type CameraRef,
@@ -28,6 +28,9 @@ import {
 } from '@/db/settings';
 import { absolutize, copyIntoSegments, persistRecording, thumbRelPath } from '@/utils/file-store';
 import { generateThumbnailFile, getDurationMs } from '@/utils/video';
+
+import CallDetector from '../../../modules/expo-call-detector/src/CallDetectorModule';
+import { useCallState } from './use-call-state';
 
 export const STABILIZATION_MODES = ['off', 'standard', 'cinematic', 'auto'] as const;
 export type StabilizationMode = (typeof STABILIZATION_MODES)[number];
@@ -56,15 +59,32 @@ export function useRecorder(initialDraftId?: string) {
   // camera render until then so the first frame uses the saved facing (no back→front flash).
   const [prefsReady, setPrefsReady] = useState(false);
 
-  // VisionCamera records to a file via a per-recording `Recorder` created from this output.
-  // The output is also handed to `<Camera outputs={[videoOutput]}>` in recorder.tsx. Disabling
-  // audio when muted recreates the output (drops the mic from the session) — a clip with no
-  // audio track is what `mute` meant under expo-camera. Pinned to 1080p; the HEVC codec is
-  // pinned per-recording via setOutputSettings (iOS) so every clip stays format-uniform and
-  // exports on the merge engine's zero-re-encode fast path.
+  // callActive: a phone / VoIP call holds the mic — telephony outranks us for the microphone, so
+  // capturing with it live throws the AVFoundation -11800 / '!pri' error that froze the session, so
+  // we drop the mic for the call's duration (see enableAudio). appActive: false while backgrounded —
+  // the camera session is stopped then (see cameraActive in recorder.tsx) so iOS can't auto-resume
+  // the mic into a call that began in the background.
+  const { callActive, appActive } = useCallState();
+
+  // The mic config the session SHOULD have. `cameraReady` gates it so a cold open comes up
+  // video-only first (call detection lands before the mic is ever requested); dropped while a call
+  // holds the mic (`callActive`) or the user muted, so that clip has no audio track.
+  const micWanted = cameraReady && !muted && !callActive;
+  // Freeze the mic config for the duration of a recording: an enableAudio change rebuilds the video
+  // output, which tears down the in-flight recorder before it can finalize — dropping the clip. We
+  // hold the value captured while idle and only let it change once recording stops, so a call
+  // mid-recording finalizes the current clip first, then drops the mic for the next one.
+  const frozenMicRef = useRef(false);
+  if (!isRecording) frozenMicRef.current = micWanted;
+  const micEnabled = isRecording ? frozenMicRef.current : micWanted;
+
+  // VisionCamera records to a file via a per-recording `Recorder` created from this output. The
+  // output is also handed to `<Camera outputs={[videoOutput]}>` in recorder.tsx. Pinned to 1080p;
+  // the HEVC codec is pinned per-recording via setOutputSettings (iOS) so every clip stays
+  // format-uniform and exports on the merge engine's zero-re-encode fast path.
   const videoOutput = useVideoOutput({
     targetResolution: CommonResolutions.FHD_16_9,
-    enableAudio: !muted,
+    enableAudio: micEnabled,
     fileType: 'mov',
   });
 
@@ -90,6 +110,10 @@ export function useRecorder(initialDraftId?: string) {
   // Set only when a hold STARTED the recording — releasing a hold begun on top of a
   // tap-started recording must not stop it (that hold is just drag-zooming).
   const holdInitiatedRef = useRef(false);
+  // The promise for the in-flight startRecording() run (it resolves once the clip is persisted).
+  // Awaited by finalizeRecording so leaving the screen can save the segment before the camera
+  // tears down.
+  const recordingPromiseRef = useRef<Promise<void> | null>(null);
 
   // Drop an empty draft on leave so it doesn't litter Home: either one we created this
   // session and never kept a clip in, or a resumed draft whose every clip was deleted.
@@ -149,6 +173,38 @@ export function useRecorder(initialDraftId?: string) {
   useEffect(() => {
     if (prefsReady) void setSetting(CAMERA_MUTED_KEY, String(muted));
   }, [muted, prefsReady]);
+
+  // Stop the in-flight recording whenever the call state CHANGES — starting (the mic must drop) or
+  // ending (the clip was recording silent and the mic is back). No clip then spans an audio-state
+  // change: it's finalized and saved at the boundary, and the user starts the next one manually
+  // (with the mic in its new state). We deliberately do NOT auto-resume.
+  useEffect(() => {
+    if (isRecordingRef.current) stopRecording();
+  }, [callActive]);
+
+  // Leaving the app mid-recording must save the clip. We finalize on the FIRST sign of leaving —
+  // AppState 'inactive', which precedes 'background' — while the capture session is still alive and
+  // JS is still running. Finalizing only at 'background' loses the clip: iOS has by then interrupted
+  // the session, so the recorder can't flush cleanly. A background task covers the persist tail in
+  // case we cross into the background. Trade-off: anything that deactivates the app (backgrounding,
+  // Control Center, app switcher) stops and saves the current clip; we never auto-resume.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active' || !isRecordingRef.current) return;
+      let taskId = -1;
+      void (async () => {
+        taskId = CallDetector.beginBackgroundTask();
+        try {
+          await finalizeRecording();
+        } finally {
+          CallDetector.endBackgroundTask(taskId);
+        }
+      })();
+    });
+    return () => sub.remove();
+    // finalizeRecording reads only refs; the listener is set up once and reads current state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function startRecording() {
     if (!cameraRef.current || isRecordingRef.current || !cameraReady) return;
@@ -210,6 +266,10 @@ export function useRecorder(initialDraftId?: string) {
         durationMs,
         thumbnail: ok ? thumbRel : null,
       });
+      // Reflect the new segment synchronously: a close/unmount that races the live query must not
+      // see an "empty" draft and delete it (the deletion check below reads these refs).
+      everHadSegments.current = true;
+      segmentCount.current = Math.max(segmentCount.current, 1);
     } catch {
       // interrupted mid-record — drop the clip
     } finally {
@@ -305,13 +365,26 @@ export function useRecorder(initialDraftId?: string) {
 
   function toggleRecording() {
     if (isRecordingRef.current) stopRecording();
-    else void startRecording();
+    else recordingPromiseRef.current = startRecording();
   }
 
   function startHoldRecording() {
     if (isRecordingRef.current) return;
     holdInitiatedRef.current = true;
-    void startRecording();
+    recordingPromiseRef.current = startRecording();
+  }
+
+  // Stop an in-flight recording and wait for its clip to be persisted into the draft. Called before
+  // leaving the screen (the close button) so the segment is saved instead of being lost when the
+  // camera tears down. No-op when idle.
+  async function finalizeRecording() {
+    if (!isRecordingRef.current) return;
+    stopRecording();
+    try {
+      await recordingPromiseRef.current;
+    } catch {
+      // persist failed — nothing more we can do; the caller leaves regardless
+    }
   }
 
   function endHoldRecording() {
@@ -346,8 +419,11 @@ export function useRecorder(initialDraftId?: string) {
     torch,
     stabilization,
     muted,
+    callActive,
+    appActive,
     onCameraReady: () => setCameraReady(true),
     toggleRecording,
+    finalizeRecording,
     importClip: () => void importClip(),
     startHoldRecording,
     endHoldRecording,

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -114,6 +114,10 @@ export function useRecorder(initialDraftId?: string) {
   // Awaited by finalizeRecording so leaving the screen can save the segment before the camera
   // tears down.
   const recordingPromiseRef = useRef<Promise<void> | null>(null);
+  // Guards the background-finalize listener against re-entry: iOS fires 'inactive' THEN 'background'
+  // on a single backgrounding, and the persist tail keeps isRecordingRef true across both — without
+  // this we'd finalize and open a background task twice for one clip.
+  const backgroundFinalizingRef = useRef(false);
 
   // Drop an empty draft on leave so it doesn't litter Home: either one we created this
   // session and never kept a clip in, or a resumed draft whose every clip was deleted.
@@ -190,7 +194,8 @@ export function useRecorder(initialDraftId?: string) {
   // Control Center, app switcher) stops and saves the current clip; we never auto-resume.
   useEffect(() => {
     const sub = AppState.addEventListener('change', (state) => {
-      if (state === 'active' || !isRecordingRef.current) return;
+      if (state === 'active' || !isRecordingRef.current || backgroundFinalizingRef.current) return;
+      backgroundFinalizingRef.current = true;
       let taskId = -1;
       void (async () => {
         taskId = CallDetector.beginBackgroundTask();
@@ -198,6 +203,7 @@ export function useRecorder(initialDraftId?: string) {
           await finalizeRecording();
         } finally {
           CallDetector.endBackgroundTask(taskId);
+          backgroundFinalizingRef.current = false;
         }
       })();
     });


### PR DESCRIPTION
## Problem

On iOS, telephony has exclusive top priority for the microphone. When a call was active and the recorder had the mic enabled, the capture session threw `AVFoundationErrorDomain -11800` / `'!pri'` (insufficient priority) and the **camera froze**. Repro: be on a call (or background the app, take a call, return) and open the camera.

## Approach

Detect call state and force the mic **off** for the call's duration so video keeps running and clips are simply silent — then restore the mic when the call ends. Because predicting call state can still lose a race against the OS, we also **react to the actual `-11800` error** as ground truth and recover from it instead of freezing.

### Call detection — local Expo module `expo-call-detector`
No maintained, new-arch/Expo-friendly call-detection package exists (all community options are abandoned legacy-bridge modules), so this is a small local module we own:
- iOS: wraps CallKit's `CXCallObserver`. Crucially it reports a call **already in progress** when the listener attaches (CXCallObserver otherwise only pushes *future* changes — the case that caused the freeze when opening the recorder mid-call). The observer is created eagerly so the synchronous snapshot and the delegate can't race the first-touch and construct two observers.
- iOS: `beginBackgroundTask` / `endBackgroundTask` helpers so a clip can finish writing to disk when the app is backgrounded. Active task ids are tracked under a lock and ended exactly once, so an expiration handler firing before JS calls end never double-ends.
- iOS-only podspec (CallKit / `UIApplication` background tasks aren't on the tvOS SDK).
- Android: safe no-op stub (always "no call"); web no-op.

### Recorder behavior
- `enableAudio` gated on call + mute state; **frozen for a clip's duration** so toggling it never rebuilds the output mid-recording (which dropped the clip).
- Re-poll call state and stop the session while backgrounded, so iOS can't auto-resume the mic into a call that began in the background.
- Stop **and save** the in-flight clip on any call transition (start or end) and when the app deactivates — finalizing on `inactive` (which precedes `background`) so the clip flushes while the session is still alive; a background task covers the persist tail. The background-finalize listener is guarded against re-entry so the `inactive`→`background` pair doesn't finalize twice or open two background tasks.
- Save the clip on the close button before navigating; protect the draft from the empty-draft cleanup racing the live query.
- Lock all camera controls during recording; show an "On call" indicator on the (locked) mic button.

### Error-driven recovery (the safety net)
Prediction can still lose a race: on a cold-open / resume into an *in-progress* call, `CXCallObserver.calls` may not have synced on the first foreground frame, so the snapshot reads "no call", the mic attaches, and `-11800` fires — leaving the session frozen (it does not self-recover). Rather than try to out-predict the OS, the recorder's `onError` detects the `-11800` / `'!pri'` signature, forces the mic off (treating the error as an active call until the next authoritative call-state event), and **bounces the capture session off→on** so it rebuilds video-only instead of staying frozen.

## Trade-offs / known limitations

- **Leaving the app mid-recording stops and saves the current clip** (no auto-resume) — and this fires on *any* deactivation: backgrounding, Control Center, the app switcher, the incoming-call banner. This is intentional. We finalize on `inactive` because it fires *before* `background`, while the capture session is still alive and JS is still running. Scoping it to "genuine backgrounding only" (`background`) is **unreliable**: by the time `background` fires, iOS has already interrupted the capture session, so the recorder can't flush cleanly and the clip is lost. Saving slightly too eagerly beats dropping clips.
- **Background save is bounded by iOS's background-execution window.** The background task buys ~30s (not unlimited), which is ample for finalizing one clip, but it's not a license for indefinite background work.
- **Android call detection is not implemented** (stub returns "no call"); the equivalent is `TelephonyManager`/`TelephonyCallback` + `READ_PHONE_STATE`, a follow-up. iOS is the implemented platform.

## Native change — rebuild required
This adds a native module, so reviewers/testers need a dev-client rebuild (`npx expo run:ios --device`), not just a Metro reload.

## Test plan
- Open recorder **during** an active call → comes up video-only, no `-11800`.
- Call **mid-recording** → clip saves (audio up to the call), mic drops, "On call" shown, restores after hang-up.
- Background **mid-recording** → clip saved to the draft.
- Close button **mid-recording** → clip saved before leaving.
- Recorded clips during calls contain no audio.
- If `-11800` ever does fire (lost prediction race) → the preview recovers to video-only instead of freezing, and "On call" appears.
