### PR TITLE
Re-apply 5 Mbps target bitrate for 1080p recordings

### DIFF
--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -82,8 +82,13 @@ export function useRecorder(initialDraftId?: string) {
   // output is also handed to `<Camera outputs={[videoOutput]}>` in recorder.tsx. Pinned to 1080p;
   // the HEVC codec is pinned per-recording via setOutputSettings (iOS) so every clip stays
   // format-uniform and exports on the merge engine's zero-re-encode fast path.
+  // targetBitRate ~5 Mbps: the mobile-feed sweet spot for 1080p (uploads shrink 2-5× vs the
+  // encoder's default, playback starts faster, rebuffers less) — and since export is
+  // passthrough, record-time bitrate IS upload bitrate. Set here at output creation, which is
+  // safe — unlike mutating a running session via setOutputSettings, which crashed the recorder.
   const videoOutput = useVideoOutput({
     targetResolution: CommonResolutions.FHD_16_9,
+    targetBitRate: 5_000_000,
     enableAudio: micEnabled,
     fileType: 'mov',
   });


### PR DESCRIPTION
Fixes #90

## Problem

Commit 6867d5f set `targetBitRate: 5_000_000` on the recorder's `useVideoOutput` config. Revert da1f0f6 (which targeted the TUS chunking change) collaterally removed that hunk because the reverted branch contained it too. Current `main` therefore records with no bitrate cap: clips come out at the encoder default, uploads are 2–5× larger than needed, and any upload-speed measurements are being taken against inflated files.

## Fix

Cherry-pick of the original commit (6867d5f), re-applying the exact hunk:

- `targetBitRate: 5_000_000` on the `useVideoOutput` config in `src/features/recorder/use-recorder.ts`.
- ~5 Mbps is the mobile-feed sweet spot for 1080p, and since export runs on the zero-re-encode passthrough path, record-time bitrate is upload bitrate.
- Set at **output creation**, per the [react-native-vision-camera video recording docs](https://react-native-vision-camera.com/docs/guides/recording-video) — mutating a running session via `setOutputSettings` crashed the recorder, which is what the original commit message calls out.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint` clean on the touched file