### PR TITLE
feat(transcription): retire Tiny model with generic catalog-retirement migration

### DIFF
--- a/src/features/onboarding/steps.ts
+++ b/src/features/onboarding/steps.ts
@@ -71,7 +71,7 @@ export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
     bullets: [
       {
         icon: 'sparkles',
-        text: 'Every clip is captioned automatically — tap Model to choose a transcription model, from Tiny to multilingual Large Turbo.',
+        text: 'Every clip is captioned automatically — tap Model to choose a transcription model, from Base to multilingual Large Turbo.',
       },
       {
         icon: 'captions.bubble',

--- a/src/features/transcription/models.test.ts
+++ b/src/features/transcription/models.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { getModel, LARGE_MODEL_BYTES, MODELS, modelUrl } from './models';
+import {
+  getModel,
+  LARGE_MODEL_BYTES,
+  migrateStaleModelId,
+  MODELS,
+  modelUrl,
+  RETIRED_MODELS,
+} from './models';
 
 describe('model catalog', () => {
   it('resolves a known id and rejects unknown / nullish ids', () => {
-    expect(getModel('tiny.en')?.id).toBe('tiny.en');
+    expect(getModel('base.en')?.id).toBe('base.en');
     expect(getModel('nope')).toBeNull();
     expect(getModel(null)).toBeNull();
     expect(getModel(undefined)).toBeNull();
@@ -31,5 +38,19 @@ describe('model catalog', () => {
   it('only the large model crosses the confirm-before-download threshold', () => {
     const large = MODELS.filter((m) => m.approxBytes >= LARGE_MODEL_BYTES);
     expect(large.map((m) => m.id)).toEqual(['large-v3-turbo-q5_0']);
+  });
+
+  it('every retired id is actually gone and maps to a model still in the catalog', () => {
+    // Guards future retirements: a retired id must not linger in MODELS, and its replacement must
+    // resolve (never another retired id, so migration can't dead-end).
+    for (const [id, replacement] of Object.entries(RETIRED_MODELS)) {
+      expect(getModel(id)).toBeNull();
+      if (replacement !== null) expect(getModel(replacement)).not.toBeNull();
+    }
+  });
+
+  it('migrates a retired id to its replacement and clears unknown ids', () => {
+    expect(migrateStaleModelId('tiny.en')?.id).toBe('base.en');
+    expect(migrateStaleModelId('some-corrupt-value')).toBeNull();
   });
 });

--- a/src/features/transcription/models.ts
+++ b/src/features/transcription/models.ts
@@ -8,7 +8,7 @@ export type WhisperModel = {
   id: string;
   label: string;
   /**
-   * The underlying Whisper checkpoint name (e.g. `tiny.en`, `large-v3-turbo`), shown muted in the
+   * The underlying Whisper checkpoint name (e.g. `base.en`, `large-v3-turbo`), shown muted in the
    * picker so it's transparent which actual model — and quantization — the friendly label maps to.
    */
   name: string;
@@ -26,15 +26,6 @@ export type WhisperModel = {
 };
 
 export const MODELS: WhisperModel[] = [
-  {
-    id: 'tiny.en',
-    label: 'Tiny (English)',
-    name: 'tiny.en · q5_1',
-    filename: 'ggml-tiny.en-q5_1.bin',
-    approxBytes: 31 * 1024 * 1024,
-    note: 'Fastest · English only',
-    lang: 'en',
-  },
   {
     id: 'base.en',
     label: 'Base (English)',
@@ -78,5 +69,22 @@ export const LARGE_MODEL_BYTES = 300 * 1024 * 1024;
 
 export const getModel = (id: string | null | undefined): WhisperModel | null =>
   MODELS.find((m) => m.id === id) ?? null;
+
+/**
+ * Ids of models retired from the catalog, mapped to the id users should migrate to (`null` to just
+ * clear the selection). Add an entry here whenever a model is removed from MODELS. The engine
+ * rewrites a stored retired selection on launch, which then flows through the normal switch path:
+ * old weights deleted, replacement downloaded, auto captions regenerated.
+ */
+export const RETIRED_MODELS: Record<string, string | null> = {
+  'tiny.en': 'base.en',
+};
+
+/**
+ * Where a stored id that no longer resolves should migrate: a retired id's designated replacement,
+ * or `null` (clear the selection) for anything unknown/corrupt.
+ */
+export const migrateStaleModelId = (id: string): WhisperModel | null =>
+  getModel(RETIRED_MODELS[id]);
 
 export const modelUrl = (m: WhisperModel): string => BASE_URL + m.filename;

--- a/src/features/transcription/needs-transcription.test.ts
+++ b/src/features/transcription/needs-transcription.test.ts
@@ -4,7 +4,7 @@ import { needsTranscription, type TranscriptState } from './needs-transcription'
 
 const MAX = 2;
 const done = (over: Partial<TranscriptState> = {}): TranscriptState => ({
-  model: 'tiny.en',
+  model: 'base.en',
   sourceFile: 'a.mp4',
   status: 'done',
   ...over,
@@ -12,49 +12,49 @@ const done = (over: Partial<TranscriptState> = {}): TranscriptState => ({
 
 describe('needsTranscription', () => {
   it('runs when there is no row yet', () => {
-    expect(needsTranscription('a.mp4', 'tiny.en', undefined, 0, MAX, false)).toBe(true);
+    expect(needsTranscription('a.mp4', 'base.en', undefined, 0, MAX, false)).toBe(true);
   });
 
   it('skips a matching, completed row', () => {
-    expect(needsTranscription('a.mp4', 'tiny.en', done(), 0, MAX, false)).toBe(false);
+    expect(needsTranscription('a.mp4', 'base.en', done(), 0, MAX, false)).toBe(false);
   });
 
   it('re-runs when the effective file changed (destructive edit)', () => {
-    expect(needsTranscription('edited.mp4', 'tiny.en', done(), 0, MAX, false)).toBe(true);
+    expect(needsTranscription('edited.mp4', 'base.en', done(), 0, MAX, false)).toBe(true);
   });
 
   it('re-runs when the model changed', () => {
-    expect(needsTranscription('a.mp4', 'base.en', done(), 0, MAX, false)).toBe(true);
+    expect(needsTranscription('a.mp4', 'small.en-q5_1', done(), 0, MAX, false)).toBe(true);
   });
 
   it('resumes a row stranded in processing', () => {
-    expect(needsTranscription('a.mp4', 'tiny.en', done({ status: 'processing' }), 0, MAX, false)).toBe(
+    expect(needsTranscription('a.mp4', 'base.en', done({ status: 'processing' }), 0, MAX, false)).toBe(
       true,
     );
   });
 
   it('retries an errored row while under the attempt budget', () => {
     const row = done({ status: 'error' });
-    expect(needsTranscription('a.mp4', 'tiny.en', row, 0, MAX, false)).toBe(true);
-    expect(needsTranscription('a.mp4', 'tiny.en', row, 1, MAX, false)).toBe(true);
+    expect(needsTranscription('a.mp4', 'base.en', row, 0, MAX, false)).toBe(true);
+    expect(needsTranscription('a.mp4', 'base.en', row, 1, MAX, false)).toBe(true);
   });
 
   it('gives up on an errored row once the budget is spent', () => {
     const row = done({ status: 'error' });
-    expect(needsTranscription('a.mp4', 'tiny.en', row, MAX, MAX, false)).toBe(false);
+    expect(needsTranscription('a.mp4', 'base.en', row, MAX, MAX, false)).toBe(false);
   });
 
   it('a file change overrides a spent error budget (fresh file, fresh start)', () => {
     const row = done({ status: 'error', sourceFile: 'old.mp4' });
-    expect(needsTranscription('new.mp4', 'tiny.en', row, MAX, MAX, false)).toBe(true);
+    expect(needsTranscription('new.mp4', 'base.en', row, MAX, MAX, false)).toBe(true);
   });
 
   it('locks a hand-edited row against a model switch', () => {
     // Same file, different model — would normally re-run, but the user edit wins.
-    expect(needsTranscription('a.mp4', 'base.en', done(), 0, MAX, true)).toBe(false);
+    expect(needsTranscription('a.mp4', 'small.en-q5_1', done(), 0, MAX, true)).toBe(false);
   });
 
   it('still re-runs an edited row when the effective file changed (edit is stale)', () => {
-    expect(needsTranscription('edited.mp4', 'tiny.en', done(), 0, MAX, true)).toBe(true);
+    expect(needsTranscription('edited.mp4', 'base.en', done(), 0, MAX, true)).toBe(true);
   });
 });

--- a/src/features/transcription/use-library-transcription.ts
+++ b/src/features/transcription/use-library-transcription.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { allSegmentsQuery } from '@/db/drafts';
 import type { Segment } from '@/db/schema';
-import { selectedModelQuery } from '@/db/settings';
+import { selectedModelQuery, setSelectedModel } from '@/db/settings';
 import {
   allTranscriptsQuery,
   clearAutoTranscripts,
@@ -15,7 +15,7 @@ import { absolutize } from '@/utils/file-store';
 import { effFile } from '@/utils/segment-window';
 import { getActiveDraft } from './active-draft';
 import { cancelModelDownloadsExcept, deleteModelsExcept, ensureModel, isModelReady } from './model';
-import { getModel, type WhisperModel } from './models';
+import { getModel, migrateStaleModelId, type WhisperModel } from './models';
 import { needsTranscription } from './needs-transcription';
 import { isRecordingActive, setResumeHandler } from './recording-signal';
 import { releaseVad } from './vad';
@@ -56,7 +56,18 @@ type Row = {
 export function useLibraryTranscription(): TranscriptionStatus {
   const { data: modelRow, updatedAt } = useLiveQuery(selectedModelQuery, []);
   const ready = updatedAt != null;
-  const model = getModel(modelRow[0]?.value);
+  const storedModelId = modelRow[0]?.value ?? null;
+  const model = getModel(storedModelId);
+
+  // A stored selection that no longer resolves (the model was retired from the catalog, or the
+  // value is corrupt) is rewritten to its designated replacement — or cleared — so the user isn't
+  // silently left with transcription off. The write flows back through the live query and behaves
+  // like a normal model switch: stale weights are deleted and auto captions regenerate.
+  useEffect(() => {
+    if (ready && storedModelId != null && model == null) {
+      void setSelectedModel(migrateStaleModelId(storedModelId)?.id ?? null);
+    }
+  }, [ready, storedModelId, model]);
 
   const { data: segments } = useLiveQuery(allSegmentsQuery, []);
   const { data: transcriptRows } = useLiveQuery(allTranscriptsQuery, []);


### PR DESCRIPTION
## Summary
- Remove **Tiny (English)** (`tiny.en`) from the Whisper model catalog — its quality wasn't worth offering.
- Generalize model removal for the future: a new `RETIRED_MODELS` map in `models.ts` records removed ids and what they migrate to. Retiring a model is now a one-line entry.
- On launch, the transcription engine detects a stored selection that no longer resolves and rewrites it to the retirement replacement (or clears corrupt/unknown ids). The write flows back through the live query and behaves exactly like a normal model switch: stale weights are deleted from disk, the replacement downloads, auto captions regenerate, and hand-edited captions stay locked.
- Users who had Tiny selected are migrated to **Base (English)** automatically.
- Onboarding copy updated ("from Base to multilingual Large Turbo").

## Tests
- Guard tests keep future retirements honest: every retired id must actually be gone from `MODELS`, and its replacement must resolve to a live catalog model (migration can never dead-end on another retired id).
- Direct migration tests: `tiny.en → base.en`, unknown/corrupt ids clear to no selection.
- `needs-transcription` tests updated to only reference ids still in the catalog.
- All 20 transcription tests pass; typecheck and lint clean.