### PR TITLE
chore(upload): explicit background session type + throttle progress updates

### DIFF
--- a/src/features/upload/native-chunk-upload.ts
+++ b/src/features/upload/native-chunk-upload.ts
@@ -101,6 +101,7 @@ export const uploadRemainderNative: UploadRemainder = async ({
     const result = await source.upload(resourceUrl, {
       httpMethod: 'PATCH',
       uploadType: UploadType.BINARY_CONTENT,
+      sessionType: 'background', //explicit
       headers,
       signal,
       onProgress: onProgress ? ({ bytesSent }) => onProgress(bytesSent) : undefined,

--- a/src/features/upload/use-upload.ts
+++ b/src/features/upload/use-upload.ts
@@ -356,17 +356,26 @@ export function useUpload(
       if (!merged) throw new Error('Export is not ready yet');
       const file = new File(merged.path);
       const checksum = await sha256Checksum(file);
+      // Throttle progress to at most one setState / 200ms — the native task can tick
+      // hundreds of times a second, and a re-render per tick starves the upload. The
+      // final (EOF) tick always goes through so the bar still reaches 100%.
+      let lastTick = 0;
       const result = await uploadOne(
         destination,
         { artifactId: destination.artifactId, filename: `${draftId}.mp4`, kind: 'video', file },
         destination.resourceUrl,
         checksum,
         signal,
-        ({ bytesSent, totalBytes }) =>
+        ({ bytesSent, totalBytes }) => {
+          const done = totalBytes > 0 && bytesSent >= totalBytes;
+          const now = Date.now();
+          if (!done && now - lastTick < 200) return;
+          lastTick = now;
           setActiveState({
             status: 'uploading',
             progress: totalBytes ? bytesSent / totalBytes : 0,
-          }),
+          });
+        },
       );
       // Persist the video's resource URL now (so a crash mid-session resumes the video via HEAD),
       // but keep the draft status 'uploading' — it isn't marked 'uploaded' until every related


### PR DESCRIPTION
## What

- **Make the upload session type explicit.** `expo-file-system`'s native upload task already defaults to a background `URLSession`; this sets `sessionType: 'background'` explicitly at the call site so the behavior is visible rather than implied by the library default. No behavior change.
- **Throttle merged-upload progress updates.** The native task emits progress hundreds of times a second; a `setState` per tick re-renders constantly and starves the upload. Progress is now coalesced to at most one update per 200 ms, with the final (EOF) tick always allowed through so the bar still reaches 100%.

## Notes

- A background `URLSession` continues an in-flight transfer while the app is backgrounded, but iOS may throttle discretionary background transfers — worth watching under sustained backgrounding. The `waitUntilAppForeground` gate still parks the retry loop between chunks/files, so segment-mode uploads pause at each boundary until foreground.
- The commit also advances the `pulsevault-mieweb` submodule pointer.

## Files

- `src/features/upload/native-chunk-upload.ts` — explicit `sessionType: 'background'`
- `src/features/upload/use-upload.ts` — 200 ms progress throttle
- `pulsevault-mieweb` — submodule pointer bump
