### PR TITLE
feat: beat-mode upload without eager merge + pairing-link uploadUnit override

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "enabledPlugins": {
-    "expo@claude-plugins-official": true
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node_modules/
 dist/
 web-build/
 expo-env.d.ts
+.claude/
+.vscode/
+.cursor/
 
 # Native
 .kotlin/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,1 +1,0 @@
-{ "recommendations": ["expo.vscode-expo-tools"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "source.organizeImports": "explicit",
-    "source.sortMembers": "explicit"
-  }
-}

--- a/src/app/export.tsx
+++ b/src/app/export.tsx
@@ -4,7 +4,7 @@ import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 import { useLocalSearchParams } from 'expo-router';
 import { Icon } from '@/components/icon';
 import { useVideoPlayer, VideoView } from 'expo-video';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, Share, StyleSheet, View } from 'react-native';
 import { shareAsync } from 'expo-sharing';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -15,6 +15,7 @@ import { CloseButton } from '@/features/recorder/close-button';
 import { Spacing } from '@/constants/theme';
 import { useTheme } from '@/hooks/use-theme';
 import { segmentsForDraft } from '@/db/drafts';
+import type { Segment } from '@/db/schema';
 import { useExport } from '@/features/export/use-export';
 import { MergeProgressRing } from '@/features/export/merge-progress-ring';
 import { useSaveToDocuments } from '@/features/export/use-save-to-documents';
@@ -27,6 +28,9 @@ import type { TranscriptLine } from '@/features/transcription/whisper';
 import { type UploadState, useUpload } from '@/features/upload/use-upload';
 import { formatClipCount, formatDuration } from '@/utils/format';
 import { effMs } from '@/utils/segment-window';
