### PR TITLE
Restore iPad support required for com.mieweb.pulse updates

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,6 +10,7 @@
     "userInterfaceStyle": "automatic",
     "ios": {
       "icon": "./assets/expo.icon",
+      "supportsTablet": true,
       "bundleIdentifier": "com.mieweb.pulse",
       "appleTeamId": "X5873NL7XM",
       "infoPlist": {


### PR DESCRIPTION
TestFlight upload of 2.0.0 failed with **ITMS-90101**:

> This bundle does not support one or more of the devices supported by the previous app version.

The original Pulse app (1.2.1) shipped with `supportsTablet: true` (`TARGETED_DEVICE_FAMILY = 1,2`). App Store rules forbid an update from dropping a previously supported device family, so the replacement app must keep iPad support forever on this app record.

One-line fix: add `supportsTablet: true` to the `ios` block of `app.json`. The app runs on iPad as a scaled iPhone layout, same as the old version did.

After merge, re-run the iOS build workflow — the upload should pass this check.