### PR TITLE
Move upload tokens to SecureStore, add resumable uploads, and pairing TOFU confirmation

### DIFF
--- a/app.json
+++ b/app.json
@@ -78,7 +78,8 @@
         }
       ],
       "expo-asset",
-      "expo-font"
+      "expo-font",
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/drizzle/0006_glossy_king_cobra.sql
+++ b/drizzle/0006_glossy_king_cobra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `projects` DROP COLUMN `upload_token`;

--- a/drizzle/0007_clear_doctor_faustus.sql
+++ b/drizzle/0007_clear_doctor_faustus.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `upload_artifacts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`local_key` text NOT NULL,
+	`artifact_id` text NOT NULL,
+	`resource_url` text,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,329 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7e97c786-6965-460d-9b3d-a5bba81977ce",
+  "prevId": "ddb20b60-55b8-42ad-a085-8394965037b4",
+  "tables": {
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'camera'"
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_server": {
+          "name": "upload_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_artifact_id": {
+          "name": "upload_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_unit": {
+          "name": "upload_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_resource_url": {
+          "name": "upload_resource_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captions_upload_status": {
+          "name": "captions_upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "segments": {
+      "name": "segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_filename": {
+          "name": "edited_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_duration_ms": {
+          "name": "edited_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trim_start_ms": {
+          "name": "trim_start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trim_end_ms": {
+          "name": "trim_end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segments_project_id_projects_id_fk": {
+          "name": "segments_project_id_projects_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcripts": {
+      "name": "transcripts",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'processing'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lines": {
+          "name": "lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_lines": {
+          "name": "edited_lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_segment_id_segments_id_fk": {
+          "name": "transcripts_segment_id_segments_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,388 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4320a957-8400-4049-8465-999a50a43c3b",
+  "prevId": "7e97c786-6965-460d-9b3d-a5bba81977ce",
+  "tables": {
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'camera'"
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_server": {
+          "name": "upload_server",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_artifact_id": {
+          "name": "upload_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_unit": {
+          "name": "upload_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_resource_url": {
+          "name": "upload_resource_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captions_upload_status": {
+          "name": "captions_upload_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "segments": {
+      "name": "segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edited_filename": {
+          "name": "edited_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_duration_ms": {
+          "name": "edited_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trim_start_ms": {
+          "name": "trim_start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trim_end_ms": {
+          "name": "trim_end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "segments_project_id_projects_id_fk": {
+          "name": "segments_project_id_projects_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcripts": {
+      "name": "transcripts",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'processing'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lines": {
+          "name": "lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_lines": {
+          "name": "edited_lines",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_segment_id_segments_id_fk": {
+          "name": "transcripts_segment_id_segments_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "upload_artifacts": {
+      "name": "upload_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_key": {
+          "name": "local_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_url": {
+          "name": "resource_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "upload_artifacts_project_id_projects_id_fk": {
+          "name": "upload_artifacts_project_id_projects_id_fk",
+          "tableFrom": "upload_artifacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,20 @@
       "when": 1782857970496,
       "tag": "0005_abandoned_blue_marvel",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1782880024088,
+      "tag": "0006_glossy_king_cobra",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1782880133288,
+      "tag": "0007_clear_doctor_faustus",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.js
+++ b/drizzle/migrations.js
@@ -7,6 +7,8 @@ import m0002 from './0002_mature_mephistopheles.sql';
 import m0003 from './0003_fair_baron_zemo.sql';
 import m0004 from './0004_certain_prism.sql';
 import m0005 from './0005_abandoned_blue_marvel.sql';
+import m0006 from './0006_glossy_king_cobra.sql';
+import m0007 from './0007_clear_doctor_faustus.sql';
 
   export default {
     journal,
@@ -16,7 +18,9 @@ m0001,
 m0002,
 m0003,
 m0004,
-m0005
+m0005,
+m0006,
+m0007
     }
   }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "expo-linking": "~56.0.13",
         "expo-media-library": "~56.0.7",
         "expo-router": "~56.2.11",
+        "expo-secure-store": "~56.0.4",
         "expo-sharing": "~56.0.18",
         "expo-splash-screen": "~56.0.10",
         "expo-sqlite": "~56.0.4",
@@ -8657,6 +8658,15 @@
         "react-server-dom-webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "56.0.4",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-56.0.4.tgz",
+      "integrity": "sha512-hjEi/gmpdFFJ9lYbdp3k3p/WchV7Gi0Qt8jt/m/0WJadqQrskafHAlDxbZkII1cN3Yd7zp9Lvkeq3UfGhSwirQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-linking": "~56.0.13",
     "expo-media-library": "~56.0.7",
     "expo-router": "~56.2.11",
+    "expo-secure-store": "~56.0.4",
     "expo-sharing": "~56.0.18",
     "expo-splash-screen": "~56.0.10",
     "expo-sqlite": "~56.0.4",

--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -73,14 +73,31 @@ export default function ExportScreen() {
         }`
       : null;
 