+
+/** Sum of each clip's effective duration — the beat-mode summary line has no merged output to read a duration from. */
+const totalDurationMs = (clips: Segment[]) => clips.reduce((sum, s) => sum + effMs(s), 0);
 
 function hostOf(url: string): string {
   try {
@@ -71,7 +75,29 @@ export default function ExportScreen() {
   }, [draftId]);
   // Zero-length clips (failed native reads) can't be concatenated — drop them before merging.
   const clips = segments.filter((s) => effMs(s) > 0);
-  const { state, retry } = useExport(clips);
+
+  // Stable ref (not a plain value) so `useUpload` can be called — and its `destination`/
+  // `pendingPairing` read — before the merge even starts. Breaks what would otherwise be a
+  // circular dependency: `useExport`'s `auto` option needs to know the destination's
+  // `uploadUnit`, which comes from `useUpload`, which needs the merged output. See the
+  // `useUpload` doc comment.
+  const mergedRef = useRef<{ path: string; durationMs: number } | null>(null);
+  const upload = useUpload(draftId ?? '', clips, mergedRef);
+
+  // A beat destination uploads each clip individually — `uploadBeats` never reads the merged
+  // file — so there's no reason to block this screen on a merge it doesn't need. `pendingPairing`
+  // covers a draft that hasn't claimed its destination yet (§ pairing UX): the same distinction
+  // has to apply before the first tap, not just after.
+  const effectiveUploadUnit = upload.destination?.uploadUnit ?? upload.pendingPairing?.uploadUnit ?? null;
+  const isBeatOnly = effectiveUploadUnit === 'beat';
+
+  const { state, run } = useExport(clips, { auto: !isBeatOnly });
+  // `uploadMerged` reads `mergedRef.current` at upload time, not via a reactive prop — update it
+  // whenever the merge's own state changes instead of threading `merged` through as a value.
+  useEffect(() => {
+    mergedRef.current =
+      state.status === 'done' ? { path: state.outputPath, durationMs: state.durationMs } : null;
+  }, [state]);
 
   // Captions stitched onto one draft-wide timeline (same clip order/offsets as the merge), for the
   // preview overlay.
@@ -84,9 +110,10 @@ export default function ExportScreen() {
   const docs = useSaveToDocuments();
   const theme = useTheme();
 
-  const merged =
-    state.status === 'done' ? { path: state.outputPath, durationMs: state.durationMs } : null;
-  const upload = useUpload(draftId ?? '', clips, merged);
+  // Merged-only: uploading the single video needs the merge done first. Beat mode has nothing to
+  // wait on — each clip uploads on its own, so the section shows up immediately.
+  const uploadReady = isBeatOnly || state.status === 'done';
+
   const watchUrl =
     upload.destination?.uploadUnit === 'merged'
       ? `${upload.destination.server}/artifacts/${upload.destination.artifactId}${
@@ -250,114 +277,32 @@ export default function ExportScreen() {
                 )}
               </Pressable>
             </View>
+          </>
+        )}
 
-            {(upload.destination || upload.pendingPairing) && (
-              <View style={styles.uploadSection}>
-                <ThemedText
-                  type="caption1"
-                  themeColor="textSecondary"
-                  style={styles.uploadSectionLabel}>
-                  UPLOAD
-                </ThemedText>
+        {state.status === 'idle' && (
+          <>
+            <ThemedText type="subtitle" style={styles.title}>
+              Ready to upload
+            </ThemedText>
+            <ThemedText themeColor="textSecondary">
+              {formatClipCount(clips.length)} · {formatDuration(totalDurationMs(clips))}
+            </ThemedText>
 
-                {upload.destination ? (
-                  upload.destinationExpired && upload.state.status === 'idle' ? (
-                    <View style={[styles.button, { backgroundColor: theme.backgroundElement }]}>
-                      <Icon
-                        name="exclamationmark.triangle.fill"
-                        size={18}
-                        tintColor={theme.textSecondary}
-                      />
-                      <ThemedText themeColor="textSecondary">Upload link expired</ThemedText>
-                    </View>
-                  ) : (
-                    <Pressable
-                      onPress={() => {
-                        if (upload.state.status === 'idle') void upload.start();
-                        else if (upload.state.status === 'error' && upload.state.retryable)
-                          void upload.retry();
-                        else if (upload.state.status === 'done') void copyWatchLink();
-                      }}
-                      onLongPress={upload.state.status === 'done' ? shareWatchLink : undefined}
-                      disabled={upload.state.status === 'uploading'}
-                      accessibilityRole="button"
-                      accessibilityLabel={uploadButtonLabel(
-                        upload.state,
-                        upload.destination.server,
-                      )}
-                      style={({ pressed }) => [
-                        styles.button,
-                        { backgroundColor: theme.backgroundElement },
-                        pressed && styles.pressed,
-                      ]}>
-                      {upload.state.status === 'uploading' ? (
-                        <>
-                          <ActivityIndicator color={theme.text} />
-                          <ThemedText>
-                            Uploading… {Math.round(upload.state.progress * 100)}%
-                          </ThemedText>
-                          <Pressable
-                            onPress={() => void upload.cancel()}
-                            hitSlop={8}
-                            accessibilityRole="button"
-                            accessibilityLabel="Cancel upload">
-                            <Icon name="xmark" size={16} tintColor={theme.textSecondary} />
-                          </Pressable>
-                        </>
-                      ) : upload.state.status === 'done' ? (
-                        <>
-                          <Icon name="checkmark" size={18} tintColor={theme.text} />
-                          <ThemedText>Uploaded — Copy link</ThemedText>
-                        </>
-                      ) : upload.state.status === 'error' ? (
-                        <>
-                          <Icon
-                            name="exclamationmark.triangle.fill"
-                            size={18}
-                            tintColor={theme.accent}
-                          />
-                          <ThemedText>
-                            {upload.state.retryable
-                              ? 'Upload failed — Retry'
-                              : 'Rejected by server'}
-                          </ThemedText>
-                        </>
-                      ) : (
-                        <>
-                          <Icon name="icloud.and.arrow.up" size={18} tintColor={theme.text} />
-                          <ThemedText>Upload to {hostOf(upload.destination.server)}</ThemedText>
-                        </>
-                      )}
-                    </Pressable>
-                  )
-                ) : (
-                  // Gated on `idle` too, not just `pendingPairing` itself, so a tap can't double-fire in
-                  // the brief window between `claim()` flipping local state to "uploading" and the
-                  // destination/pendingPairing live queries catching up to make `destination` non-null.
-                  upload.pendingPairing &&
-                  upload.state.status === 'idle' && (
-                    <Pressable
-                      onPress={() => void upload.claim(upload.pendingPairing!)}
-                      accessibilityRole="button"
-                      accessibilityLabel={`Upload to ${hostOf(upload.pendingPairing.server)}`}
-                      style={({ pressed }) => [
-                        styles.button,
-                        { backgroundColor: theme.backgroundElement },
-                        pressed && styles.pressed,
-                      ]}>
-                      <Icon name="icloud.and.arrow.up" size={18} tintColor={theme.text} />
-                      <ThemedText>Upload to {hostOf(upload.pendingPairing.server)}</ThemedText>
-                    </Pressable>
-                  )
-                )}
-
-                {upload.state.status === 'error' && (
-                  <ThemedText themeColor="textSecondary" type="small" style={styles.errorMessage}>
-                    {upload.state.reason}
-                  </ThemedText>
-                )}
-              </View>
-            )}
+            <View style={styles.actions}>
+              <Pressable
+                onPress={run}
+                accessibilityRole="button"
+                accessibilityLabel="Export a merged copy"
+                style={({ pressed }) => [
+                  styles.button,
+                  { backgroundColor: theme.backgroundElement },
+                  pressed && styles.pressed,
+                ]}>
+                <Icon name="film" size={18} tintColor={theme.text} />
+                <ThemedText>Export a merged copy</ThemedText>
+              </Pressable>
+            </View>
           </>
         )}
 
@@ -365,7 +310,7 @@ export default function ExportScreen() {
           <>
             <Icon name="exclamationmark.triangle.fill" size={64} tintColor={theme.accent} />
             <ThemedText type="subtitle" style={styles.title}>
-              Export failed
+              {isBeatOnly ? 'Merged copy failed' : 'Export failed'}
             </ThemedText>
             <ThemedText themeColor="textSecondary" style={styles.errorMessage}>
               {state.message}
@@ -373,7 +318,7 @@ export default function ExportScreen() {
 
             <View style={styles.actions}>
               <Pressable
-                onPress={retry}
+                onPress={run}
                 accessibilityRole="button"
                 accessibilityLabel="Try again"
                 style={({ pressed }) => [
@@ -386,6 +331,99 @@ export default function ExportScreen() {
               </Pressable>
             </View>
           </>
+        )}
+
+        {/* Beat mode has nothing to wait on (each clip uploads on its own) so this shows up
+            regardless of merge state; merged mode still needs `state.status === 'done'` first —
+            see `uploadReady`. */}
+        {(upload.destination || upload.pendingPairing) && uploadReady && (
+          <View style={styles.uploadSection}>
+            <ThemedText type="caption1" themeColor="textSecondary" style={styles.uploadSectionLabel}>
+              UPLOAD
+            </ThemedText>
+
+            {upload.destination ? (
+              upload.destinationExpired && upload.state.status === 'idle' ? (
+                <View style={[styles.button, { backgroundColor: theme.backgroundElement }]}>
+                  <Icon name="exclamationmark.triangle.fill" size={18} tintColor={theme.textSecondary} />
+                  <ThemedText themeColor="textSecondary">Upload link expired</ThemedText>
+                </View>
+              ) : (
+                <Pressable
+                  onPress={() => {
+                    if (upload.state.status === 'idle') void upload.start();
+                    else if (upload.state.status === 'error' && upload.state.retryable)
+                      void upload.retry();
+                    else if (upload.state.status === 'done') void copyWatchLink();
+                  }}
+                  onLongPress={upload.state.status === 'done' ? shareWatchLink : undefined}
+                  disabled={upload.state.status === 'uploading'}
+                  accessibilityRole="button"
+                  accessibilityLabel={uploadButtonLabel(upload.state, upload.destination.server)}
+                  style={({ pressed }) => [
+                    styles.button,
+                    { backgroundColor: theme.backgroundElement },
+                    pressed && styles.pressed,
+                  ]}>
+                  {upload.state.status === 'uploading' ? (
+                    <>
+                      <ActivityIndicator color={theme.text} />
+                      <ThemedText>Uploading… {Math.round(upload.state.progress * 100)}%</ThemedText>
+                      <Pressable
+                        onPress={() => void upload.cancel()}
+                        hitSlop={8}
+                        accessibilityRole="button"
+                        accessibilityLabel="Cancel upload">
+                        <Icon name="xmark" size={16} tintColor={theme.textSecondary} />
+                      </Pressable>
+                    </>
+                  ) : upload.state.status === 'done' ? (
+                    <>
+                      <Icon name="checkmark" size={18} tintColor={theme.text} />
+                      <ThemedText>Uploaded — Copy link</ThemedText>
+                    </>
+                  ) : upload.state.status === 'error' ? (
+                    <>
+                      <Icon name="exclamationmark.triangle.fill" size={18} tintColor={theme.accent} />
+                      <ThemedText>
+                        {upload.state.retryable ? 'Upload failed — Retry' : 'Rejected by server'}
+                      </ThemedText>
+                    </>
+                  ) : (
+                    <>
+                      <Icon name="icloud.and.arrow.up" size={18} tintColor={theme.text} />
+                      <ThemedText>Upload to {hostOf(upload.destination.server)}</ThemedText>
+                    </>
+                  )}
+                </Pressable>
+              )
+            ) : (
+              // Gated on `idle` too, not just `pendingPairing` itself, so a tap can't double-fire in
+              // the brief window between `claim()` flipping local state to "uploading" and the
+              // destination/pendingPairing live queries catching up to make `destination` non-null.
+              upload.pendingPairing &&
+              upload.state.status === 'idle' && (
+                <Pressable
+                  onPress={() => void upload.claim(upload.pendingPairing!)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Upload to ${hostOf(upload.pendingPairing.server)}`}
+                  style={({ pressed }) => [
+                    styles.button,
+                    { backgroundColor: theme.backgroundElement },
+                    pressed && styles.pressed,
+                  ]}>
+                  <Icon name="icloud.and.arrow.up" size={18} tintColor={theme.text} />
+                  <ThemedText>Upload to {hostOf(upload.pendingPairing.server)}</ThemedText>
+                </Pressable>
+              )
+            )}
+
+            {upload.state.status === 'error' && (
+              <ThemedText themeColor="textSecondary" type="small" style={styles.errorMessage}>
+                {upload.state.reason}
+              </ThemedText>
+            )}
+          </View>
         )}
       </View>
     </ThemedView>

