### PR TITLE
feat(recorder): bump zoom gesture sensitivity; declare export compliance

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,6 +13,7 @@
       "bundleIdentifier": "com.mieweb.pulse.dev",
       "appleTeamId": "X5873NL7XM",
       "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false,
         "NSCameraUsageDescription": "Pulse uses your camera to record videos.",
         "NSMicrophoneUsageDescription": "Pulse uses your microphone to record audio with your videos."
       }

--- a/src/features/recorder/use-recorder-gestures.ts
+++ b/src/features/recorder/use-recorder-gestures.ts
@@ -9,10 +9,12 @@ import { runOnJS, useSharedValue, withTiming } from 'react-native-reanimated';
 const HOLD_MS = 250;
 /** Vertical drag distance (px) that doubles (drag up) or halves (drag down) the zoom factor.
  * Drag-zoom is multiplicative so the feel is consistent regardless of the device's zoom range.
- * Tuned by feel — wants an on-device pass. */
-const DRAG_DOUBLING_PX = 250;
+ * Smaller ⇒ more sensitive (less travel to double). Tuned by feel — wants an on-device pass. */
+const DRAG_DOUBLING_PX = 180;
 /** Pinch scale is multiplicative and VisionCamera's `zoom` is an absolute factor, so the pinch
- * scale maps straight onto the factor (scale 2 ⇒ 2× the zoom factor) — physically exact. */
+ * scale maps onto the factor. We raise the raw scale to this exponent (>1) to make the pinch a
+ * touch more sensitive than the physically-exact 1:1 (scale 2 ⇒ 2× the zoom factor at 1.0). */
+const PINCH_SENSITIVITY = 1.3;
 
 export function useRecorderGestures({
   onToggle,
@@ -113,7 +115,7 @@ export function useRecorderGestures({
         pinchBase.value = zoomSv.value;
       })
       .onUpdate((e) => {
-        writeZoom(pinchBase.value * e.scale);
+        writeZoom(pinchBase.value * e.scale ** PINCH_SENSITIVITY);
       });
 
     // Single-finger tap on the preview → focus to that point (tap-to-focus). One finger vs the


### PR DESCRIPTION
## Summary
- Increase sensitivity on both camera zoom gestures in `use-recorder-gestures.ts`:
  - **Hold-to-drag** (hold record button, slide up/down): `DRAG_DOUBLING_PX` `250 → 180`, so ~28% less travel to double/halve the zoom.
  - **Pinch-to-zoom**: added `PINCH_SENSITIVITY = 1.3` applied as `e.scale ** 1.3`, replacing the physically-exact 1:1 map. Same finger spread → a bit more zoom.
- Both still clamp to the device's `[minZoom, maxZoom]` via `writeZoom`.
- Set `ITSAppUsesNonExemptEncryption=false` in `app.json` `infoPlist` so `expo prebuild` writes it into `Info.plist` and TestFlight auto-answers the export compliance prompt.

## Notes
- Sensitivity knobs for an on-device tuning pass: `DRAG_DOUBLING_PX` (lower = more sensitive) and `PINCH_SENSITIVITY` (higher = more sensitive).