+  // The link embeds a live bearer token (the same one that authorizes this upload) — anyone
+  // who gets it can act as this session, so warn before it leaves the app via clipboard/share.
+  const WATCH_LINK_WARNING =
+    'This link lets anyone who has it view (and control) this upload — treat it like a password.';
+
   const copyWatchLink = async () => {
     if (!watchUrl) return;
-    await Clipboard.setStringAsync(watchUrl);
-    Alert.alert('Link copied', 'The watch link is on your clipboard.');
+    Alert.alert('Copy watch link?', WATCH_LINK_WARNING, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Copy',
+        onPress: () => {
+          void Clipboard.setStringAsync(watchUrl).then(() =>
+            Alert.alert('Link copied', 'The watch link is on your clipboard.'),
+          );
+        },
+      },
+    ]);
   };
   const shareWatchLink = () => {
     if (!watchUrl) return;
-    void Share.share({ message: watchUrl, url: watchUrl });
+    Alert.alert('Share watch link?', WATCH_LINK_WARNING, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Share', onPress: () => void Share.share({ message: watchUrl, url: watchUrl }) },
+    ]);
   };
 
   const runShare = async () => {

--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -9,7 +9,8 @@ import {
 } from '@/utils/file-store';
 import { generateThumbnailFile } from '@/utils/video';
 import { db } from './client';
-import { projects, segments } from './schema';
+import { projects, segments, uploadArtifacts } from './schema';
+import { deleteDraftToken, setDraftToken } from './secure-token';
 
 const now = sql`(unixepoch('subsec') * 1000)`;
 
@@ -166,14 +167,15 @@ export async function renameDraft(draftId: string, name: string | null): Promise
 export async function deleteDraft(draftId: string): Promise<void> {
   await db.delete(projects).where(eq(projects.id, draftId));
   deleteDraftDir(draftId);
+  await deleteDraftToken(draftId);
 }
 
 // Upload destination (deep-link pairing) -----------------------------------------------------
 
-/** A draft's currently-set upload destination, or null fields if it has none. */
+/** A draft's currently-set upload destination, or null fields if it has none. The token lives
+ * in expo-secure-store, not this row — see `getDraftToken` in `secure-token.ts`. */
 export async function getUploadDestination(draftId: string): Promise<{
   uploadServer: string | null;
-  uploadToken: string | null;
   uploadArtifactId: string | null;
   uploadUnit: 'beat' | 'merged' | null;
 } | null> {
@@ -181,7 +183,6 @@ export async function getUploadDestination(draftId: string): Promise<{
   if (!project) return null;
   return {
     uploadServer: project.uploadServer,
-    uploadToken: project.uploadToken,
     uploadArtifactId: project.uploadArtifactId,
     uploadUnit: project.uploadUnit,
   };
@@ -192,6 +193,7 @@ export async function getUploadDestination(draftId: string): Promise<{
  * `/capabilities` lookup) and flip its mode to `'upload'`. Resets any prior
  * upload progress (`uploadResourceUrl`/`uploadStatus`/`captionsUploadStatus`)
  * since a new destination invalidates an in-flight upload to the old one.
+ * The bearer token is written to expo-secure-store, not this row (§ token security).
  */
 export async function setUploadDestination(
   draftId: string,
@@ -202,7 +204,6 @@ export async function setUploadDestination(
     .set({
       mode: 'upload',
       uploadServer: destination.server,
-      uploadToken: destination.token,
       uploadArtifactId: destination.artifactId,
       uploadUnit: destination.uploadUnit,
       uploadResourceUrl: null,
@@ -211,6 +212,10 @@ export async function setUploadDestination(
       lastModified: now,
     })
     .where(eq(projects.id, draftId));
+  await setDraftToken(draftId, destination.token);
+  // A new destination invalidates any sub-artifacts (beat videos/captions, merged
+  // captions) uploaded to the old one — they'd resume against the wrong server otherwise.
+  await db.delete(uploadArtifacts).where(eq(uploadArtifacts.projectId, draftId));
 }
 
 /** Persist upload progress so a killed app can resume via `HEAD` on `resourceUrl` rather than restarting. */
@@ -237,6 +242,43 @@ export async function setCaptionsUploadStatus(
     .update(projects)
     .set({ captionsUploadStatus: status, lastModified: now })
     .where(eq(projects.id, draftId));
+}
+
+// Upload sub-artifacts (beat/captions resume identity) --------------------------------------
+
+/** A sub-artifact's identity/progress, or `null` if this `localKey` hasn't been reserved yet. */
+export async function getUploadArtifact(
+  draftId: string,
+  localKey: string,
+): Promise<{ artifactId: string; resourceUrl: string | null } | null> {
+  const [row] = await db
+    .select({ artifactId: uploadArtifacts.artifactId, resourceUrl: uploadArtifacts.resourceUrl })
+    .from(uploadArtifacts)
+    .where(eq(uploadArtifacts.id, `${draftId}:${localKey}`));
+  return row ?? null;
+}
+
+/** Reserve (or update the progress of) a sub-artifact, so a retry resumes it instead of
+ * minting a fresh artifactId and re-uploading from scratch. */
+export async function upsertUploadArtifact(
+  draftId: string,
+  localKey: string,
+  data: { artifactId: string; resourceUrl?: string | null },
+): Promise<void> {
+  const id = `${draftId}:${localKey}`;
+  await db
+    .insert(uploadArtifacts)
+    .values({
+      id,
+      projectId: draftId,
+      localKey,
+      artifactId: data.artifactId,
+      resourceUrl: data.resourceUrl ?? null,
+    })
+    .onConflictDoUpdate({
+      target: uploadArtifacts.id,
+      set: { artifactId: data.artifactId, ...(data.resourceUrl !== undefined ? { resourceUrl: data.resourceUrl } : {}) },
+    });
 }
 
 // Draft transfer (.pulse export/import) ----------------------------------------------------

--- a/src/db/pairing.ts
+++ b/src/db/pairing.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { db } from './client';
 import { settings } from './schema';
+import { deletePendingPairingToken, getPendingPairingToken, setPendingPairingToken } from './secure-token';
 
 /**
  * A server pairing the device has connected to but no draft has claimed yet
@@ -20,6 +21,10 @@ export type PendingPairing = {
   uploadUnit: 'beat' | 'merged';
 };
 
+/** The non-secret portion of a `PendingPairing`, persisted as JSON in `settings`. The token
+ * (a live bearer credential) lives in expo-secure-store instead — see `secure-token.ts`. */
+export type PendingPairingMeta = Omit<PendingPairing, 'token'>;
+
 /** Live-queryable row holding the pending pairing's JSON, if any. */
 export const pendingPairingQuery = db
   .select({ value: settings.value })
@@ -27,10 +32,10 @@ export const pendingPairingQuery = db
   .where(eq(settings.key, PENDING_PAIRING_KEY));
 
 /** Parses a `pendingPairingQuery` row's raw value; `null` for missing/corrupt data. */
-export function parsePendingPairing(raw: string | null | undefined): PendingPairing | null {
+export function parsePendingPairing(raw: string | null | undefined): PendingPairingMeta | null {
   if (!raw) return null;
   try {
-    const parsed = JSON.parse(raw) as Partial<PendingPairing>;
+    const parsed = JSON.parse(raw) as Partial<PendingPairingMeta>;
     if (
       typeof parsed.server !== 'string' ||
       typeof parsed.artifactId !== 'string' ||
@@ -40,7 +45,6 @@ export function parsePendingPairing(raw: string | null | undefined): PendingPair
     }
     return {
       server: parsed.server,
-      token: parsed.token ?? null,
       artifactId: parsed.artifactId,
       uploadUnit: parsed.uploadUnit,
     };
@@ -51,16 +55,21 @@ export function parsePendingPairing(raw: string | null | undefined): PendingPair
 
 export async function getPendingPairing(): Promise<PendingPairing | null> {
   const rows = await db.select({ value: settings.value }).from(settings).where(eq(settings.key, PENDING_PAIRING_KEY));
-  return parsePendingPairing(rows[0]?.value);
+  const meta = parsePendingPairing(rows[0]?.value);
+  if (!meta) return null;
+  return { ...meta, token: await getPendingPairingToken() };
 }
 
 export async function setPendingPairing(pairing: PendingPairing): Promise<void> {
+  const meta: PendingPairingMeta = { server: pairing.server, artifactId: pairing.artifactId, uploadUnit: pairing.uploadUnit };
   await db
     .insert(settings)
-    .values({ key: PENDING_PAIRING_KEY, value: JSON.stringify(pairing) })
-    .onConflictDoUpdate({ target: settings.key, set: { value: JSON.stringify(pairing) } });
+    .values({ key: PENDING_PAIRING_KEY, value: JSON.stringify(meta) })
+    .onConflictDoUpdate({ target: settings.key, set: { value: JSON.stringify(meta) } });
+  await setPendingPairingToken(pairing.token);
 }
 
 export async function clearPendingPairing(): Promise<void> {
   await db.delete(settings).where(eq(settings.key, PENDING_PAIRING_KEY));
+  await deletePendingPairingToken();
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,7 +19,8 @@ export const projects = sqliteTable('projects', {
   // declares). `uploadUnit` is resolved once from the server's `/capabilities`
   // at pairing time and cached here so later upload runs don't re-fetch it.
   uploadServer: text('upload_server'),
-  uploadToken: text('upload_token'),
+  // The bearer token itself is NOT stored here — it's a live capability credential, kept in
+  // expo-secure-store instead (`db/secure-token.ts`), not in this plaintext-at-rest table.
   uploadArtifactId: text('upload_artifact_id'),
   uploadUnit: text('upload_unit', { enum: ['beat', 'merged'] }),
   // The TUS resource URL (the `Location` from the initial create) for the
@@ -96,6 +97,25 @@ export const settings = sqliteTable('settings', {
   value: text('value'),
 });
 
+/**
+ * A sub-artifact within an upload session (a beat-mode segment's video/captions, or the
+ * merged-mode session's captions), keyed so a retry can look up and resume the SAME
+ * server-side artifact instead of minting a fresh UUID and re-uploading from scratch.
+ * `localKey` is `"captions"` for the merged-mode session's SRT, or
+ * `` `${segmentId}:video` ``/`` `${segmentId}:captions` `` for beat mode.
+ */
+export const uploadArtifacts = sqliteTable('upload_artifacts', {
+  id: text('id').primaryKey(), // `${projectId}:${localKey}`
+  projectId: text('project_id')
+    .notNull()
+    .references(() => projects.id, { onDelete: 'cascade' }),
+  localKey: text('local_key').notNull(),
+  artifactId: text('artifact_id').notNull(),
+  // Null until the first PATCH round succeeds — see `tus-client.ts`'s `createUpload`.
+  resourceUrl: text('resource_url'),
+});
+
 export type Project = typeof projects.$inferSelect;
 export type Segment = typeof segments.$inferSelect;
 export type Transcript = typeof transcripts.$inferSelect;
+export type UploadArtifact = typeof uploadArtifacts.$inferSelect;

--- a/src/db/secure-token.ts
+++ b/src/db/secure-token.ts
@@ -1,0 +1,36 @@
+import * as SecureStore from 'expo-secure-store';
+
+/**
+ * Upload capability tokens are live bearer credentials (§ pulsevault protocol) — kept in
+ * the Keychain/Keystore via expo-secure-store instead of the plain-SQLite `projects`/
+ * `settings` tables, which are unencrypted at rest and readable from an unencrypted device
+ * backup or a rooted/jailbroken device.
+ */
+const draftTokenKey = (draftId: string) => `upload.token.${draftId}`;
+const PENDING_PAIRING_TOKEN_KEY = 'upload.pendingPairing.token';
+
+export async function getDraftToken(draftId: string): Promise<string | null> {
+  return (await SecureStore.getItemAsync(draftTokenKey(draftId))) ?? null;
+}
+
+export async function setDraftToken(draftId: string, token: string | null): Promise<void> {
+  if (token) await SecureStore.setItemAsync(draftTokenKey(draftId), token);
+  else await SecureStore.deleteItemAsync(draftTokenKey(draftId));
+}
+
+export async function deleteDraftToken(draftId: string): Promise<void> {
+  await SecureStore.deleteItemAsync(draftTokenKey(draftId));
+}
+
+export async function getPendingPairingToken(): Promise<string | null> {
+  return (await SecureStore.getItemAsync(PENDING_PAIRING_TOKEN_KEY)) ?? null;
+}
+
+export async function setPendingPairingToken(token: string | null): Promise<void> {
+  if (token) await SecureStore.setItemAsync(PENDING_PAIRING_TOKEN_KEY, token);
+  else await SecureStore.deleteItemAsync(PENDING_PAIRING_TOKEN_KEY);
+}
+
+export async function deletePendingPairingToken(): Promise<void> {
+  await SecureStore.deleteItemAsync(PENDING_PAIRING_TOKEN_KEY);
+}

--- a/src/features/upload/app-state-gate.ts
+++ b/src/features/upload/app-state-gate.ts
@@ -8,6 +8,7 @@ import { AppState } from 'react-native';
  * imports and testable under this project's pure-logic jest config.
  */
 export function waitUntilAppForeground(signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }));
   if (AppState.currentState === 'active') return Promise.resolve();
   return new Promise((resolve, reject) => {
     const onAbort = () => {

--- a/src/features/upload/native-chunk-upload.ts
+++ b/src/features/upload/native-chunk-upload.ts
@@ -6,6 +6,30 @@ function randomId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+const TUS_RESUME_DIR_NAME = 'tus-resume';
+
+/**
+ * Deletes any leftover files under the cache dir's `tus-resume/` scratch
+ * space. `prepareUploadSource`'s temp copy is only cleaned up in a `finally`
+ * block, which never runs if the app process is killed outright (not just an
+ * aborted upload) mid-resume — leaving a duplicate, unencrypted copy of
+ * potentially sensitive video content sitting in app cache indefinitely.
+ * Call once at app startup: any file found here by definition belongs to a
+ * session that never got a chance to finish uploading, and the next resume
+ * attempt always writes a fresh temp file from the current offset anyway, so
+ * nothing here is ever needed after the process that wrote it is gone.
+ */
+export function cleanupStaleUploadTempFiles(): void {
+  const dir = new Directory(Paths.cache, TUS_RESUME_DIR_NAME);
+  if (!dir.exists) return;
+  try {
+    dir.delete();
+  } catch {
+    // Best-effort — a locked/missing file here just means it'll be retried
+    // next launch, not a reason to fail app startup.
+  }
+}
+
 /**
  * When resuming a partial upload (`offset > 0`), streams just the remainder
  * (from `offset` to EOF) into a temp file via `FileHandle` (seek + bounded

--- a/src/features/upload/upload-deep-link-provider.tsx
+++ b/src/features/upload/upload-deep-link-provider.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/features/toast/toast-provider';
 
 import { CAPABILITIES_REJECTION_MESSAGE, checkCapabilities } from './capabilities';
 import { parseUploadDeepLink } from './deep-link';
+import { cleanupStaleUploadTempFiles } from './native-chunk-upload';
 
 const REJECTION_MESSAGE: Record<'unsupported-version' | 'invalid-link', string> = {
   'unsupported-version':
@@ -23,22 +24,48 @@ function hostOf(url: string): string {
 }
 
 /**
+ * Trust-on-first-use gate (PROTOCOL.md §3): asks the user to confirm the
+ * server's origin before the app makes any request to it — not just a toast
+ * after the fact. Resolves `false` on cancel or dismiss (tap outside / back
+ * button), never defaulting to "proceed".
+ */
+function confirmPairing(host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    Alert.alert(
+      'Connect to this server?',
+      `Pulse will pair with "${host}" and upload to it. Only continue if you recognize this server and opened or scanned this link yourself.`,
+      [
+        { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+        { text: 'Connect', onPress: () => resolve(true) },
+      ],
+      { cancelable: true, onDismiss: () => resolve(false) },
+    );
+  });
+}
+
+/**
  * Mounts the single global `pulsecam://` deep-link listener for the app's
  * lifetime, matching `TranscriptionProvider`'s pattern — a provider rather
  * than a bare hook, so it's guaranteed to subscribe exactly once regardless
  * of where it's rendered, avoiding duplicate-listener bugs.
  *
- * No confirm screen: a recognized link is connected to immediately. Success
- * just stores a global "pending pairing" (db/pairing.ts) and toasts — it
- * does NOT pick a draft. Any draft (a fresh recording or an existing one)
- * can claim it later from its export screen, matching the "this server can
- * receive one upload from this device" single-use model without forcing
- * that choice up front.
+ * A recognized link asks the user to confirm the server's origin (TOFU)
+ * before anything is fetched from it. Confirming just stores a global
+ * "pending pairing" (db/pairing.ts) and toasts — it does NOT pick a draft.
+ * Any draft (a fresh recording or an existing one) can claim it later from
+ * its export screen, matching the "this server can receive one upload from
+ * this device" single-use model without forcing that choice up front.
  */
 export function UploadDeepLinkProvider({ children }: { children: React.ReactNode }) {
   const url = useLinkingURL();
   const handledUrl = useRef<string | null>(null);
   const { showToast } = useToast();
+
+  // Best-effort sweep of orphaned tus-resume temp files from a previous
+  // launch that was killed mid-upload — see `cleanupStaleUploadTempFiles`.
+  useEffect(() => {
+    cleanupStaleUploadTempFiles();
+  }, []);
 
   useEffect(() => {
     if (!url || url === handledUrl.current || !url.startsWith('pulsecam://')) return;
@@ -53,19 +80,34 @@ export function UploadDeepLinkProvider({ children }: { children: React.ReactNode
     const { link } = result;
     const host = hostOf(link.server);
 
-    void checkCapabilities(link.server).then((capResult) => {
-      if (!capResult.ok) {
-        Alert.alert("Can't connect", CAPABILITIES_REJECTION_MESSAGE[capResult.reason]);
+    void confirmPairing(host).then((confirmed) => {
+      if (!confirmed) {
+        // Nothing was persisted and no request was made — let the same link be
+        // scanned/opened again if the user changes their mind.
+        handledUrl.current = null;
         return;
       }
-      void setPendingPairing({
-        server: link.server,
-        token: link.token,
-        artifactId: link.artifactId,
-        uploadUnit: capResult.capabilities.uploadUnit,
-      }).then(() => {
-        showToast(`Connected to ${host} — open a pulse or make a new one to upload`);
-      });
+      return checkCapabilities(link.server)
+        .then((capResult) => {
+          if (!capResult.ok) {
+            Alert.alert("Can't connect", CAPABILITIES_REJECTION_MESSAGE[capResult.reason]);
+            return;
+          }
+          return setPendingPairing({
+            server: link.server,
+            token: link.token,
+            artifactId: link.artifactId,
+            uploadUnit: capResult.capabilities.uploadUnit,
+          }).then(() => {
+            showToast(`Connected to ${host} — open a pulse or make a new one to upload`);
+          });
+        })
+        .catch(() => {
+          // Let the same link be retried — nothing was persisted, so silently swallowing this
+          // would leave the user stuck with no path forward but to restart the app.
+          handledUrl.current = null;
+          Alert.alert("Can't connect", CAPABILITIES_REJECTION_MESSAGE.unreachable);
+        });
     });
   }, [url, showToast]);
 

--- a/src/features/upload/use-upload.ts
+++ b/src/features/upload/use-upload.ts
@@ -3,8 +3,16 @@ import { Directory, File, Paths } from 'expo-file-system';
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { projectQuery, setCaptionsUploadStatus, setUploadDestination, setUploadProgress } from '@/db/drafts';
+import {
+  getUploadArtifact,
+  projectQuery,
+  setCaptionsUploadStatus,
+  setUploadDestination,
+  setUploadProgress,
+  upsertUploadArtifact,
+} from '@/db/drafts';
 import { clearPendingPairing, parsePendingPairing, type PendingPairing, pendingPairingQuery } from '@/db/pairing';
+import { getDraftToken, getPendingPairingToken } from '@/db/secure-token';
 import type { Segment } from '@/db/schema';
 import { useTick } from '@/hooks/use-tick';
 import { useDraftTranscripts } from '@/features/transcription/use-draft-transcripts';
@@ -15,7 +23,13 @@ import { effFile } from '@/utils/segment-window';
 import { waitUntilAppForeground } from './app-state-gate';
 import { decodeCapabilityClaims, isClaimsExpired } from './capability-token';
 import { uploadRemainderNative } from './native-chunk-upload';
-import { type ArtifactKind, cancelTusUpload, type TusUploadOptions, uploadViaTus } from './tus-client';
+import {
+  type ArtifactKind,
+  cancelTusUpload,
+  TusUploadError,
+  type TusUploadOptions,
+  uploadViaTus,
+} from './tus-client';
 
 // Safety margin before a token's real `exp` so we never start a request that would land at the
 // server just past expiry — see `capability-token.ts`. Also how often the hook re-checks expiry
@@ -31,10 +45,12 @@ function isTokenExpired(token: string | null): boolean {
   return isClaimsExpired(claims, EXPIRY_BUFFER_MS, Date.now());
 }
 
+const EXPIRED_PAIRING_MESSAGE = 'Upload link expired — ask the operator for a new pairing link.';
+
 class ExpiredPairingError extends Error {
   readonly retryable = false;
   constructor() {
-    super('Upload link expired — ask the operator for a new pairing link.');
+    super(EXPIRED_PAIRING_MESSAGE);
     this.name = 'ExpiredPairingError';
   }
 }
@@ -94,6 +110,12 @@ function describeError(err: unknown): { reason: string; retryable: boolean } {
  * all in that branch. Every secondary artifact in a session declares
  * `relatedTo` pointing at the session anchor (`destination.artifactId`) so the
  * one capability token issued for that anchor authorizes the whole session.
+ *
+ * Every secondary artifact's identity (and, once known, its resource URL) is
+ * persisted in `upload_artifacts` keyed by a stable local key (e.g. a beat's
+ * `${segmentId}:video`) — a retry looks up the existing entry and resumes it
+ * via `tus-client`'s normal HEAD-then-PATCH resume path instead of minting a
+ * fresh artifactId and re-uploading a duplicate from byte 0.
  */
 export function useUpload(
   draftId: string,
@@ -111,34 +133,82 @@ export function useUpload(
   const [activeState, setActiveState] = useState<UploadState>({ status: 'idle' });
 
   const controllerRef = useRef<AbortController | null>(null);
+  // Guards a double-tap on Retry from leaking the previous run's controller — `start` would
+  // otherwise overwrite `controllerRef.current` with a second one while the first is still
+  // running, making the first uncancellable.
+  const runningRef = useRef(false);
+  // The sub-artifact actually being uploaded right now — not necessarily the session anchor
+  // (e.g. mid-captions-upload in merged mode, or a beat segment) — so `cancel()` can DELETE
+  // the resource that's really in flight instead of always targeting the anchor.
+  const currentUploadRef = useRef<{ artifactId: string; resourceUrl: string | null } | null>(null);
 
   // Re-evaluate expiry on a timer too, not just on writes — a token can go stale while the user
   // is just sitting on this screen.
   useTick(EXPIRY_CHECK_INTERVAL_MS);
 
+  const hasDestination =
+    project?.mode === 'upload' && !!project.uploadServer && !!project.uploadArtifactId && !!project.uploadUnit;
+
+  // The bearer token lives in expo-secure-store, not the (reactive) drizzle-backed `project`
+  // row — SecureStore has no live-query equivalent, so it's loaded into local state keyed off
+  // which draft is showing, and set directly wherever this hook itself writes a fresh token
+  // (`claim()`) so the very first upload in the same tap doesn't have to wait on a re-fetch.
+  // Stale/unused rather than actively reset when `hasDestination` is false — `destination`
+  // below only ever reads it while `hasDestination` is true, and the effect re-fires (keyed
+  // on `draftId`) the moment a destination reappears, so nothing reads a wrong-draft value.
+  const [draftToken, setDraftTokenState] = useState<string | null>(null);
+  useEffect(() => {
+    if (!hasDestination) return;
+    let cancelled = false;
+    void getDraftToken(draftId).then((token) => {
+      if (!cancelled) setDraftTokenState(token);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [draftId, hasDestination]);
+
   const destination: Destination | null = useMemo(
     () =>
-      project?.mode === 'upload' &&
-      project.uploadServer &&
-      project.uploadArtifactId &&
-      project.uploadUnit
+      hasDestination
         ? {
-            server: project.uploadServer,
-            token: project.uploadToken,
-            artifactId: project.uploadArtifactId,
-            uploadUnit: project.uploadUnit,
-            resourceUrl: project.uploadResourceUrl,
+            server: project!.uploadServer!,
+            token: draftToken,
+            artifactId: project!.uploadArtifactId!,
+            uploadUnit: project!.uploadUnit!,
+            resourceUrl: project!.uploadResourceUrl,
           }
         : null,
-    [project],
+    [hasDestination, project, draftToken],
   );
   const destinationExpired = destination !== null && isTokenExpired(destination.token);
 
-  const rawPendingPairing = parsePendingPairing(pendingPairingRows[0]?.value);
-  const pendingPairingExpired = rawPendingPairing !== null && isTokenExpired(rawPendingPairing.token);
+  // Keyed on the row's raw value (not a fresh `parsePendingPairing()` object every render) so
+  // the token-loading effect below only re-fires when the pairing actually changes.
+  const rawPendingPairing = useMemo(
+    () => parsePendingPairing(pendingPairingRows[0]?.value),
+    [pendingPairingRows],
+  );
+  // Stale/unused rather than actively reset when there's no pending pairing — `pendingPairing`
+  // below only ever reads it alongside a truthy `rawPendingPairing`.
+  const [pendingToken, setPendingTokenState] = useState<string | null>(null);
+  useEffect(() => {
+    if (!rawPendingPairing) return;
+    let cancelled = false;
+    void getPendingPairingToken().then((token) => {
+      if (!cancelled) setPendingTokenState(token);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [rawPendingPairing]);
+  const pendingPairingExpired = rawPendingPairing !== null && isTokenExpired(pendingToken);
   // Only offer the global pending pairing on a draft that hasn't already claimed its own
   // destination — and never once it's expired (§ "don't show it when expired").
-  const pendingPairing = destination === null && rawPendingPairing && !pendingPairingExpired ? rawPendingPairing : null;
+  const pendingPairing: PendingPairing | null =
+    destination === null && rawPendingPairing && !pendingPairingExpired
+      ? { ...rawPendingPairing, token: pendingToken }
+      : null;
 
   // Garbage-collect a pairing that went stale before anyone claimed it, so it doesn't linger as
   // dead state and doesn't get raced into `claim()` by a stale closure.
@@ -165,7 +235,8 @@ export function useUpload(
       // the start can go stale partway through. Stopping here with a clear, non-retryable
       // reason beats letting the loop run into a confusing wall of 403s.
       if (isTokenExpired(destination.token)) throw new ExpiredPairingError();
-      return uploadViaTus({
+      currentUploadRef.current = { artifactId: artifact.artifactId, resourceUrl };
+      const result = await uploadViaTus({
         server: destination.server,
         token: destination.token,
         artifactId: artifact.artifactId,
@@ -175,11 +246,27 @@ export function useUpload(
         checksum,
         file: artifact.file,
         resourceUrl,
+        onResourceCreated: (url) => {
+          currentUploadRef.current = { artifactId: artifact.artifactId, resourceUrl: url };
+        },
         signal,
-        waitUntilForeground: waitUntilAppForeground,
+        // A single `uploadOne` call can span one long-lived retry loop (many HEAD/PATCH
+        // cycles), and the app can sit backgrounded for hours mid-upload — long enough for
+        // the token to expire between attempts even though it was checked at the top of this
+        // function. Re-checking here, every time the loop regains foreground (not just once
+        // at the start), surfaces the same clear `ExpiredPairingError`-shaped message instead
+        // of a confusing 403 deep inside the retry loop's backoff.
+        waitUntilForeground: async (sig) => {
+          await waitUntilAppForeground(sig);
+          if (isTokenExpired(destination.token)) {
+            throw new TusUploadError(EXPIRED_PAIRING_MESSAGE, { retryable: false });
+          }
+        },
         uploadRemainder: uploadRemainderNative,
         onProgress,
       });
+      currentUploadRef.current = { artifactId: artifact.artifactId, resourceUrl: result.resourceUrl };
+      return result;
     },
     [],
   );
@@ -204,19 +291,28 @@ export function useUpload(
       if (lines.length > 0) {
         await setCaptionsUploadStatus(draftId, 'uploading');
         const srtFile = writeTempTextFile(`${draftId}.srt`, linesToSrt(lines));
-        await uploadOne(
+        // Reuse a previously-reserved captions artifact so a retry after a captions-PATCH
+        // failure resumes it instead of minting a new UUID and uploading a duplicate.
+        const existing = await getUploadArtifact(draftId, 'captions');
+        const captionsArtifactId = existing?.artifactId ?? Crypto.randomUUID();
+        if (!existing) await upsertUploadArtifact(draftId, 'captions', { artifactId: captionsArtifactId });
+        const captionsResult = await uploadOne(
           destination,
           {
-            artifactId: Crypto.randomUUID(),
+            artifactId: captionsArtifactId,
             filename: `${draftId}.srt`,
             kind: 'captions',
             relatedTo: destination.artifactId,
             file: srtFile,
           },
-          null,
+          existing?.resourceUrl ?? null,
           undefined,
           signal,
         );
+        await upsertUploadArtifact(draftId, 'captions', {
+          artifactId: captionsArtifactId,
+          resourceUrl: captionsResult.resourceUrl,
+        });
         await setCaptionsUploadStatus(draftId, 'uploaded');
       }
       return result.resourceUrl;
@@ -231,46 +327,62 @@ export function useUpload(
       const reportProgress = () =>
         setActiveState({ status: 'uploading', progress: totalBytes ? completed / totalBytes : 0 });
 
-      // The wire protocol requires a UUID `artifactId` (see PROTOCOL.md §4.1);
-      // this app's local segment ids are `${draftId}-${timestamp}` strings, not
-      // UUIDs, so each beat gets a freshly minted UUID for the upload itself.
-      // The manifest below records the mapping so order/identity survives.
-      const beatArtifactIds = new Map(segments.map((s) => [s.id, Crypto.randomUUID()]));
-
       for (const segment of segments) {
         const file = new File(absolutize(effFile(segment)));
         const checksum = await sha256Checksum(file);
-        const artifactId = beatArtifactIds.get(segment.id)!;
-        await uploadOne(
+
+        // The wire protocol requires a UUID `artifactId` (see PROTOCOL.md §4.1); this app's
+        // local segment ids are `${draftId}-${timestamp}` strings, not UUIDs, so each beat
+        // gets a freshly minted UUID the first time it's uploaded. Persisted in
+        // `upload_artifacts` so a retry resumes the SAME artifact instead of minting another.
+        const videoKey = `${segment.id}:video`;
+        const existingVideo = await getUploadArtifact(draftId, videoKey);
+        const videoArtifactId = existingVideo?.artifactId ?? Crypto.randomUUID();
+        if (!existingVideo) await upsertUploadArtifact(draftId, videoKey, { artifactId: videoArtifactId });
+        const videoResult = await uploadOne(
           destination,
           {
-            artifactId,
+            artifactId: videoArtifactId,
             filename: `${segment.id}.mp4`,
             kind: 'video',
             relatedTo: destination.artifactId,
             file,
           },
-          null,
+          existingVideo?.resourceUrl ?? null,
           checksum,
           signal,
         );
+        await upsertUploadArtifact(draftId, videoKey, {
+          artifactId: videoArtifactId,
+          resourceUrl: videoResult.resourceUrl,
+        });
 
         const lines = transcripts.get(segment.id)?.lines ?? [];
         if (lines.length > 0) {
+          const captionsKey = `${segment.id}:captions`;
+          const existingCaptions = await getUploadArtifact(draftId, captionsKey);
+          const captionsArtifactId = existingCaptions?.artifactId ?? Crypto.randomUUID();
+          if (!existingCaptions) {
+            await upsertUploadArtifact(draftId, captionsKey, { artifactId: captionsArtifactId });
+          }
           const srtFile = writeTempTextFile(`${segment.id}.srt`, linesToSrt(lines));
-          await uploadOne(
+          const captionsResult = await uploadOne(
             destination,
             {
-              artifactId: Crypto.randomUUID(),
+              artifactId: captionsArtifactId,
               filename: `${segment.id}.srt`,
               kind: 'captions',
               relatedTo: destination.artifactId,
               file: srtFile,
             },
-            null,
+            existingCaptions?.resourceUrl ?? null,
             undefined,
             signal,
           );
+          await upsertUploadArtifact(draftId, captionsKey, {
+            artifactId: captionsArtifactId,
+            resourceUrl: captionsResult.resourceUrl,
+          });
         }
 
         completed += 1;
@@ -282,6 +394,11 @@ export function useUpload(
       // zip format that extension is documented with elsewhere — it's purely
       // an allowlist check — and `uploadUnit: "beat"` is the default, so this
       // has to work without requiring the operator to reconfigure anything).
+      const beatArtifactIds = new Map<string, string>();
+      for (const segment of segments) {
+        const row = await getUploadArtifact(draftId, `${segment.id}:video`);
+        if (row) beatArtifactIds.set(segment.id, row.artifactId);
+      }
       const manifest = JSON.stringify({
         version: 1,
         beats: segments.map((s, i) => ({ artifactId: beatArtifactIds.get(s.id), order: i })),
@@ -306,6 +423,9 @@ export function useUpload(
     async (explicitDestination?: Destination) => {
       const dest = explicitDestination ?? destination;
       if (!dest) return;
+      // A run is already in flight — ignore a double-tap on Retry rather than overwriting
+      // `controllerRef.current` and leaking the first run's controller uncancellable.
+      if (runningRef.current) return;
       // Checked before even attempting the request, not just inside `uploadOne` — no point
       // flashing "uploading" for a run that's already dead on arrival.
       if (isTokenExpired(dest.token)) {
@@ -314,6 +434,7 @@ export function useUpload(
         await setUploadProgress(draftId, { status: 'failed' });
         return;
       }
+      runningRef.current = true;
       const controller = new AbortController();
       controllerRef.current = controller;
       setActiveState({ status: 'uploading', progress: 0 });
@@ -328,6 +449,9 @@ export function useUpload(
         const { reason, retryable } = describeError(err);
         setActiveState({ status: 'error', reason, retryable });
         await setUploadProgress(draftId, { status: 'failed' });
+      } finally {
+        runningRef.current = false;
+        currentUploadRef.current = null;
       }
     },
     [destination, draftId, uploadMerged, uploadBeats],
@@ -347,6 +471,7 @@ export function useUpload(
         resourceUrl: null,
       };
       await setUploadDestination(draftId, pairing);
+      setDraftTokenState(pairing.token);
       await clearPendingPairing();
       await start(claimedDestination);
     },
@@ -355,12 +480,25 @@ export function useUpload(
 
   const cancel = useCallback(async () => {
     controllerRef.current?.abort();
-    if (destination?.resourceUrl) {
-      await cancelTusUpload(destination.resourceUrl, destination.token);
+    // Target whatever's actually in flight right now — a beat/captions sub-artifact may not
+    // be the session anchor (`destination.resourceUrl`) at all — falling back to the anchor
+    // only if nothing had started uploading yet.
+    const target = currentUploadRef.current?.resourceUrl ?? destination?.resourceUrl ?? null;
+    if (target) {
+      await cancelTusUpload(target, destination?.token ?? null);
     }
     await setUploadProgress(draftId, { status: 'idle' });
     setActiveState({ status: 'idle' });
   }, [destination, draftId]);
+
+  // Abort whatever's in flight if this hook instance unmounts mid-upload — otherwise the
+  // upload loop (and its DB writes) keeps running after the screen that started it is gone,
+  // potentially racing a fresh hook instance mounted for the same draft.
+  useEffect(() => {
+    return () => {
+      controllerRef.current?.abort();
+    };
+  }, []);
 
   return { state, destination, destinationExpired, pendingPairing, start, retry: start, cancel, claim };
 }


### PR DESCRIPTION
## Summary

Bundles several related upload/pairing security and robustness fixes:

- **Tokens out of plaintext SQLite.** Upload/pairing bearer tokens were stored in the plain `projects.upload_token` / `settings` columns — unencrypted at rest, readable from an unencrypted device backup or a rooted/jailbroken device. They now live in `expo-secure-store` (Keychain/Keystore) via a new `db/secure-token.ts`, with migrations dropping the old column and adding an `upload_artifacts` table.
- **Resumable per-artifact uploads.** Each beat's video/captions (or a merged-mode session's captions) previously got a fresh random `artifactId` on every retry, so a partial failure meant re-uploading already-completed pieces from scratch under orphaned server-side ids. Each sub-artifact's identity and resource URL are now persisted and resumed via `getUploadArtifact`/`upsertUploadArtifact`.
- **Trust-on-first-use pairing confirmation.** A recognized `pulsecam://` link previously connected immediately with no chance to see or decline the server's origin. Now shows a confirmation naming the host before any request is made (PROTOCOL.md §3).
- **Stale temp file cleanup.** The resumable-upload temp copy in app cache is now swept on next launch if the app was killed mid-upload, instead of lingering indefinitely.
- **Watch-link sharing warning.** The export screen's watch link embeds a live bearer token; copy/share now warns before it leaves the app.

Also fixes a couple of smaller correctness issues found along the way: a double-tap on Retry could leak the previous run's `AbortController`; `cancel()` could target the wrong resource mid-captions-upload; the retry loop didn't re-check token expiry after a long backgrounding period.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `jest src/features/upload src/db` — 26/26 passing