--- a/src/features/export/use-export.ts
+++ b/src/features/export/use-export.ts
@@ -8,6 +8,7 @@ import { effFile, effMs } from '@/utils/segment-window';
 const Native = VideoTrim as Spec;
 
 export type ExportState =
+  | { status: 'idle' }
   | { status: 'merging'; progress: number }
   | { status: 'done'; outputPath: string; durationMs: number }
   | { status: 'error'; message: string };
@@ -17,12 +18,26 @@ export type ExportState =
  * (passthrough join for uniform clips, selective outlier-conform for mixed, re-encode fallback).
  * Joins each clip's EFFECTIVE file (edited ?? original) in timeline order. A single-clip draft
  * skips the merge and exports that file directly (nothing to concatenate). The job re-runs only
- * when the clip set actually changes (keyed on a file signature, not array identity) or on `retry`.
+ * when the clip set actually changes (keyed on a file signature, not array identity) or on `run`.
+ *
+ * `options.auto` (default `true`) controls whether the merge starts on mount. Pass `false` for a
+ * beat-mode upload destination — `uploadBeats` never touches the merged file, so merging eagerly
+ * would just be wasted CPU/battery blocking the screen for no reason. The hook stays `idle` until
+ * something (Share, Save, Preview) calls `run()` on demand.
  */
