### PR TITLE
Revision-stamp edited segment files so re-edits invalidate caches

### DIFF
--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -114,6 +114,9 @@ export async function deleteSegment(segmentId: string): Promise<void> {
     deleteSegmentFile(editedThumbRelPath(seg.editedFilename));
   }
   deleteSegmentFile(thumbRelPath(seg.projectId, segmentId));
+  // The row's cover may not match either derived path (e.g. a prior revision's thumb kept as a
+  // fallback after a failed regeneration) — delete whatever the row actually references too.
+  if (seg.thumbnail) deleteSegmentFile(seg.thumbnail);
 
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
@@ -160,6 +163,9 @@ export async function resetEdit(segmentId: string): Promise<void> {
     deleteSegmentFile(seg.editedFilename);
     deleteSegmentFile(editedThumbRelPath(seg.editedFilename));
   }
+  // The prior cover may be from an older revision than `editedFilename` (kept as a fallback
+  // after a failed re-edit thumb generation) — drop it too, but never the fresh `thumbRel`.
+  if (seg.thumbnail && seg.thumbnail !== thumbRel) deleteSegmentFile(seg.thumbnail);
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
 

--- a/src/db/drafts.ts
+++ b/src/db/drafts.ts
@@ -109,9 +109,11 @@ export async function deleteSegment(segmentId: string): Promise<void> {
     .where(eq(segments.originalFilename, seg.originalFilename));
   if (stillReferenced === 0) deleteSegmentFile(seg.originalFilename);
   // The edited file and both thumbnails are per-segment (never shared) — delete with the row.
-  if (seg.editedFilename) deleteSegmentFile(seg.editedFilename);
+  if (seg.editedFilename) {
+    deleteSegmentFile(seg.editedFilename);
+    deleteSegmentFile(editedThumbRelPath(seg.editedFilename));
+  }
   deleteSegmentFile(thumbRelPath(seg.projectId, segmentId));
-  deleteSegmentFile(editedThumbRelPath(seg.projectId, segmentId));
 
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
@@ -124,18 +126,21 @@ export async function setEdited(
 ): Promise<void> {
   const [seg] = await db.select().from(segments).where(eq(segments.id, segmentId));
   if (!seg) return;
-  // Replacing a prior edit — drop the old file first (importTrimmedFile writes a fresh one).
-  if (seg.editedFilename && seg.editedFilename !== editedFilename) {
-    deleteSegmentFile(seg.editedFilename);
-  }
-  // Cover the edited file's first frame at the distinct edited-thumb path (the pristine thumb
+  // Cover the edited file's first frame at its revision-paired thumb path (the pristine thumb
   // stays on disk untouched, ready for a reset).
-  const thumbRel = editedThumbRelPath(seg.projectId, segmentId);
+  const thumbRel = editedThumbRelPath(editedFilename);
   const ok = await generateThumbnailFile(absolutize(editedFilename), absolutize(thumbRel));
   await db
     .update(segments)
     .set({ editedFilename, editedDurationMs, thumbnail: ok ? thumbRel : seg.thumbnail })
     .where(eq(segments.id, segmentId));
+  // Replacing a prior edit — drop its files only now that the row points at the new revision,
+  // so a failure above never leaves the segment referencing deleted files. Keep the old thumb
+  // as the cover fallback if the new one failed to generate.
+  if (seg.editedFilename && seg.editedFilename !== editedFilename) {
+    deleteSegmentFile(seg.editedFilename);
+    if (ok) deleteSegmentFile(editedThumbRelPath(seg.editedFilename));
+  }
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
 
@@ -143,15 +148,18 @@ export async function setEdited(
 export async function resetEdit(segmentId: string): Promise<void> {
   const [seg] = await db.select().from(segments).where(eq(segments.id, segmentId));
   if (!seg) return;
-  if (seg.editedFilename) deleteSegmentFile(seg.editedFilename);
-  // Revert the cover to the pristine original's thumbnail; drop the now-orphaned edited thumb.
-  deleteSegmentFile(editedThumbRelPath(seg.projectId, segmentId));
+  // Revert the cover to the pristine original's thumbnail.
   const thumbRel = thumbRelPath(seg.projectId, segmentId);
   const ok = await generateThumbnailFile(absolutize(seg.originalFilename), absolutize(thumbRel));
   await db
     .update(segments)
     .set({ editedFilename: null, editedDurationMs: null, thumbnail: ok ? thumbRel : null })
     .where(eq(segments.id, segmentId));
+  // Drop the now-orphaned edited file and thumb only after the row no longer references them.
+  if (seg.editedFilename) {
+    deleteSegmentFile(seg.editedFilename);
+    deleteSegmentFile(editedThumbRelPath(seg.editedFilename));
+  }
   await db.update(projects).set({ lastModified: now }).where(eq(projects.id, seg.projectId));
 }
 

--- a/src/features/draft-transfer/unpack.ts
+++ b/src/features/draft-transfer/unpack.ts
@@ -92,7 +92,7 @@ export async function importPulseFile(fileUri: string): Promise<ImportResult> {
         // effective clip, mirroring the original/edited thumb-path split the editor uses.
         const effective = editedFilename ?? originalFilename;
         const coverRel = editedFilename
-          ? editedThumbRelPath(draftId, segmentId)
+          ? editedThumbRelPath(editedFilename)
           : thumbRelPath(draftId, segmentId);
         const ok = await generateThumbnailFile(absolutize(effective), absolutize(coverRel));
 

--- a/src/features/recorder/use-video-trim.ts
+++ b/src/features/recorder/use-video-trim.ts
@@ -14,8 +14,8 @@ const Native = VideoTrim as Spec;
  * Drives react-native-video-trim's full-screen editor (trim + crop/rotate/flip/mute/speed).
  * Tap a clip → `openTrim` opens the editor on the PRISTINE original; on save, RNVT's output
  * (passthrough copy for pure cuts, re-encode for transform edits) is moved into the draft as
- * the segment's `.edited.mp4` and recorded via `setEdited` (destructive model — originals
- * stay untouched, re-editing re-opens the original).
+ * a fresh `.edited.{rev}.mp4` revision and recorded via `setEdited` (destructive model —
+ * originals stay untouched, re-editing re-opens the original).
  */
 export function useVideoTrim(draftId: string | null) {
   // The editor is fire-and-forget (showEditor) and its events carry no correlation id, so we

--- a/src/utils/file-store.ts
+++ b/src/utils/file-store.ts
@@ -3,8 +3,8 @@ import { Directory, File, Paths } from 'expo-file-system';
 // Clips live under the document directory (safe from system eviction). The DB stores
 // relative paths only; we absolutize at runtime so the sandbox container can change
 // between launches without invalidating references (§2.2).
-//   drafts/{draftId}/segments/{segmentId}.mp4         — pristine original
-//   drafts/{draftId}/segments/{segmentId}.edited.mp4  — re-encoded editor output
+//   drafts/{draftId}/segments/{segmentId}.mp4               — pristine original
+//   drafts/{draftId}/segments/{segmentId}.edited.{rev}.mp4  — re-encoded editor output
 
 /**
  * Normalize a bare filesystem path to a `file://` URI. `merge()` / `getFrameAt` / the camera hand
@@ -18,9 +18,14 @@ export function segmentRelPath(draftId: string, segmentId: string): string {
   return `drafts/${draftId}/segments/${segmentId}.mp4`;
 }
 
-/** The edited (RNVT output) file's relative path — coexists with the pristine original. */
-export function editedSegmentRelPath(draftId: string, segmentId: string): string {
-  return `drafts/${draftId}/segments/${segmentId}.edited.mp4`;
+/**
+ * The edited (RNVT output) file's relative path — coexists with the pristine original. Each
+ * edit gets a fresh revision stamp so the path (and thus every path-derived cache key: the
+ * segment signature, the expo-video source URI, the expo-image cover URI) changes whenever the
+ * content changes. Reusing one fixed path would leave those caches serving the previous edit.
+ */
+export function editedSegmentRelPath(draftId: string, segmentId: string, rev: number): string {
+  return `drafts/${draftId}/segments/${segmentId}.edited.${rev}.mp4`;
 }
 
 /** The pristine clip's persisted jpeg thumbnail (relative path). */
@@ -29,12 +34,14 @@ export function thumbRelPath(draftId: string, segmentId: string): string {
 }
 
 /**
- * The edited clip's persisted jpeg thumbnail (relative path). A *distinct* path from the
- * original's so the rendered URI changes when the cover changes — otherwise expo-image would
- * serve the stale pre-edit frame from its cache for an identical URI.
+ * The edited clip's persisted jpeg thumbnail (relative path), derived from the edited file's
+ * own path (`….mp4` → `….thumb.jpg`). Pairing the thumb to the exact edited revision keeps the
+ * rendered URI distinct across edits — otherwise expo-image would serve a stale frame from its
+ * cache for an identical URI. Deriving (instead of rebuilding from ids) also resolves the thumb
+ * for rows created before revision stamps existed.
  */
-export function editedThumbRelPath(draftId: string, segmentId: string): string {
-  return `drafts/${draftId}/segments/${segmentId}.edited.thumb.jpg`;
+export function editedThumbRelPath(editedRelPath: string): string {
+  return editedRelPath.replace(/\.mp4$/, '.thumb.jpg');
 }
 
 export function absolutize(relPath: string): string {
@@ -54,8 +61,8 @@ function segmentDest(draftId: string, segmentId: string): File {
 }
 
 /** The on-disk edited segment file for a draft, creating the segments dir if needed. */
-function editedSegmentDest(draftId: string, segmentId: string): File {
-  return new File(segmentsDir(draftId), `${segmentId}.edited.mp4`);
+function editedSegmentDest(draftId: string, segmentId: string, rev: number): File {
+  return new File(segmentsDir(draftId), `${segmentId}.edited.${rev}.mp4`);
 }
 
 /** Move a recorded clip out of the cache into the draft's segments dir; returns its relative path. */
@@ -84,18 +91,19 @@ export async function copyIntoSegments(
 }
 
 /**
- * Move an RNVT editor output (in app cache/files) into the draft's segments dir as the
- * segment's `.edited.mp4`, replacing any prior edit; returns its relative path (§ destructive trim).
+ * Move an RNVT editor output (in app cache/files) into the draft's segments dir as a fresh
+ * `.edited.{rev}.mp4` revision; returns its relative path (§ destructive trim). The prior
+ * edit (if any) stays on disk untouched — `setEdited` deletes it only after the segment row
+ * points at the new file, so a failed move never strands the row on a deleted file.
  */
 export async function importTrimmedFile(
   srcUri: string,
   draftId: string,
   segmentId: string,
 ): Promise<string> {
-  const dest = editedSegmentDest(draftId, segmentId);
-  if (dest.exists) dest.delete();
-  await new File(srcUri).move(dest);
-  return editedSegmentRelPath(draftId, segmentId);
+  const rev = Date.now();
+  await new File(srcUri).move(editedSegmentDest(draftId, segmentId, rev));
+  return editedSegmentRelPath(draftId, segmentId, rev);
 }
 
 /** Delete a clip file. Caller must ensure no other segment references it (splits can share a file). */
@@ -126,6 +134,7 @@ export function writeOriginalBytes(draftId: string, segmentId: string, bytes: Ui
 
 /** Write an imported clip's edited (re-encoded) bytes alongside its original; returns its rel path. */
 export function writeEditedBytes(draftId: string, segmentId: string, bytes: Uint8Array): string {
-  editedSegmentDest(draftId, segmentId).write(bytes);
-  return editedSegmentRelPath(draftId, segmentId);
+  const rev = Date.now();
+  editedSegmentDest(draftId, segmentId, rev).write(bytes);
+  return editedSegmentRelPath(draftId, segmentId, rev);
 }

--- a/src/utils/segment-window.test.ts
+++ b/src/utils/segment-window.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import type { Segment } from '@/db/schema';
-import { effFile, effMs, indexAtGlobalMs, segmentOffsets } from './segment-window';
+import { effFile, effMs, indexAtGlobalMs, segmentOffsets, segmentSignature } from './segment-window';
 
 // Minimal Segment factory — only the fields the timeline math reads.
 const seg = (over: Partial<Segment>): Segment =>
@@ -31,6 +31,25 @@ describe('segmentOffsets', () => {
   it('produces prefix sums of effective durations', () => {
     const segs = [seg({ durationMs: 1000 }), seg({ durationMs: 500 }), seg({ durationMs: 2000 })];
     expect(segmentOffsets(segs)).toEqual([0, 1000, 1500]);
+  });
+});
+
+describe('segmentSignature', () => {
+  it('changes when a segment gains an edit or when a re-edit lands at a new revision path', () => {
+    const pristine = [seg({ id: 'a' }), seg({ id: 'b' })];
+    const edited = [seg({ id: 'a', editedFilename: 'a.edited.100.mp4' }), seg({ id: 'b' })];
+    const reEdited = [seg({ id: 'a', editedFilename: 'a.edited.200.mp4' }), seg({ id: 'b' })];
+
+    expect(segmentSignature(edited)).not.toBe(segmentSignature(pristine));
+    // Every edit writes a distinct revision-stamped file, so replacing an existing edit must
+    // also produce a new signature — this is what invalidates merge/transcript/preview caches.
+    expect(segmentSignature(reEdited)).not.toBe(segmentSignature(edited));
+  });
+
+  it('is stable when nothing changed', () => {
+    const a = [seg({ id: 'a', editedFilename: 'a.edited.100.mp4' })];
+    const b = [seg({ id: 'a', editedFilename: 'a.edited.100.mp4' })];
+    expect(segmentSignature(a)).toBe(segmentSignature(b));
   });
 });
 


### PR DESCRIPTION
Fixes #91

## Problem

Re-editing an already-edited segment writes the RNVT output to the same `{segmentId}.edited.mp4` path. Since the path is the cache key throughout the app, nothing downstream notices the content changed:

- `segmentSignature` (a join of each segment's effective file path) stays identical, so export reuses the previously merged file and ships the old cut, and the merged transcript is not marked stale.
- The preview player reloads only when `effFile(active)` changes, so the open draft keeps playing the previous edit.
- `expo-image` caches by URI ([caching docs](https://docs.expo.dev/versions/latest/sdk/image/#caching)), so the segment bar keeps rendering the pre-edit cover frame for the identical thumb URI. The codebase already worked around this for the original→edited transition by giving the edited thumb a distinct path — but the edited→edited transition reused one path and hit the same stale-cache problem.

There was also a data-loss hole in the same flow: `importTrimmedFile` deleted the prior edit **before** moving the new file in, so a failed `File.move` ([expo-file-system API](https://docs.expo.dev/versions/latest/sdk/filesystem/#move-2)) left the segment row pointing at a file that no longer exists.

## Fix

Content-addressed-style unique paths per edit:

- Each edit lands at `{segmentId}.edited.{rev}.mp4` with `rev = Date.now()`. Every path-derived cache key (segment signature, expo-video source URI, expo-image cover URI) now changes exactly when the content does — no consumer changes needed.
- The edited thumbnail path is derived from the edited file's own path (`….mp4` → `….thumb.jpg`), keeping the cover URI paired to the exact revision. Deriving from the stored filename (instead of rebuilding from ids) also resolves the thumb for rows written before revision stamps existed, so **no migration is needed** — legacy `…edited.mp4` rows keep working and are cleaned up correctly on their next edit/reset/delete.
- Crash-safe ordering: `importTrimmedFile` moves to a fresh path without touching the prior edit; `setEdited` / `resetEdit` update the row first and delete the superseded files only after the row references the new ones. If new-thumb generation fails, the old thumb is kept as the cover fallback instead of being deleted out from under the row.

## Changes

- `src/utils/file-store.ts` — `editedSegmentRelPath`/`editedSegmentDest` take a `rev`; `editedThumbRelPath` now derives from the edited file path; `importTrimmedFile`/`writeEditedBytes` stamp a revision and no longer pre-delete.
- `src/db/drafts.ts` — `setEdited`/`resetEdit` reordered (DB row first, file cleanup after); `deleteSegment`/`resetEdit`/`setEdited` derive the edited thumb from the stored filename.
- `src/features/draft-transfer/unpack.ts` — cover path derived from the imported edited filename.
- `src/utils/segment-window.test.ts` — tests pinning the invalidation contract: the signature must change when an edit is added **and** when a re-edit lands at a new revision, and stay stable otherwise.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint` clean on touched files
- `npx jest` — 10 suites, 77 tests pass (including the new signature tests)