### PR TITLE
Fix theme fallback for unrecognized color scheme values

### DIFF
--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -3,7 +3,10 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export function useTheme() {
   const scheme = useColorScheme();
-  const theme = scheme === 'unspecified' ? 'light' : scheme;
+  // `useColorScheme()` can return `null`/`undefined` (scheme not yet known) as well as the
+  // literal `"unspecified"` (Android's Appearance API when the OS reports no preference) —
+  // none of those are keys in `Colors`, so all three fall back to light.
+  const theme = scheme === 'light' || scheme === 'dark' ? scheme : 'light';
 
   return Colors[theme];
 }


### PR DESCRIPTION
## Summary

`useColorScheme()` can return `null`/`undefined` (scheme not yet known) in addition to the literal `"unspecified"` (Android's `Appearance` API when the OS reports no preference). Only `"unspecified"` was handled — a `null`/`undefined` scheme fell through to being used directly as a key into `Colors`, which has no entry for it. `useTheme` now falls back to `light` unless the scheme is exactly `"light"` or `"dark"`.

## Test plan

- [x] `tsc --noEmit` — clean