-export function useExport(segments: Segment[]) {
-  const [state, setState] = useState<ExportState>({ status: 'merging', progress: 0 });
+export function useExport(segments: Segment[], options?: { auto?: boolean }) {
+  const auto = options?.auto ?? true;
+  // Lazy initializer, snapshotted once at mount — just avoids a one-frame "idle" flash for the
+  // common case where `auto` doesn't change over the component's lifetime. The effect below is
+  // what actually corrects state if `auto` changes later (e.g. a destination resolves after mount).
+  const [state, setState] = useState<ExportState>(() =>
+    auto ? { status: 'merging', progress: 0 } : { status: 'idle' },
+  );
   const [attempt, setAttempt] = useState(0);
-  const retry = () => setAttempt((n) => n + 1);
+  const run = () => setAttempt((n) => n + 1);
+
+  // Not auto-running and nobody has explicitly called `run()` yet — the merge below never runs.
+  const shouldRun = auto || attempt > 0;
 
   // Stable across re-renders that don't change the actual clips, so the live query re-emitting
   // the same data doesn't kick off a second merge.
@@ -30,7 +45,8 @@ export function useExport(segments: Segment[]) {
   const signature = files.join('|');
 
   useEffect(() => {
-    if (segments.length === 0) return;
+    if (segments.length === 0 || !shouldRun) return;
+
     // A late merge resolving after this effect re-ran (or the screen unmounted) must not clobber
     // newer state — only the most recent run is allowed to commit.
     let current = true;
@@ -70,7 +86,10 @@ export function useExport(segments: Segment[]) {
       sub.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [signature, attempt]);
+  }, [signature, attempt, shouldRun]);
 
-  return { state, retry };
+  // Derived, not stored: overrides a stale `merging`/`done`/`error` value left over from a
+  // previous render where `auto` was true (e.g. the destination changed shape) without needing a
+  // corrective `setState` inside the effect above.
+  return { state: shouldRun ? state : { status: 'idle' as const }, run };
 }

--- a/src/features/upload/deep-link.test.ts
+++ b/src/features/upload/deep-link.test.ts
@@ -11,7 +11,12 @@ describe('parseUploadDeepLink', () => {
     );
     expect(result).toEqual({
       ok: true,
-      link: { artifactId: ARTIFACT_ID, server: 'https://vault.example.org', token: 'secret' },
+      link: {
+        artifactId: ARTIFACT_ID,
+        server: 'https://vault.example.org',
+        token: 'secret',
+        uploadUnit: null,
+      },
     });
   });
 
@@ -21,7 +26,7 @@ describe('parseUploadDeepLink', () => {
     );
     expect(result).toEqual({
       ok: true,
-      link: { artifactId: ARTIFACT_ID, server: 'https://vault.example.org', token: null },
+      link: { artifactId: ARTIFACT_ID, server: 'https://vault.example.org', token: null, uploadUnit: null },
     });
   });
 
