### PR TITLE
ci(ios): check out and build the video-trim git submodule

### DIFF
--- a/.github/workflows/build-ios-from-expo.yml
+++ b/.github/workflows/build-ios-from-expo.yml
@@ -36,11 +36,38 @@ jobs:
     runs-on: macos-latest
     steps:
       # ── Checkout, Xcode, Node, JS deps ────────────────────────────────────
-      - name: Setup Expo environment
-        uses: mieweb/actions/prepare-expo-env@v2.2.4
+      # NOT using prepare-expo-env here: its checkout omits submodules, so the
+      # react-native-video-trim git submodule (modules/react-native-video-trim)
+      # is empty and Metro fails with "Unable to resolve module
+      # react-native-video-trim". We check out submodules and build the module.
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
         with:
-          package_manager: npm
-          node_version: "20"
+          submodules: recursive
+
+      - name: Select Xcode
+        run: |
+          XC=/Applications/Xcode_26.app
+          [ -d "$XC/Contents/Developer" ] || XC=$(ls -td /Applications/Xcode_26*.app 2>/dev/null | head -1)
+          [ -d "$XC/Contents/Developer" ] || XC=$(ls -td /Applications/Xcode*.app | grep -viE 'beta|rc|gm' | head -1)
+          echo "Selected Xcode: $XC"
+          sudo xcode-select -s "$XC/Contents/Developer"
+          xcodebuild -version
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      # The submodule commits only src/ (lib/ is gitignored). Metro resolves the
+      # package through its built lib/, so build it the way local dev does.
+      - name: Build the react-native-video-trim submodule
+        run: |
+          npm --prefix modules/react-native-video-trim install
+          npm --prefix modules/react-native-video-trim run prepare
 
       # ── Give every CI build a unique, increasing build number ─────────────
       - name: Stamp build number


### PR DESCRIPTION
## Why

After signing was fully solved, the build got all the way through native compilation and failed at the **JS bundling** step:

```
::error src/db/migrate.tsx:3 :: Unable to resolve module react-native-video-trim
```

`modules/react-native-video-trim` is a **git submodule** (`github.com/morepriyam/react-native-video-trim`). `prepare-expo-env` checks out **without** submodules, so the directory was empty in CI and Metro couldn't resolve the package. The submodule also commits only `src/` (`lib/` is gitignored), and Metro resolves the package via its built `lib/`.

## What

Replaces the `prepare-expo-env` step with explicit setup that fixes both:
- `actions/checkout@v4` with `submodules: recursive` (populates the submodule)
- Xcode select + Node 20 + `npm ci` (same as before)
- `npm --prefix modules/react-native-video-trim install` → runs `bob build` to generate the gitignored `lib/` that Metro resolves

No secrets change. Signing (cert + profile + identity) is already confirmed working — this clears the JS bundling failure.

## After merge
**Actions → iOS Expo Build & Upload → Run workflow.**