### PR TITLE
Validate TUS Location origin and bump pulsevault-mieweb

### DIFF
--- a/src/features/upload/tus-client.test.ts
+++ b/src/features/upload/tus-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { cancelTusUpload, type UploadRemainder, uploadViaTus } from './tus-client';
+import { cancelTusUpload, TusUploadError, type UploadRemainder, uploadViaTus } from './tus-client';
 
 const SERVER = 'https://vault.example.test/pulsevault';
 const ARTIFACT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
@@ -192,6 +192,52 @@ describe('uploadViaTus', () => {
     const metadata = (createCall?.init?.headers as Record<string, string>)['Upload-Metadata'];
     expect(metadata).toContain(`relatedTo ${btoa('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')}`);
     expect(metadata).toContain(`checksum ${btoa('sha256:deadbeef')}`);
+  });
+
+  it('rejects a Location header that redirects to a different origin than the paired server', async () => {
+    // A malicious or compromised paired server could otherwise redirect every
+    // subsequent HEAD/PATCH/DELETE (each carrying the bearer capability
+    // token) to an attacker-controlled host by returning an absolute
+    // Location on a different origin.
+    const file = fakeFile(5);
+    const { fetchImpl } = createFetchStub({
+      POST: [new Response(null, { status: 201, headers: { location: 'https://evil.example/collect' } })],
+    });
+    const { uploadRemainder } = createRemainderStub([]);
+
+    await expect(
+      uploadViaTus({
+        server: SERVER,
+        token: 'tok',
+        artifactId: ARTIFACT_ID,
+        filename: 'clip.mp4',
+        kind: 'video',
+        file: file as never,
+        fetchImpl,
+        uploadRemainder,
+      }),
+    ).rejects.toBeInstanceOf(TusUploadError);
+  });
+
+  it('accepts a Location header that is same-origin but on a different path prefix', async () => {
+    const file = fakeFile(5);
+    const { fetchImpl } = createFetchStub({
+      POST: [new Response(null, { status: 201, headers: { location: '/other-prefix/upload/abc' } })],
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '5' } })],
+    });
+    const { uploadRemainder } = createRemainderStub([]);
+
+    const result = await uploadViaTus({
+      server: SERVER,
+      token: 'tok',
+      artifactId: ARTIFACT_ID,
+      filename: 'clip.mp4',
+      kind: 'video',
+      file: file as never,
+      fetchImpl,
+      uploadRemainder,
+    });
+    expect(result.resourceUrl).toBe('https://vault.example.test/other-prefix/upload/abc');
   });
 });
 

--- a/src/features/upload/tus-client.ts
+++ b/src/features/upload/tus-client.ts
@@ -43,6 +43,12 @@ export type TusUploadOptions = {
   file: File;
   /** A previously-created upload's resource URL, to resume instead of creating a new one. */
   resourceUrl?: string | null;
+  /**
+   * Called as soon as the resource URL is known — immediately if resuming, or right after
+   * the initial `POST` otherwise — so a caller can track "what's actually in flight right
+   * now" (e.g. for `cancel()`) without waiting for the whole upload to finish.
+   */
+  onResourceCreated?: (resourceUrl: string) => void;
   signal?: AbortSignal;
   onProgress?: (progress: TusUploadProgress) => void;
   /** Dependency-injected for testing; defaults to the global `fetch`. Only used for the headers-only requests (create/HEAD/DELETE) — never for the byte-carrying PATCH, see `uploadRemainder`. */
@@ -166,8 +172,23 @@ function statusErrorFromRemainder(result: RemainderUploadResult, fallbackMessage
   return new TusUploadError(fallbackMessage, { retryable, statusCode: result.status });
 }
 
+/**
+ * Resolves the server's `Location` response header against the paired
+ * server's base URL, then requires the result to stay on that same origin.
+ * Without this check, a malicious or compromised paired server could return
+ * an absolute `Location` pointing at a different host, and every subsequent
+ * `HEAD`/`PATCH`/`DELETE` — each carrying `Authorization: Bearer <token>` —
+ * would leak the capability token to that host instead of the paired server.
+ */
 function resolveLocation(location: string, base: string): string {
-  return new URL(location, base).toString();
+  const resolved = new URL(location, base);
+  const baseOrigin = new URL(base).origin;
+  if (resolved.origin !== baseOrigin) {
+    throw new TusUploadError('Server returned an upload location on an unexpected origin', {
+      retryable: false,
+    });
+  }
+  return resolved.toString();
 }
 
 async function createUpload(
@@ -238,6 +259,7 @@ export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadRes
   const resourceUrl =
     opts.resourceUrl ??
     (await withRetry(() => createUpload(opts, fetchImpl), opts.signal, waitUntilForeground));
+  opts.onResourceCreated?.(resourceUrl);
 
   // HEAD-then-upload-remainder is retried as ONE unit, not as two separately
   // retried steps — a retry after a transient failure MUST re-HEAD first to


### PR DESCRIPTION
## Summary

`resolveLocation` in `tus-client.ts` resolved the server's `Location` response header via `new URL(location, base)` with no check that the result stayed on the paired server's origin. A malicious or compromised paired server could return an absolute `Location` on a different host and receive every subsequent `HEAD`/`PATCH`/`DELETE` for that upload — each carrying `Authorization: Bearer <token>` — redirecting the capability token to that host instead. This is the "token redirect" threat named in RFC 6750 §10.4, and matches the same-origin validation OWASP recommends for any server-supplied redirect target before resending credentials.

`resolveLocation` now throws a non-retryable error if the resolved location's origin doesn't match the paired server's.

Also bumps the `pulsevault-mieweb` submodule to pick up the corresponding server-side fix for the same class of bug — `authorize()` was resolving a different artifactId than the one a `PATCH`/`HEAD` request actually operated on — plus the other hardening merged there (streaming checksum validation, storage collision-guard fixes, https enforcement in `buildUploadLink`).

## Test plan

- [x] `tus-client.test.ts` — 8/8 passing, including two new tests: rejects a cross-origin `Location`, accepts a same-origin `Location` on a different path prefix
- [x] `tsc --noEmit` — clean