@@ -78,13 +83,42 @@ describe('parseUploadDeepLink', () => {
     );
     expect(result).toEqual({
       ok: true,
-      link: { artifactId: ARTIFACT_ID, server: 'https://vault.example.org/pulsevault', token: null },
+      link: {
+        artifactId: ARTIFACT_ID,
+        server: 'https://vault.example.org/pulsevault',
+        token: null,
+        uploadUnit: null,
+      },
     });
   });
 
   it('rejects an unparseable server value', () => {
     const result = parseUploadDeepLink(
       `pulsecam://?v=1&artifactId=${ARTIFACT_ID}&server=not-a-url`,
+    );
+    expect(result).toEqual({ ok: false, reason: 'invalid-link' });
+  });
+
+  it('accepts an explicit uploadUnit override, either value', () => {
+    for (const uploadUnit of ['beat', 'merged']) {
+      const result = parseUploadDeepLink(
+        `pulsecam://?v=1&artifactId=${ARTIFACT_ID}&server=https%3A%2F%2Fvault.example.org&uploadUnit=${uploadUnit}`,
+      );
+      expect(result).toEqual({
+        ok: true,
+        link: {
+          artifactId: ARTIFACT_ID,
+          server: 'https://vault.example.org',
+          token: null,
+          uploadUnit,
+        },
+      });
+    }
+  });
+
+  it('rejects an invalid uploadUnit value', () => {
+    const result = parseUploadDeepLink(
+      `pulsecam://?v=1&artifactId=${ARTIFACT_ID}&server=https%3A%2F%2Fvault.example.org&uploadUnit=bogus`,
     );
     expect(result).toEqual({ ok: false, reason: 'invalid-link' });
   });

