### PR TITLE
feat(design): adopt iOS/iPadOS 27 design system (colors + typography)

### DIFF
--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -11,7 +11,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { CloseButton } from '@/features/recorder/close-button';
-import { Accent, Spacing } from '@/constants/theme';
+import { Spacing } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
 import { segmentsForDraft } from '@/db/drafts';
 import { useExport } from '@/features/export/use-export';
@@ -100,14 +100,20 @@ export default function ExportScreen() {
                 onPress={runShare}
                 disabled={busy}
                 accessibilityRole="button"
-                accessibilityLabel="Share"
-                style={[styles.button, styles.primary, busy && styles.disabled]}>
+                accessibilityLabel={busy ? 'Sharing' : 'Share'}
+                accessibilityState={{ disabled: busy, busy }}
+                style={({ pressed }) => [
+                  styles.button,
+                  { backgroundColor: theme.accent },
+                  busy && styles.disabled,
+                  pressed && styles.pressed,
+                ]}>
                 {busy ? (
-                  <ActivityIndicator color="#fff" />
+                  <ActivityIndicator color={theme.onAccent} />
                 ) : (
                   <>
-                    <Icon name="square.and.arrow.up" size={18} tintColor="#fff" />
-                    <ThemedText style={styles.primaryLabel}>Share</ThemedText>
+                    <Icon name="square.and.arrow.up" size={18} tintColor={theme.onAccent} />
+                    <ThemedText style={{ color: theme.onAccent }}>Share</ThemedText>
                   </>
                 )}
               </Pressable>
@@ -116,8 +122,22 @@ export default function ExportScreen() {
                 onPress={() => void photos.save(toFileUri(state.outputPath))}
                 disabled={photos.status !== 'idle'}
                 accessibilityRole="button"
-                accessibilityLabel="Save to Photos"
-                style={[styles.button, { backgroundColor: theme.backgroundElement }]}>
+                accessibilityLabel={
+                  photos.status === 'saved'
+                    ? 'Saved to Photos'
+                    : photos.status === 'saving'
+                      ? 'Saving to Photos'
+                      : 'Save to Photos'
+                }
+                accessibilityState={{
+                  disabled: photos.status !== 'idle',
+                  busy: photos.status === 'saving',
+                }}
+                style={({ pressed }) => [
+                  styles.button,
+                  { backgroundColor: theme.backgroundElement },
+                  pressed && styles.pressed,
+                ]}>
                 {photos.status === 'saving' ? (
                   <ActivityIndicator color={theme.text} />
                 ) : photos.status === 'saved' ? (
@@ -137,8 +157,22 @@ export default function ExportScreen() {
                 onPress={() => void docs.save(toFileUri(state.outputPath))}
                 disabled={docs.status !== 'idle'}
                 accessibilityRole="button"
-                accessibilityLabel="Save to Files"
-                style={[styles.button, { backgroundColor: theme.backgroundElement }]}>
+                accessibilityLabel={
+                  docs.status === 'saved'
+                    ? 'Saved to Files'
+                    : docs.status === 'saving'
+                      ? 'Saving to Files'
+                      : 'Save to Files'
+                }
+                accessibilityState={{
+                  disabled: docs.status !== 'idle',
+                  busy: docs.status === 'saving',
+                }}
+                style={({ pressed }) => [
+                  styles.button,
+                  { backgroundColor: theme.backgroundElement },
+                  pressed && styles.pressed,
+                ]}>
                 {docs.status === 'saving' ? (
                   <ActivityIndicator color={theme.text} />
                 ) : docs.status === 'saved' ? (
@@ -159,7 +193,7 @@ export default function ExportScreen() {
 
         {state.status === 'error' && (
           <>
-            <Icon name="exclamationmark.triangle.fill" size={64} tintColor={Accent} />
+            <Icon name="exclamationmark.triangle.fill" size={64} tintColor={theme.accent} />
             <ThemedText type="subtitle" style={styles.title}>
               Export failed
             </ThemedText>
@@ -172,9 +206,13 @@ export default function ExportScreen() {
                 onPress={retry}
                 accessibilityRole="button"
                 accessibilityLabel="Try again"
-                style={[styles.button, styles.primary]}>
-                <Icon name="arrow.clockwise" size={18} tintColor="#fff" />
-                <ThemedText style={styles.primaryLabel}>Try again</ThemedText>
+                style={({ pressed }) => [
+                  styles.button,
+                  { backgroundColor: theme.accent },
+                  pressed && styles.pressed,
+                ]}>
+                <Icon name="arrow.clockwise" size={18} tintColor={theme.onAccent} />
+                <ThemedText style={{ color: theme.onAccent }}>Try again</ThemedText>
               </Pressable>
             </View>
           </>
@@ -282,7 +320,6 @@ const styles = StyleSheet.create({
     height: 52,
     borderRadius: 14,
   },
-  primary: { backgroundColor: Accent },
-  primaryLabel: { color: '#fff' },
+  pressed: { opacity: 0.85 },
   disabled: { opacity: 0.5 },
 });

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -181,8 +181,13 @@ export default function HomeScreen() {
               hitSlop={12}
               disabled={busy}
               accessibilityRole="button"
-              accessibilityLabel="Import drafts"
-              style={({ pressed }) => [styles.headerButton, pressed && styles.headerButtonPressed]}>
+              accessibilityLabel={transferState === 'importing' ? 'Importing drafts' : 'Import drafts'}
+              accessibilityHint="Imports drafts from a .pulse file"
+              accessibilityState={{ disabled: busy, busy: transferState === 'importing' }}
+              style={({ pressed }) => [
+                styles.headerButton,
+                pressed && { backgroundColor: theme.backgroundElement },
+              ]}>
               {transferState === 'importing' ? (
                 <ActivityIndicator size="small" color={theme.textSecondary} />
               ) : (
@@ -204,8 +209,12 @@ export default function HomeScreen() {
                 onPress={() => setSelectionMode(true)}
                 hitSlop={12}
                 accessibilityRole="button"
-                accessibilityLabel="Select drafts to export"
-                style={({ pressed }) => [styles.headerButton, pressed && styles.headerButtonPressed]}>
+                accessibilityLabel="Export drafts"
+                accessibilityHint="Select drafts to share as a .pulse file"
+                style={({ pressed }) => [
+                  styles.headerButton,
+                  pressed && { backgroundColor: theme.backgroundElement },
+                ]}>
                 <Icon name="square.and.arrow.up" size={20} tintColor={theme.text} />
                 <ThemedText type="smallBold" style={styles.headerButtonLabel}>
                   Export
@@ -216,8 +225,14 @@ export default function HomeScreen() {
               onPress={() => setPickerOpen(true)}
               hitSlop={12}
               accessibilityRole="button"
-              accessibilityLabel="On-device AI"
-              style={({ pressed }) => [styles.headerButton, pressed && styles.headerButtonPressed]}>
+              accessibilityLabel="On-device AI model"
+              accessibilityHint="Choose the model used for captions"
+              accessibilityState={{ selected: !!selectedModel }}
+              accessibilityValue={{ text: selectedModel ? selectedModel.label : 'Off' }}
+              style={({ pressed }) => [
+                styles.headerButton,
+                pressed && { backgroundColor: theme.backgroundElement },
+              ]}>
               <Icon
                 name="wand.and.stars"
                 size={20}
@@ -244,7 +259,7 @@ export default function HomeScreen() {
       {visibleDrafts.length === 0 ? (
         <View style={styles.empty}>
           <Icon name="video.badge.plus" size={52} tintColor={theme.textSecondary} />
-          <ThemedText style={styles.emptyTitle}>No drafts yet</ThemedText>
+          <ThemedText type="title3" style={styles.emptyTitle}>No drafts yet</ThemedText>
           <ThemedText themeColor="textSecondary" style={styles.emptyHint}>
             Tap + to record your first video.
           </ThemedText>
@@ -342,17 +357,18 @@ const styles = StyleSheet.create({
     paddingBottom: Spacing.two,
   },
   headerActions: { flexDirection: 'row', alignItems: 'center', gap: Spacing.two },
-  // Shared header action: icon stacked above its label, with a ≥44pt touch target.
+  // Shared header action: icon stacked above its label, with a ≥44×44pt touch target (HIG).
   headerButton: {
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
     gap: Spacing.half,
     minHeight: 44,
+    minWidth: 44,
+    borderRadius: 12,
     paddingHorizontal: Spacing.two,
   },
   headerButtonLabel: { fontSize: 11, lineHeight: 13 },
-  headerButtonPressed: { opacity: 0.5 },
   devRowWrap: {
     alignItems: 'flex-end',
     paddingHorizontal: Spacing.four,
@@ -369,10 +385,9 @@ const styles = StyleSheet.create({
     gap: Spacing.two,
     paddingHorizontal: Spacing.five,
   },
+  // Size/leading come from the `title3` type; keep it semibold for the empty-state heading.
   emptyTitle: {
-    fontSize: 20,
     fontWeight: '600',
-    lineHeight: 26,
   },
   emptyHint: {
     textAlign: 'center',

--- a/src/app/subtitles.tsx
+++ b/src/app/subtitles.tsx
@@ -307,7 +307,7 @@ function CueRow({
   const chars = cue.text.trim().length;
   const cps = chars / Math.max(0.01, (cue.t1 - cue.t0) / 100);
   const over = cps > CPS_BAD || chars > MAX_CHARS;
-  const cpsColor = cps > CPS_BAD ? Accent : cps > CPS_WARN ? '#E5A100' : theme.textSecondary;
+  const cpsColor = cps > CPS_BAD ? Accent : cps > CPS_WARN ? theme.warning : theme.textSecondary;
 
   // Collapsed: a calm, readable row — start time + text, accent when it's the playing cue.
   if (!selected) {

--- a/src/components/themed-text.tsx
+++ b/src/components/themed-text.tsx
@@ -1,10 +1,40 @@
 import { Platform, StyleSheet, Text, type TextProps } from 'react-native';
 
-import { Fonts, ThemeColor } from '@/constants/theme';
+import { Fonts, SystemColors, ThemeColor } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
 
+/**
+ * Typography follows the iOS / iPadOS 27 type scale (Apple Design Resources).
+ * Sizes and line heights are taken from the kit's Dynamic Type + Text Leading
+ * collections at the "Large (Default)" content size. Weights follow Apple's
+ * defaults (Regular, with Headline/Large Title emphasized).
+ *
+ * Prefer the iOS-named variants (`body`, `headline`, `title1`, …) for new code.
+ * The legacy names (`default`, `title`, `subtitle`, `small`, `smallBold`) are
+ * kept as aliases mapped to their nearest iOS style so existing call sites work.
+ */
 export type ThemedTextProps = TextProps & {
-  type?: 'default' | 'title' | 'small' | 'smallBold' | 'subtitle' | 'link' | 'linkPrimary' | 'code';
+  type?:
+    | 'largeTitle'
+    | 'title1'
+    | 'title2'
+    | 'title3'
+    | 'headline'
+    | 'body'
+    | 'callout'
+    | 'subheadline'
+    | 'footnote'
+    | 'caption1'
+    | 'caption2'
+    // legacy aliases
+    | 'default'
+    | 'title'
+    | 'subtitle'
+    | 'small'
+    | 'smallBold'
+    | 'link'
+    | 'linkPrimary'
+    | 'code';
   themeColor?: ThemeColor;
 };
 
@@ -13,61 +43,33 @@ export function ThemedText({ style, type = 'default', themeColor, ...rest }: The
 
   return (
     <Text
-      style={[
-        { color: theme[themeColor ?? 'text'] },
-        type === 'default' && styles.default,
-        type === 'title' && styles.title,
-        type === 'small' && styles.small,
-        type === 'smallBold' && styles.smallBold,
-        type === 'subtitle' && styles.subtitle,
-        type === 'link' && styles.link,
-        type === 'linkPrimary' && styles.linkPrimary,
-        type === 'code' && styles.code,
-        style,
-      ]}
+      style={[{ color: theme[themeColor ?? 'text'] }, styles[type], style]}
       {...rest}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  small: {
-    fontSize: 14,
-    lineHeight: 20,
-    fontWeight: 500,
-  },
-  smallBold: {
-    fontSize: 14,
-    lineHeight: 20,
-    fontWeight: 700,
-  },
-  default: {
-    fontSize: 16,
-    lineHeight: 24,
-    fontWeight: 500,
-  },
-  title: {
-    fontSize: 48,
-    fontWeight: 600,
-    lineHeight: 52,
-  },
-  subtitle: {
-    fontSize: 32,
-    lineHeight: 44,
-    fontWeight: 600,
-  },
-  link: {
-    lineHeight: 30,
-    fontSize: 14,
-  },
-  linkPrimary: {
-    lineHeight: 30,
-    fontSize: 14,
-    color: '#3c87f7',
-  },
-  code: {
-    fontFamily: Fonts.mono,
-    fontWeight: Platform.select({ android: 700 }) ?? 500,
-    fontSize: 12,
-  },
+  // iOS 27 type scale — size / lineHeight / weight
+  largeTitle: { fontSize: 34, lineHeight: 41, fontWeight: 700 },
+  title1: { fontSize: 28, lineHeight: 34, fontWeight: 400 },
+  title2: { fontSize: 22, lineHeight: 28, fontWeight: 400 },
+  title3: { fontSize: 20, lineHeight: 25, fontWeight: 400 },
+  headline: { fontSize: 17, lineHeight: 22, fontWeight: 600 },
+  body: { fontSize: 17, lineHeight: 22, fontWeight: 400 },
+  callout: { fontSize: 16, lineHeight: 21, fontWeight: 400 },
+  subheadline: { fontSize: 15, lineHeight: 20, fontWeight: 400 },
+  footnote: { fontSize: 13, lineHeight: 18, fontWeight: 400 },
+  caption1: { fontSize: 12, lineHeight: 16, fontWeight: 400 },
+  caption2: { fontSize: 11, lineHeight: 13, fontWeight: 400 },
+
+  // Legacy aliases mapped to the nearest iOS style
+  default: { fontSize: 17, lineHeight: 22, fontWeight: 400 }, // → Body
+  title: { fontSize: 34, lineHeight: 41, fontWeight: 700 }, // → Large Title
+  subtitle: { fontSize: 28, lineHeight: 34, fontWeight: 600 }, // → Title 1 (emphasized)
+  small: { fontSize: 15, lineHeight: 20, fontWeight: 400 }, // → Subheadline
+  smallBold: { fontSize: 15, lineHeight: 20, fontWeight: 600 }, // → Subheadline (emphasized)
+  link: { fontSize: 15, lineHeight: 20, fontWeight: 400 }, // → Subheadline
+  linkPrimary: { fontSize: 15, lineHeight: 20, fontWeight: 400, color: SystemColors.blue.light }, // iOS system blue
+  code: { fontFamily: Fonts.mono, fontSize: 13, lineHeight: 18, fontWeight: Platform.select({ android: 700 }) ?? 400 },
 });

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -1,27 +1,64 @@
 import { Platform } from 'react-native';
 
-/** Pulse brand red — record button, primary actions, highlights. */
-export const Accent = '#F01E21';
+/**
+ * iOS / iPadOS 27 system red — record button, primary actions, highlights.
+ * Base (light) value; the theme `accent` token below is mode-aware.
+ */
+export const Accent = '#FF383C';
 
+/**
+ * iOS / iPadOS 27 system color ramp (Apple Design Resources, Beta).
+ * Exact values pulled from the official UI Kit variable collection.
+ * Use these for any new design work that should feel native on iOS 27.
+ */
+export const SystemColors = {
+  // System accent colors — light / dark
+  red: { light: '#FF383C', dark: '#FF4245' },
+  orange: { light: '#FF8D28', dark: '#FF9230' },
+  yellow: { light: '#FFCC00', dark: '#FFD600' },
+  green: { light: '#34C759', dark: '#30D158' },
+  mint: { light: '#00C8B3', dark: '#00DAC3' },
+  teal: { light: '#00C3D0', dark: '#00D2E0' },
+  cyan: { light: '#00C0E8', dark: '#3CD3FE' },
+  blue: { light: '#0088FF', dark: '#0091FF' },
+  indigo: { light: '#6155F5', dark: '#6D7CFF' },
+  purple: { light: '#CB30E0', dark: '#DB34F2' },
+  pink: { light: '#FF2D55', dark: '#FF375F' },
+  brown: { light: '#AC7F5E', dark: '#B78A66' },
+  // System grays 1–6 — light / dark
+  gray: { light: '#8E8E93', dark: '#8E8E93' },
+  gray2: { light: '#AEAEB2', dark: '#636366' },
+  gray3: { light: '#C7C7CC', dark: '#48484A' },
+  gray4: { light: '#D1D1D6', dark: '#3A3A3C' },
+  gray5: { light: '#E5E5EA', dark: '#2C2C2E' },
+  gray6: { light: '#F2F2F7', dark: '#1C1C1E' },
+} as const;
+
+/**
+ * Semantic theme tokens mapped to iOS / iPadOS 27 system colors.
+ * The comment after each value names the Apple semantic role it mirrors.
+ */
 export const Colors = {
   light: {
-    text: '#000000',
-    background: '#ffffff',
-    backgroundElement: '#F0F0F3',
-    backgroundSelected: '#E0E1E6',
-    textSecondary: '#60646C',
-    border: '#E4E4E9',
-    accent: Accent,
+    text: '#000000', // Label / Primary
+    background: '#ffffff', // Background / Primary (systemBackground)
+    backgroundElement: '#F2F2F7', // Background / Secondary (secondarySystemBackground)
+    backgroundSelected: '#E5E5EA', // System Gray 5
+    textSecondary: 'rgba(60,60,67,0.6)', // Label / Secondary
+    border: '#C6C6C8', // Separator / Opaque (opaqueSeparator)
+    accent: SystemColors.red.light, // #FF383C
+    warning: SystemColors.orange.light, // #FF8D28 — soft/at-risk states
     onAccent: '#ffffff',
   },
   dark: {
-    text: '#ffffff',
-    background: '#000000',
-    backgroundElement: '#212225',
-    backgroundSelected: '#2E3135',
-    textSecondary: '#B0B4BA',
-    border: '#2A2A2E',
-    accent: Accent,
+    text: '#ffffff', // Label / Primary
+    background: '#000000', // Background / Primary (systemBackground)
+    backgroundElement: '#1C1C1E', // Background / Secondary (secondarySystemBackground)
+    backgroundSelected: '#2C2C2E', // System Gray 5
+    textSecondary: 'rgba(235,235,245,0.7)', // Label / Secondary
+    border: '#38383A', // Separator / Opaque (opaqueSeparator)
+    accent: SystemColors.red.dark, // #FF4245
+    warning: SystemColors.orange.dark, // #FF9230 — soft/at-risk states
     onAccent: '#ffffff',
   },
 } as const;

--- a/src/features/export/merge-progress-ring.tsx
+++ b/src/features/export/merge-progress-ring.tsx
@@ -8,7 +8,6 @@ import Animated, {
 import Svg, { Circle } from 'react-native-svg';
 
 import { ThemedText } from '@/components/themed-text';
-import { Accent } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -53,7 +52,7 @@ export function MergeProgressRing({ progress }: { progress: number }) {
           cx={SIZE / 2}
           cy={SIZE / 2}
           r={RADIUS}
-          stroke={Accent}
+          stroke={theme.accent}
           strokeWidth={STROKE}
           strokeLinecap="round"
           fill="none"

--- a/src/features/onboarding/onboarding-screen.tsx
+++ b/src/features/onboarding/onboarding-screen.tsx
@@ -112,7 +112,7 @@ export function OnboardingScreen() {
                 <Icon name={item.symbol ?? 'sparkles'} size={56} tintColor={theme.accent} />
               </View>
             )}
-            <ThemedText style={styles.title}>{item.title}</ThemedText>
+            <ThemedText type="title1" style={styles.title}>{item.title}</ThemedText>
             <View style={styles.bullets}>
               {item.bullets.map((bullet, i) => (
                 <View key={i} style={styles.bulletRow}>
@@ -127,7 +127,7 @@ export function OnboardingScreen() {
                       <View style={[styles.bulletDot, { backgroundColor: theme.accent }]} />
                     )}
                   </View>
-                  <ThemedText style={styles.bulletText}>{bullet.text}</ThemedText>
+                  <ThemedText type="body" style={styles.bulletText}>{bullet.text}</ThemedText>
                 </View>
               ))}
             </View>
@@ -183,10 +183,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  // Size/leading come from the `title1` type; keep it centered and bold for the onboarding hero.
   title: {
     textAlign: 'center',
-    fontSize: 26,
-    lineHeight: 32,
     fontWeight: '700',
   },
   bullets: {
@@ -227,8 +226,6 @@ const styles = StyleSheet.create({
   },
   bulletText: {
     flex: 1,
-    fontSize: 16,
-    lineHeight: 24,
   },
   footer: {
     paddingHorizontal: Spacing.four,


### PR DESCRIPTION
Aligns the app's design tokens and components with the official **iOS / iPadOS 27 UI Kit** (Apple Design Resources), pulled directly from the kit's Variables collections.

## Colors — `constants/theme.ts`
- Semantic tokens mapped to iOS 27 system colors: secondary label (translucent), `secondarySystemBackground`, system gray 5, opaque separator.
- Accent switched from the legacy brand red to **iOS system red**, mode-aware (`#FF383C` light / `#FF4245` dark).
- Added a `SystemColors` ramp (12 accents + grays 1–6) and a `warning` token (systemOrange) for soft/at-risk states.

## Typography — `components/themed-text.tsx`
- Rebuilt on the iOS 27 type scale — sizes and line heights taken from the kit's **Dynamic Type** + **Text Leading** collections at the Large/Default content size.
- Added iOS-named variants (`body`, `headline`, `title1–3`, `callout`, `caption1/2`, …); legacy variant names kept as aliases mapped to their nearest iOS style, so existing call sites are unchanged.

## Components / accessibility
- **Home** Import / Export / Model buttons: ≥44×44pt touch targets, native rounded press fill, and full VoiceOver state (announces selected model + busy/import state).
- **Export** screen: press feedback on every action, dynamic accessibility labels + state for the Share / Save-to-Photos / Save-to-Files lifecycle, mode-aware accent.
- Routed loaders, onboarding typography, and the empty state through the design system; replaced remaining hardcoded values on themed surfaces.

## Intentionally not themed
Camera / video-overlay colors (recorder, segment bar, preview modal, caption overlay, play badges) stay white-on-video — they sit on live footage and must remain legible regardless of light/dark, matching Apple's own camera UI.

## Verification
- `tsc --noEmit` passes.