--- a/src/features/upload/deep-link.ts
+++ b/src/features/upload/deep-link.ts
@@ -15,6 +15,12 @@ export type UploadDeepLink = {
    */
   server: string;
   token: string | null;
+  /**
+   * Per-session override of the deployment-wide value from `GET
+   * /capabilities` (PROTOCOL.md §3, §8). `null` means the link didn't carry
+   * one — fall back to `/capabilities` exactly as before this field existed.
+   */
+  uploadUnit: 'beat' | 'merged' | null;
 };
 
 export type DeepLinkResult =
@@ -83,5 +89,12 @@ export function parseUploadDeepLink(url: string): DeepLinkResult {
   // mounted pulsevault at, breaking every subsequent request.
   const server = rawServer.replace(/\/$/, '');
 
-  return { ok: true, link: { artifactId, server, token: param('token') } };
+  // Optional — absent on a link from an operator/server predating this field. Present but not
+  // one of the two known values means a corrupt/forged link, same treatment as a bad artifactId.
+  const rawUploadUnit = param('uploadUnit');
+  if (rawUploadUnit !== null && rawUploadUnit !== 'beat' && rawUploadUnit !== 'merged') {
+    return { ok: false, reason: 'invalid-link' };
+  }
+
+  return { ok: true, link: { artifactId, server, token: param('token'), uploadUnit: rawUploadUnit } };
 }

--- a/src/features/upload/upload-deep-link-provider.tsx
+++ b/src/features/upload/upload-deep-link-provider.tsx
@@ -1,4 +1,5 @@
 import { useLinkingURL } from 'expo-linking';
+import { router } from 'expo-router';
 import { useEffect, useRef } from 'react';
 import { Alert } from 'react-native';
 
@@ -71,6 +72,15 @@ export function UploadDeepLinkProvider({ children }: { children: React.ReactNode
     if (!url || url === handledUrl.current || !url.startsWith('pulsecam://')) return;
     handledUrl.current = url;
 
+    // Expo Router has no route matching this scheme-only URL (no path, just query params), so
+    // its own automatic Linking-to-route resolution pushes the root route on top of whatever
+    // screen was already open (PROTOCOL.md §3 — this link is data-only, never meant to navigate
+    // anywhere on its own). By the time this effect runs, that push has already happened — this
+    // provider is the parent of `<Stack>`, so its own linking subscription fires first. Collapse
+    // it back to a single screen immediately, before even asking to confirm the pairing, so a
+    // rejected/invalid link doesn't leave the extra screen behind either.
+    router.dismissAll();
+
     const result = parseUploadDeepLink(url);
     if (!result.ok) {
       Alert.alert("Can't open this link", REJECTION_MESSAGE[result.reason]);
@@ -93,11 +103,14 @@ export function UploadDeepLinkProvider({ children }: { children: React.ReactNode
             Alert.alert("Can't connect", CAPABILITIES_REJECTION_MESSAGE[capResult.reason]);
             return;
           }
+          // The link's own `uploadUnit` (if present) is a per-session override of the
+          // deployment-wide value `/capabilities` reports (PROTOCOL.md §3, §8) — prefer it.
+          // `/capabilities` is still fetched regardless, for the protocol-version check above.
           return setPendingPairing({
             server: link.server,
             token: link.token,
             artifactId: link.artifactId,
-            uploadUnit: capResult.capabilities.uploadUnit,
+            uploadUnit: link.uploadUnit ?? capResult.capabilities.uploadUnit,
           }).then(() => {
             showToast(`Connected to ${host} — open a pulse or make a new one to upload`);
           });

--- a/src/features/upload/use-upload.ts
+++ b/src/features/upload/use-upload.ts
@@ -1,7 +1,7 @@
 import * as Crypto from 'expo-crypto';
 import { Directory, File, Paths } from 'expo-file-system';
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   getUploadArtifact,
@@ -138,11 +138,18 @@ function describeError(err: unknown): ErrorDescription {
  * `${segmentId}:video`) — a retry looks up the existing entry and resumes it
  * via `tus-client`'s normal HEAD-then-PATCH resume path instead of minting a
  * fresh artifactId and re-uploading a duplicate from byte 0.
+ *
+ * `mergedRef` is a ref (not a plain value) so this hook can be called — and its `destination` read
+ * — before the merged output is known. Its identity is stable across renders, which is what lets
+ * `export.tsx` decide whether to auto-merge at all (via `useExport`'s `auto` option) using this
+ * hook's own `destination`, without a circular "useExport needs destination, useUpload needs
+ * merged" dependency. Only read at upload time (`uploadMerged`), never rendered, so a ref is
+ * enough — no re-render needed when the merge finishes.
  */
 export function useUpload(
   draftId: string,
   segments: Segment[],
-  merged: { path: string; durationMs: number } | null,
+  mergedRef: RefObject<{ path: string; durationMs: number } | null>,
 ) {
   const { data: projectRows } = useLiveQuery(projectQuery(draftId), [draftId]);
   const project = projectRows[0];
@@ -303,6 +310,7 @@ export function useUpload(
 
   const uploadMerged = useCallback(
     async (destination: Destination, signal: AbortSignal) => {
+      const merged = mergedRef.current;
       if (!merged) throw new Error('Export is not ready yet');
       const file = new File(merged.path);
       const checksum = await sha256Checksum(file);
@@ -351,7 +359,7 @@ export function useUpload(
       }
       return result.resourceUrl;
     },
-    [draftId, merged, segments, transcripts, uploadOne],
+    [draftId, mergedRef, segments, transcripts, uploadOne],
   );
 
   const uploadBeats = useCallback(


### PR DESCRIPTION
Closes #40

## Summary
- `parseUploadDeepLink` reads the optional `uploadUnit` param a pairing link can now carry (mieweb/pulsevault#28) and prefers it over the deployment-wide `/capabilities` value when present
- Export screen no longer eagerly merges clips when the upload destination is beat-mode (`uploadBeats` never touches the merged file) — merge now runs on demand via `useExport`'s new `auto` option
- Untrack `.claude/settings.json` and `.vscode/{settings,extensions}.json` now that `.claude/`, `.vscode/`, `.cursor/` are gitignored
- Bump the `pulsevault-mieweb` submodule pointer to the branch backing the linked PR

## Test plan
- [x] Pair against a `beat`-mode destination and confirm the export screen doesn't block on a merge
- [x] Pair against a `merged`-mode destination and confirm merge + upload still works as before
- [x] Open a pairing link carrying `uploadUnit=beat|merged` and confirm it overrides `/capabilities`