### PR TITLE
Send TUS uploads as bounded 32 MiB chunks

### DIFF
--- a/src/features/upload/native-chunk-upload.ts
+++ b/src/features/upload/native-chunk-upload.ts
@@ -1,6 +1,6 @@
 import { Directory, File, FileMode, Paths, UploadType } from 'expo-file-system';
 
-import type { UploadRemainder } from './tus-client';
+import type { UploadChunk } from './tus-client';
 
 function randomId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -10,7 +10,7 @@ const TUS_RESUME_DIR_NAME = 'tus-resume';
 
 /**
  * Deletes any leftover files under the cache dir's `tus-resume/` scratch
- * space. `prepareUploadSource`'s temp copy is only cleaned up in a `finally`
+ * space. `prepareChunkSource`'s temp copy is only cleaned up in a `finally`
  * block, which never runs if the app process is killed outright (not just an
  * aborted upload) mid-resume — leaving a duplicate, unencrypted copy of
  * potentially sensitive video content sitting in app cache indefinitely.
@@ -31,20 +31,23 @@ export function cleanupStaleUploadTempFiles(): void {
 }
 
 /**
- * When resuming a partial upload (`offset > 0`), streams just the remainder
- * (from `offset` to EOF) into a temp file via `FileHandle` (seek + bounded
- * read, never re-reading the bytes already uploaded) so the native upload
- * task has a file to point at. When starting from byte 0 — the common case —
- * uploads `source` directly with no copy at all.
+ * Stages the bytes for one chunk — `[offset, offset + chunkBytes)` — as a
+ * file the native upload task can point at, via `FileHandle` (seek + bounded
+ * read, never touching bytes outside the chunk). The one no-copy fast path:
+ * a file that fits in a single chunk uploads `source` directly. Everything
+ * else gets a bounded temp copy, which also caps the staging cost per PATCH
+ * at the chunk size — the pre-chunking code read the *entire remainder* into
+ * memory at once on every resume, unbounded by anything but the file size.
  */
-function prepareUploadSource(
+function prepareChunkSource(
   source: File,
   offset: number,
+  chunkBytes: number,
   totalBytes: number,
 ): { file: File; cleanup: () => void } {
-  if (offset <= 0) return { file: source, cleanup: () => {} };
+  if (offset <= 0 && chunkBytes >= totalBytes) return { file: source, cleanup: () => {} };
 
-  const dir = new Directory(Paths.cache, 'tus-resume');
+  const dir = new Directory(Paths.cache, TUS_RESUME_DIR_NAME);
   dir.create({ intermediates: true, idempotent: true });
   const temp = new File(dir, `${randomId()}.bin`);
   if (temp.exists) temp.delete();
@@ -52,8 +55,8 @@ function prepareUploadSource(
   const reader = source.open(FileMode.ReadOnly);
   try {
     reader.offset = offset;
-    const remainder = reader.readBytes(totalBytes - offset);
-    temp.write(remainder);
+    const chunk = reader.readBytes(chunkBytes);
+    temp.write(chunk);
   } finally {
     reader.close();
   }
@@ -66,15 +69,16 @@ function prepareUploadSource(
 }
 
 /**
- * Real `UploadRemainder` implementation for `tus-client.ts`. Uses
- * `expo-file-system`'s native upload task (`File.upload`, `httpMethod:
- * "PATCH"`, `uploadType: BINARY_CONTENT`), which streams bytes through the
- * platform's own URLSession (iOS) / OkHttp (Android) upload APIs — entirely
- * bypassing React Native's `fetch`/`Blob` bridge, which cannot carry a raw
- * byte body here (confirmed: RN's `Blob` constructor explicitly throws on
- * `ArrayBuffer`/`TypedArray` parts, and `expo-file-system`'s own
- * `File.slice()` happens to construct exactly that internally, so even the
- * "use a Blob from slice()" approach doesn't avoid this on React Native).
+ * Real `UploadChunk` implementation for `tus-client.ts`: PATCHes one bounded
+ * chunk. Uses `expo-file-system`'s native upload task (`File.upload`,
+ * `httpMethod: "PATCH"`, `uploadType: BINARY_CONTENT`), which streams bytes
+ * through the platform's own URLSession (iOS) / OkHttp (Android) upload
+ * APIs — entirely bypassing React Native's `fetch`/`Blob` bridge, which
+ * cannot carry a raw byte body here (confirmed: RN's `Blob` constructor
+ * explicitly throws on `ArrayBuffer`/`TypedArray` parts, and
+ * `expo-file-system`'s own `File.slice()` happens to construct exactly that
+ * internally, so even the "use a Blob from slice()" approach doesn't avoid
+ * this on React Native).
  *
  * KNOWN LIMITATION: unlike the `fetch`-based POST/HEAD/DELETE in
  * `tus-client.ts`, this PATCH has no `redirect: 'manual'` equivalent —
@@ -87,16 +91,17 @@ function prepareUploadSource(
  * this module. Accepted as a residual risk: it requires a compromised or
  * MITM'd paired server to trigger, matching the fetch layer before this fix.
  */
-export const uploadRemainderNative: UploadRemainder = async ({
+export const uploadChunkNative: UploadChunk = async ({
   resourceUrl,
   offset,
+  chunkBytes,
   totalBytes,
   file,
   headers,
   signal,
   onProgress,
 }) => {
-  const { file: source, cleanup } = prepareUploadSource(file, offset, totalBytes);
+  const { file: source, cleanup } = prepareChunkSource(file, offset, chunkBytes, totalBytes);
   try {
     const result = await source.upload(resourceUrl, {
       httpMethod: 'PATCH',

--- a/src/features/upload/native-chunk-upload.ts
+++ b/src/features/upload/native-chunk-upload.ts
@@ -99,7 +99,6 @@ export const uploadChunkNative: UploadChunk = async ({
   file,
   headers,
   signal,
-  onProgress,
 }) => {
   const { file: source, cleanup } = prepareChunkSource(file, offset, chunkBytes, totalBytes);
   try {
@@ -109,7 +108,6 @@ export const uploadChunkNative: UploadChunk = async ({
       sessionType: 'background', //explicit
       headers,
       signal,
-      onProgress: onProgress ? ({ bytesSent }) => onProgress(bytesSent) : undefined,
     });
     return { status: result.status, headers: result.headers };
   } finally {

--- a/src/features/upload/transports/tus-server-transport.ts
+++ b/src/features/upload/transports/tus-server-transport.ts
@@ -1,12 +1,12 @@
-import { uploadRemainderNative } from '../native-chunk-upload';
+import { uploadChunkNative } from '../native-chunk-upload';
 import { cancelTusUpload, uploadViaTus } from '../tus-client';
 import type { UploadTransport } from '../types';
 
 /**
  * The local-backend transport: uploads one artifact to a pulsevault-compatible
- * server over TUS. A thin adapter over the existing `uploadViaTus` (protocol) +
- * `uploadRemainderNative` (the native byte-carrying PATCH) — no protocol logic
- * lives here, and neither of those files is touched.
+ * server over TUS. A thin adapter over the existing `uploadViaTus` (protocol,
+ * always-chunked) + `uploadChunkNative` (the native byte-carrying PATCH) — no
+ * protocol logic lives here, and neither of those files is touched.
  *
  * Historical note: the old export-screen hook passed `uploadViaTus` an AppState
  * gate (`waitUntilForeground`) that paused the retry loop whenever the app
@@ -29,7 +29,7 @@ export const tusServerTransport: UploadTransport = {
       resourceUrl: artifact.resourceUrl,
       onResourceCreated,
       signal,
-      uploadRemainder: uploadRemainderNative,
+      uploadChunk: uploadChunkNative,
       onProgress,
     }),
 

--- a/src/features/upload/tus-client.test.ts
+++ b/src/features/upload/tus-client.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { cancelTusUpload, TusUploadError, type UploadRemainder, uploadViaTus } from './tus-client';
+import {
+  cancelTusUpload,
+  DEFAULT_TUS_CHUNK_SIZE_BYTES,
+  TusUploadError,
+  type UploadChunk,
+  uploadViaTus,
+} from './tus-client';
 
 const SERVER = 'https://vault.example.test/pulsevault';
 const ARTIFACT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
-/** Minimal stand-in for an expo-file-system `File` — only `.size` is read by tus-client (the actual bytes never flow through this module; see `uploadRemainder`). */
+/** Minimal stand-in for an expo-file-system `File` — only `.size` is read by tus-client (the actual bytes never flow through this module; see `uploadChunk`). */
 function fakeFile(size: number) {
   return { size };
 }
 
 type FetchCall = { url: string; init?: RequestInit };
 
-/** Hand-rolled fetch stub: records calls, returns the next programmed response for each method. Only used for the headers-only requests (create/HEAD/DELETE) — the byte-carrying PATCH goes through `uploadRemainder` instead. */
+/** Hand-rolled fetch stub: records calls, returns the next programmed response for each method. Only used for the headers-only requests (create/HEAD/DELETE) — the byte-carrying PATCHes go through `uploadChunk` instead. */
 function createFetchStub(responses: Partial<Record<string, Response[]>>) {
   const calls: FetchCall[] = [];
   const queues = new Map(Object.entries(responses).map(([k, v]) => [k, [...(v ?? [])]]));
@@ -27,19 +33,29 @@ function createFetchStub(responses: Partial<Record<string, Response[]>>) {
   return { fetchImpl: fetchImpl as unknown as typeof fetch, calls };
 }
 
-type RemainderCall = { offset: number; totalBytes: number; headers: Record<string, string> };
+type ChunkCall = {
+  offset: number;
+  chunkBytes: number;
+  totalBytes: number;
+  headers: Record<string, string>;
+};
 
-/** Hand-rolled stand-in for the native upload task: records calls, returns the next programmed result. */
-function createRemainderStub(results: { status: number; headers?: Record<string, string> }[]) {
-  const calls: RemainderCall[] = [];
+/** Hand-rolled stand-in for the native per-chunk upload task: records calls, returns the next programmed result. */
+function createChunkStub(results: { status: number; headers?: Record<string, string> }[]) {
+  const calls: ChunkCall[] = [];
   const queue = [...results];
-  const uploadRemainder: UploadRemainder = async ({ offset, totalBytes, headers }) => {
-    calls.push({ offset, totalBytes, headers });
+  const uploadChunk: UploadChunk = async ({ offset, chunkBytes, totalBytes, headers }) => {
+    calls.push({ offset, chunkBytes, totalBytes, headers });
     const next = queue.shift();
-    if (!next) throw new Error('No stubbed remainder result');
+    if (!next) throw new Error('No stubbed chunk result');
     return { status: next.status, headers: next.headers ?? {} };
   };
-  return { uploadRemainder, calls };
+  return { uploadChunk, calls };
+}
+
+/** The 204 a TUS server returns for a successful PATCH: the new authoritative offset. */
+function chunkOk(newOffset: number) {
+  return { status: 204, headers: { 'Upload-Offset': String(newOffset) } };
 }
 
 const JSON_HEADERS: Record<string, string> = { 'content-type': 'application/json' };
@@ -89,16 +105,13 @@ function createRedirectFollowingFetchStub(
 }
 
 describe('uploadViaTus', () => {
-  it('creates, HEADs, uploads the remainder in one attempt, then confirms via a final HEAD', async () => {
+  it('creates, HEADs once, then uploads a small file as a single chunk', async () => {
     const file = fakeFile(20);
     const { fetchImpl, calls } = createFetchStub({
       POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
-      HEAD: [
-        new Response(null, { status: 200, headers: { 'upload-offset': '0' } }),
-        new Response(null, { status: 200, headers: { 'upload-offset': '20' } }),
-      ],
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '0' } })],
     });
-    const { uploadRemainder, calls: remainderCalls } = createRemainderStub([{ status: 204 }]);
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([chunkOk(20)]);
 
     const progress: number[] = [];
     const result = await uploadViaTus({
@@ -109,12 +122,14 @@ describe('uploadViaTus', () => {
       kind: 'video',
       file: file as never,
       fetchImpl,
-      uploadRemainder,
+      uploadChunk,
       onProgress: ({ bytesSent }) => progress.push(bytesSent),
     });
 
     expect(result.resourceUrl).toBe('https://vault.example.test/pulsevault/upload/abc');
     expect(progress).toEqual([0, 20]);
+    // Exactly one HEAD: completion is known from the last 204's Upload-Offset.
+    expect(calls.filter((c) => c.init?.method === 'HEAD')).toHaveLength(1);
 
     const createCall = calls.find((c) => c.init?.method === 'POST');
     const headers = createCall?.init?.headers as Record<string, string>;
@@ -124,22 +139,120 @@ describe('uploadViaTus', () => {
     expect(headers['Upload-Metadata']).toContain(`artifactId ${btoa(ARTIFACT_ID)}`);
     expect(headers['Upload-Metadata']).toContain(`kind ${btoa('video')}`);
 
-    expect(remainderCalls).toHaveLength(1);
-    expect(remainderCalls[0].offset).toBe(0);
-    expect(remainderCalls[0].totalBytes).toBe(20);
-    expect(remainderCalls[0].headers['Upload-Offset']).toBe('0');
-    expect(remainderCalls[0].headers.Authorization).toBe('Bearer tok');
+    expect(chunkCalls).toHaveLength(1);
+    expect(chunkCalls[0].offset).toBe(0);
+    expect(chunkCalls[0].chunkBytes).toBe(20);
+    expect(chunkCalls[0].totalBytes).toBe(20);
+    expect(chunkCalls[0].headers['Upload-Offset']).toBe('0');
+    expect(chunkCalls[0].headers.Authorization).toBe('Bearer tok');
   });
 
-  it('resumes from a provided resourceUrl without creating a new upload, uploading only the remainder', async () => {
-    const file = fakeFile(10);
+  it('splits a file into sequential bounded chunks, advancing on each 204 Upload-Offset', async () => {
+    const file = fakeFile(25);
     const { fetchImpl, calls } = createFetchStub({
+      POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '0' } })],
+    });
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([
+      chunkOk(10),
+      chunkOk(20),
+      chunkOk(25),
+    ]);
+
+    const progress: number[] = [];
+    await uploadViaTus({
+      server: SERVER,
+      token: null,
+      artifactId: ARTIFACT_ID,
+      filename: 'clip.mp4',
+      kind: 'video',
+      file: file as never,
+      chunkSizeBytes: 10,
+      fetchImpl,
+      uploadChunk,
+      onProgress: ({ bytesSent }) => progress.push(bytesSent),
+    });
+
+    // Strictly sequential, bounded, offset-labelled per chunk.
+    expect(chunkCalls.map((c) => [c.offset, c.chunkBytes])).toEqual([
+      [0, 10],
+      [10, 10],
+      [20, 5],
+    ]);
+    expect(chunkCalls.map((c) => c.headers['Upload-Offset'])).toEqual(['0', '10', '20']);
+    // Displayed progress advances only on durable (server-acknowledged) offsets.
+    expect(progress).toEqual([0, 10, 20, 25]);
+    // Still exactly one HEAD — no per-chunk offset polling on the happy path.
+    expect(calls.filter((c) => c.init?.method === 'HEAD')).toHaveLength(1);
+  });
+
+  it('defaults the chunk size to 32 MiB', async () => {
+    expect(DEFAULT_TUS_CHUNK_SIZE_BYTES).toBe(32 * 1024 * 1024);
+    const file = fakeFile(DEFAULT_TUS_CHUNK_SIZE_BYTES + 1);
+    const { fetchImpl } = createFetchStub({
+      POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '0' } })],
+    });
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([
+      chunkOk(DEFAULT_TUS_CHUNK_SIZE_BYTES),
+      chunkOk(DEFAULT_TUS_CHUNK_SIZE_BYTES + 1),
+    ]);
+
+    await uploadViaTus({
+      server: SERVER,
+      token: null,
+      artifactId: ARTIFACT_ID,
+      filename: 'clip.mp4',
+      kind: 'video',
+      file: file as never,
+      fetchImpl,
+      uploadChunk,
+    });
+
+    expect(chunkCalls.map((c) => c.chunkBytes)).toEqual([DEFAULT_TUS_CHUNK_SIZE_BYTES, 1]);
+  });
+
+  it('treats a 204 without a usable Upload-Offset as transient: re-HEADs, then continues from the authoritative offset', async () => {
+    const file = fakeFile(20);
+    const { fetchImpl, calls } = createFetchStub({
+      POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
       HEAD: [
-        new Response(null, { status: 200, headers: { 'upload-offset': '5' } }),
+        new Response(null, { status: 200, headers: { 'upload-offset': '0' } }),
+        // The re-HEAD: the anomalous 204's chunk actually landed server-side.
         new Response(null, { status: 200, headers: { 'upload-offset': '10' } }),
       ],
     });
-    const { uploadRemainder, calls: remainderCalls } = createRemainderStub([{ status: 204 }]);
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([
+      { status: 204 }, // no Upload-Offset header — position can't be trusted
+      chunkOk(20),
+    ]);
+
+    await uploadViaTus({
+      server: SERVER,
+      token: null,
+      artifactId: ARTIFACT_ID,
+      filename: 'clip.mp4',
+      kind: 'video',
+      file: file as never,
+      chunkSizeBytes: 10,
+      fetchImpl,
+      uploadChunk,
+    });
+
+    expect(calls.filter((c) => c.init?.method === 'HEAD')).toHaveLength(2);
+    // Second attempt resumed from the re-HEAD's offset, not a local guess.
+    expect(chunkCalls.map((c) => [c.offset, c.chunkBytes])).toEqual([
+      [0, 10],
+      [10, 10],
+    ]);
+  });
+
+  it('resumes from a provided resourceUrl without creating a new upload, sending only what is missing', async () => {
+    const file = fakeFile(10);
+    const { fetchImpl, calls } = createFetchStub({
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '5' } })],
+    });
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([chunkOk(10)]);
 
     const result = await uploadViaTus({
       server: SERVER,
@@ -150,14 +263,15 @@ describe('uploadViaTus', () => {
       file: file as never,
       resourceUrl: `${SERVER}/upload/abc`,
       fetchImpl,
-      uploadRemainder,
+      uploadChunk,
     });
 
     expect(result.resourceUrl).toBe(`${SERVER}/upload/abc`);
     expect(calls.some((c) => c.init?.method === 'POST')).toBe(false);
-    expect(remainderCalls).toHaveLength(1);
-    expect(remainderCalls[0].offset).toBe(5);
-    expect(remainderCalls[0].headers['Upload-Offset']).toBe('5');
+    expect(chunkCalls).toHaveLength(1);
+    expect(chunkCalls[0].offset).toBe(5);
+    expect(chunkCalls[0].chunkBytes).toBe(5);
+    expect(chunkCalls[0].headers['Upload-Offset']).toBe('5');
   });
 
   it('recreates the upload when a persisted resume URL is gone server-side (404)', async () => {
@@ -169,13 +283,12 @@ describe('uploadViaTus', () => {
         // surface a terminal "rejected".
         new Response(null, { status: 404 }),
         new Response(null, { status: 200, headers: { 'upload-offset': '0' } }),
-        new Response(null, { status: 200, headers: { 'upload-offset': '20' } }),
       ],
       POST: [
         new Response(null, { status: 201, headers: { location: '/pulsevault/upload/fresh' } }),
       ],
     });
-    const { uploadRemainder, calls: remainderCalls } = createRemainderStub([{ status: 204 }]);
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([chunkOk(20)]);
 
     const seen: string[] = [];
     const result = await uploadViaTus({
@@ -188,15 +301,15 @@ describe('uploadViaTus', () => {
       resourceUrl: `${SERVER}/upload/stale`,
       onResourceCreated: (url) => seen.push(url),
       fetchImpl,
-      uploadRemainder,
+      uploadChunk,
     });
 
     expect(result.resourceUrl).toBe(`${SERVER}/upload/fresh`);
     // Both URLs reported in order, so the caller's persisted mapping self-heals.
     expect(seen).toEqual([`${SERVER}/upload/stale`, `${SERVER}/upload/fresh`]);
     expect(calls.filter((c) => c.init?.method === 'POST')).toHaveLength(1);
-    expect(remainderCalls).toHaveLength(1);
-    expect(remainderCalls[0].offset).toBe(0);
+    expect(chunkCalls).toHaveLength(1);
+    expect(chunkCalls[0].offset).toBe(0);
   });
 
   it('does NOT recreate on a 404 for a URL the server handed out in this same run', async () => {
@@ -205,7 +318,7 @@ describe('uploadViaTus', () => {
       POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
       HEAD: [new Response(null, { status: 404 })],
     });
-    const { uploadRemainder } = createRemainderStub([]);
+    const { uploadChunk } = createChunkStub([]);
 
     await expect(
       uploadViaTus({
@@ -216,25 +329,29 @@ describe('uploadViaTus', () => {
         kind: 'video',
         file: file as never,
         fetchImpl,
-        uploadRemainder,
+        uploadChunk,
       }),
     ).rejects.toMatchObject({ retryable: false, statusCode: 404 });
     expect(calls.filter((c) => c.init?.method === 'POST')).toHaveLength(1);
   });
 
-  it('retries a transient (5xx) failure by re-HEADing and re-attempting from the fresh offset', async () => {
-    const file = fakeFile(5);
-    const { fetchImpl } = createFetchStub({
+  it('retries a transient (5xx) chunk failure by re-HEADing and re-attempting from the fresh offset', async () => {
+    const file = fakeFile(30);
+    const { fetchImpl, calls } = createFetchStub({
       POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
       HEAD: [
         new Response(null, { status: 200, headers: { 'upload-offset': '0' } }),
-        new Response(null, { status: 200, headers: { 'upload-offset': '0' } }),
-        new Response(null, { status: 200, headers: { 'upload-offset': '5' } }),
+        // Re-HEAD after the failed second chunk: the server kept a partial 17
+        // of it — the next chunk must start exactly there, not at a local
+        // chunk-boundary guess.
+        new Response(null, { status: 200, headers: { 'upload-offset': '17' } }),
       ],
     });
-    const { uploadRemainder, calls: remainderCalls } = createRemainderStub([
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([
+      chunkOk(10),
       { status: 503, headers: JSON_HEADERS },
-      { status: 204 },
+      chunkOk(27),
+      chunkOk(30),
     ]);
 
     const result = await uploadViaTus({
@@ -244,11 +361,18 @@ describe('uploadViaTus', () => {
       filename: 'clip.mp4',
       kind: 'video',
       file: file as never,
+      chunkSizeBytes: 10,
       fetchImpl,
-      uploadRemainder,
+      uploadChunk,
     });
     expect(result.resourceUrl).toBe('https://vault.example.test/pulsevault/upload/abc');
-    expect(remainderCalls).toHaveLength(2);
+    expect(calls.filter((c) => c.init?.method === 'HEAD')).toHaveLength(2);
+    expect(chunkCalls.map((c) => [c.offset, c.chunkBytes])).toEqual([
+      [0, 10],
+      [10, 10],
+      [17, 10],
+      [27, 3],
+    ]);
   });
 
   it('does not retry a terminal (4xx) failure', async () => {
@@ -257,7 +381,7 @@ describe('uploadViaTus', () => {
       POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
       HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '0' } })],
     });
-    const { uploadRemainder } = createRemainderStub([{ status: 422 }]);
+    const { uploadChunk } = createChunkStub([{ status: 422 }]);
 
     await expect(
       uploadViaTus({
@@ -268,7 +392,7 @@ describe('uploadViaTus', () => {
         kind: 'video',
         file: file as never,
         fetchImpl,
-        uploadRemainder,
+        uploadChunk,
       }),
     ).rejects.toMatchObject({ retryable: false, statusCode: 422 });
   });
@@ -279,7 +403,7 @@ describe('uploadViaTus', () => {
       POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
       HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '1' } })],
     });
-    const { uploadRemainder } = createRemainderStub([]);
+    const { uploadChunk } = createChunkStub([]);
 
     await uploadViaTus({
       server: SERVER,
@@ -291,7 +415,7 @@ describe('uploadViaTus', () => {
       checksum: 'sha256:deadbeef',
       file: file as never,
       fetchImpl,
-      uploadRemainder,
+      uploadChunk,
     });
 
     const createCall = calls.find((c) => c.init?.method === 'POST');
@@ -309,7 +433,7 @@ describe('uploadViaTus', () => {
     const { fetchImpl } = createFetchStub({
       POST: [new Response(null, { status: 201, headers: { location: 'https://evil.example/collect' } })],
     });
-    const { uploadRemainder } = createRemainderStub([]);
+    const { uploadChunk } = createChunkStub([]);
 
     await expect(
       uploadViaTus({
@@ -320,7 +444,7 @@ describe('uploadViaTus', () => {
         kind: 'video',
         file: file as never,
         fetchImpl,
-        uploadRemainder,
+        uploadChunk,
       }),
     ).rejects.toBeInstanceOf(TusUploadError);
   });
@@ -331,7 +455,7 @@ describe('uploadViaTus', () => {
       POST: [new Response(null, { status: 201, headers: { location: '/other-prefix/upload/abc' } })],
       HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '5' } })],
     });
-    const { uploadRemainder } = createRemainderStub([]);
+    const { uploadChunk } = createChunkStub([]);
 
     const result = await uploadViaTus({
       server: SERVER,
@@ -341,7 +465,7 @@ describe('uploadViaTus', () => {
       kind: 'video',
       file: file as never,
       fetchImpl,
-      uploadRemainder,
+      uploadChunk,
     });
     expect(result.resourceUrl).toBe('https://vault.example.test/other-prefix/upload/abc');
   });
@@ -364,7 +488,7 @@ describe('uploadViaTus', () => {
         },
         () => new Response(null, { status: 200, headers: { 'upload-offset': '20' } }),
       );
-      const { uploadRemainder } = createRemainderStub([]);
+      const { uploadChunk } = createChunkStub([]);
 
       await expect(
         uploadViaTus({
@@ -375,7 +499,7 @@ describe('uploadViaTus', () => {
           kind: 'video',
           file: file as never,
           fetchImpl,
-          uploadRemainder,
+          uploadChunk,
         }),
       ).rejects.toBeInstanceOf(TusUploadError);
 

--- a/src/features/upload/tus-client.test.ts
+++ b/src/features/upload/tus-client.test.ts
@@ -212,6 +212,32 @@ describe('uploadViaTus', () => {
     expect(chunkCalls.map((c) => c.chunkBytes)).toEqual([DEFAULT_TUS_CHUNK_SIZE_BYTES, 1]);
   });
 
+  it.each([0, -1, 0.5, NaN, Infinity])(
+    'rejects an invalid chunkSizeBytes (%p) up front with a non-retryable error',
+    async (chunkSizeBytes) => {
+      const file = fakeFile(20);
+      const { fetchImpl, calls } = createFetchStub({});
+      const { uploadChunk, calls: chunkCalls } = createChunkStub([]);
+
+      await expect(
+        uploadViaTus({
+          server: SERVER,
+          token: null,
+          artifactId: ARTIFACT_ID,
+          filename: 'clip.mp4',
+          kind: 'video',
+          file: file as never,
+          chunkSizeBytes,
+          fetchImpl,
+          uploadChunk,
+        }),
+      ).rejects.toMatchObject({ name: 'TusUploadError', retryable: false });
+      // Fails fast: nothing was created and no bytes moved.
+      expect(calls).toHaveLength(0);
+      expect(chunkCalls).toHaveLength(0);
+    },
+  );
+
   it('treats a 204 without a usable Upload-Offset as transient: re-HEADs, then continues from the authoritative offset', async () => {
     const file = fakeFile(20);
     const { fetchImpl, calls } = createFetchStub({

--- a/src/features/upload/tus-client.ts
+++ b/src/features/upload/tus-client.ts
@@ -49,7 +49,6 @@ export type UploadChunk = (params: {
   file: File;
   headers: Record<string, string>;
   signal?: AbortSignal;
-  onProgress?: (bytesSentThisChunk: number) => void;
 }) => Promise<ChunkUploadResult>;
 
 export type TusUploadOptions = {
@@ -74,7 +73,7 @@ export type TusUploadOptions = {
   onResourceCreated?: (resourceUrl: string) => void;
   signal?: AbortSignal;
   onProgress?: (progress: TusUploadProgress) => void;
-  /** Size of each byte-carrying PATCH. Defaults to `DEFAULT_TUS_CHUNK_SIZE_BYTES` (32 MiB) — see its doc for why. A config knob, not a tuning surface: change it only when the deployment's edge changes how it handles request bodies. */
+  /** Size of each byte-carrying PATCH; must be a positive integer. Defaults to `DEFAULT_TUS_CHUNK_SIZE_BYTES` (32 MiB) — see its doc for why. A config knob, not a tuning surface: change it only when the deployment's edge changes how it handles request bodies. */
   chunkSizeBytes?: number;
   /** Dependency-injected for testing; defaults to the global `fetch`. Only used for the headers-only requests (create/HEAD/DELETE) — never for the byte-carrying PATCHes, see `uploadChunk`. */
   fetchImpl?: typeof fetch;
@@ -306,6 +305,13 @@ export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadRes
   const fetchImpl = opts.fetchImpl ?? fetch;
   const totalBytes = opts.file.size ?? 0;
   const chunkSizeBytes = opts.chunkSizeBytes ?? DEFAULT_TUS_CHUNK_SIZE_BYTES;
+  // Fail fast on a nonsensical chunk size (0, negative, NaN, Infinity, fractional): it would
+  // produce a 0-byte or invalid PATCH and a loop that retries forever without advancing.
+  if (!Number.isSafeInteger(chunkSizeBytes) || chunkSizeBytes <= 0) {
+    throw new TusUploadError(`chunkSizeBytes must be a positive integer (got ${chunkSizeBytes})`, {
+      retryable: false,
+    });
+  }
 
   const createFresh = () => withRetry(() => createUpload(opts, fetchImpl), opts.signal);
 
@@ -320,13 +326,16 @@ export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadRes
 
         while (offset < totalBytes) {
           const chunkBytes = Math.min(chunkSizeBytes, totalBytes - offset);
-          const chunkStart = offset;
           const headers = {
             'Tus-Resumable': TUS_VERSION,
             'Upload-Offset': String(offset),
             'Content-Type': 'application/offset+octet-stream',
             ...authHeaders(opts.token),
           };
+          // No in-flight per-chunk progress is forwarded: behind a body-buffering
+          // proxy, bytes "sent" are not bytes committed, and reporting them would
+          // over-state durable progress. Progress advances only on the 204's
+          // server-acknowledged Upload-Offset below.
           const result = await opts.uploadChunk({
             resourceUrl,
             offset,
@@ -335,11 +344,6 @@ export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadRes
             file: opts.file,
             headers,
             signal: opts.signal,
-            onProgress: (sentThisChunk) =>
-              opts.onProgress?.({
-                bytesSent: Math.min(chunkStart + sentThisChunk, totalBytes),
-                totalBytes,
-              }),
           });
           if (result.status !== 204) {
             throw statusErrorFromChunk(result, `Upload failed (${result.status})`);

--- a/src/features/upload/tus-client.ts
+++ b/src/features/upload/tus-client.ts
@@ -4,30 +4,53 @@ const MAX_RETRY_ATTEMPTS = 5;
 const RETRY_BASE_DELAY_MS = 500;
 const TUS_VERSION = '1.0.0';
 
+/**
+ * Default size of each byte-carrying PATCH, in bytes (32 MiB). Uploads are
+ * always sent as a sequence of bounded chunks rather than one PATCH for the
+ * whole file — the standard TUS answer to any body-buffering middlebox (it's
+ * why `tus-js-client` exposes `chunkSize`), and what makes resume actually
+ * work through a proxy that spools entire request bodies: every completed
+ * chunk is durably on the server, so a drop loses at most one chunk.
+ *
+ * 32 MiB specifically is the throughput-neutral point, measured against the
+ * production edge (64 MB file, per-chunk figures include the proxy holding
+ * each body until complete): single PATCH to EOF 20.4 MB/s; 32 MB chunks on
+ * a kept-alive connection 20.5 MB/s; 16 MB 16.3 MB/s; 8 MB 10.1 MB/s; 8 MB
+ * with a fresh TLS connection per chunk 5.1 MB/s. Below ~32 MB the fixed
+ * per-chunk dead time (~0.4 s while the proxy spools) starts to dominate;
+ * at 32 MB it is measurement noise. It also bounds what one drop can lose
+ * and caps the per-chunk staging copy (`prepareChunkSource`) at 32 MiB of
+ * memory. A config knob, not a tuning surface: drop it toward "remainder"
+ * only when the deployment's edge is known to stream request bodies.
+ */
+export const DEFAULT_TUS_CHUNK_SIZE_BYTES = 32 * 1024 * 1024;
+
 export type ArtifactKind = 'video' | 'project' | 'captions' | 'thumbnail';
 
 export type TusUploadProgress = { bytesSent: number; totalBytes: number };
 
-/** Result of one PATCH attempt's byte-carrying request — status + response headers (any casing). */
-export type RemainderUploadResult = { status: number; headers: Record<string, string> };
+/** Result of one chunk's byte-carrying PATCH — status + response headers (any casing). */
+export type ChunkUploadResult = { status: number; headers: Record<string, string> };
 
 /**
- * Performs the byte-carrying PATCH for the remainder of `file` from `offset`
- * to EOF. This is a separate, injected concern (not implemented inline in
- * this module) because the real implementation needs `expo-file-system`'s
- * native upload task — see `./native-chunk-upload.ts` for why and how. This
- * module stays free of any React Native-specific import so it's unit
- * testable under this project's pure-logic jest config.
+ * Performs the byte-carrying PATCH for one bounded chunk of `file`: exactly
+ * `chunkBytes` bytes starting at `offset`. This is a separate, injected
+ * concern (not implemented inline in this module) because the real
+ * implementation needs `expo-file-system`'s native upload task — see
+ * `./native-chunk-upload.ts` for why and how. This module stays free of any
+ * React Native-specific import so it's unit testable under this project's
+ * pure-logic jest config.
  */
-export type UploadRemainder = (params: {
+export type UploadChunk = (params: {
   resourceUrl: string;
   offset: number;
+  chunkBytes: number;
   totalBytes: number;
   file: File;
   headers: Record<string, string>;
   signal?: AbortSignal;
-  onProgress?: (bytesSentThisAttempt: number) => void;
-}) => Promise<RemainderUploadResult>;
+  onProgress?: (bytesSentThisChunk: number) => void;
+}) => Promise<ChunkUploadResult>;
 
 export type TusUploadOptions = {
   /** Full base URL, including the operator's path prefix — e.g. `https://vault.example.org/pulsevault`. */
@@ -51,10 +74,12 @@ export type TusUploadOptions = {
   onResourceCreated?: (resourceUrl: string) => void;
   signal?: AbortSignal;
   onProgress?: (progress: TusUploadProgress) => void;
-  /** Dependency-injected for testing; defaults to the global `fetch`. Only used for the headers-only requests (create/HEAD/DELETE) — never for the byte-carrying PATCH, see `uploadRemainder`. */
+  /** Size of each byte-carrying PATCH. Defaults to `DEFAULT_TUS_CHUNK_SIZE_BYTES` (32 MiB) — see its doc for why. A config knob, not a tuning surface: change it only when the deployment's edge changes how it handles request bodies. */
+  chunkSizeBytes?: number;
+  /** Dependency-injected for testing; defaults to the global `fetch`. Only used for the headers-only requests (create/HEAD/DELETE) — never for the byte-carrying PATCHes, see `uploadChunk`. */
   fetchImpl?: typeof fetch;
-  /** Performs the actual byte-carrying PATCH. Required — pass `uploadRemainderNative` from `./native-chunk-upload` at the real call site; tests inject a fake. */
-  uploadRemainder: UploadRemainder;
+  /** Performs the actual byte-carrying PATCH for one chunk. Required — pass `uploadChunkNative` from `./native-chunk-upload` at the real call site; tests inject a fake. */
+  uploadChunk: UploadChunk;
 };
 
 export type TusUploadResult = { resourceUrl: string };
@@ -153,12 +178,18 @@ async function statusError(res: Response, fallbackMessage: string): Promise<TusU
   return new TusUploadError(message, { retryable, statusCode: res.status });
 }
 
-function statusErrorFromRemainder(
-  result: RemainderUploadResult,
-  fallbackMessage: string,
-): TusUploadError {
+function statusErrorFromChunk(result: ChunkUploadResult, fallbackMessage: string): TusUploadError {
   const retryable = result.status >= 500 || result.status === 429;
   return new TusUploadError(fallbackMessage, { retryable, statusCode: result.status });
+}
+
+/** Case-insensitive response-header lookup — `ChunkUploadResult.headers` casing is platform-dependent. */
+function headerValue(headers: Record<string, string>, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) return headers[key];
+  }
+  return undefined;
 }
 
 /**
@@ -244,65 +275,88 @@ async function fetchOffset(
 }
 
 /**
- * Upload a file to a pulsevault-compatible server over TUS. The byte-carrying
- * PATCH is delegated to `opts.uploadRemainder` rather than sent via `fetch`
- * with a JS-constructed body: React Native's `fetch` silently base64-encodes
- * any `Uint8Array`/`ArrayBuffer` body, and even a `Blob` from
- * `expo-file-system`'s `File.slice()` doesn't avoid this — `slice()` itself
- * constructs that Blob from a `Uint8Array`, which React Native's `Blob`
- * implementation explicitly refuses ("Creating blobs from 'ArrayBuffer' and
- * 'ArrayBufferView' are not supported"). The real implementation
- * (`uploadRemainderNative`) instead uses `expo-file-system`'s own native
- * upload task, which streams bytes via the platform's URLSession/OkHttp APIs
- * and never goes through that bridge at all.
+ * Upload a file to a pulsevault-compatible server over TUS, always as a
+ * sequence of bounded chunks (`chunkSizeBytes`, default 32 MiB — see
+ * `DEFAULT_TUS_CHUNK_SIZE_BYTES` for the full rationale). One code path, no
+ * "fall back to chunking on failure" heuristic: chunk boundaries are what
+ * make progress durable through a body-buffering proxy, so they must exist
+ * on the first attempt, not only after something already went wrong.
  *
- * One PATCH attempt per resume cycle (the remainder from the current offset
- * to EOF, not fixed-size chunks) — TUS clients generally recommend against
- * small fixed chunking unless forced to; resumability already comes from
- * `Upload-Offset`, not from how many requests one successful run takes. On
- * failure, the next attempt always re-`HEAD`s for the authoritative offset
- * before retrying, never trusting what the previous attempt assumed.
+ * The byte-carrying PATCHes are delegated to `opts.uploadChunk` rather than
+ * sent via `fetch` with a JS-constructed body: React Native's `fetch`
+ * silently base64-encodes any `Uint8Array`/`ArrayBuffer` body, and even a
+ * `Blob` from `expo-file-system`'s `File.slice()` doesn't avoid this —
+ * `slice()` itself constructs that Blob from a `Uint8Array`, which React
+ * Native's `Blob` implementation explicitly refuses ("Creating blobs from
+ * 'ArrayBuffer' and 'ArrayBufferView' are not supported"). The real
+ * implementation (`uploadChunkNative`) instead uses `expo-file-system`'s own
+ * native upload task, which streams bytes via the platform's
+ * URLSession/OkHttp APIs and never goes through that bridge at all.
+ *
+ * Offset discipline — the server's offset is the only source of truth:
+ * - Each successful chunk's 204 carries the new `Upload-Offset`; the loop
+ *   (and the progress callback) advance on exactly that value, so displayed
+ *   progress is always durable progress and no extra HEAD is paid per chunk.
+ * - On ANY failure or retry, the next attempt re-`HEAD`s for the
+ *   authoritative offset before sending more bytes — never trusting what the
+ *   previous attempt assumed (it may have landed some bytes before failing;
+ *   resending bytes the server already has is a TUS conflict).
  */
 export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadResult> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const totalBytes = opts.file.size ?? 0;
+  const chunkSizeBytes = opts.chunkSizeBytes ?? DEFAULT_TUS_CHUNK_SIZE_BYTES;
 
   const createFresh = () => withRetry(() => createUpload(opts, fetchImpl), opts.signal);
 
-  // HEAD-then-upload-remainder is retried as ONE unit, not as two separately
-  // retried steps — a retry after a transient failure MUST re-HEAD first to
-  // learn the real offset (the previous attempt may have landed some bytes
-  // before it failed); retrying with a stale offset would resend bytes the
-  // server already has, which most TUS servers reject as a conflict.
+  // HEAD-then-send-chunks is retried as ONE unit, not as separately retried
+  // steps — a retry after a transient failure MUST re-HEAD first to learn the
+  // real offset before any further bytes move (see offset discipline above).
   const transfer = (resourceUrl: string) =>
     withRetry(
       async () => {
-        for (;;) {
-          const offset = await fetchOffset(resourceUrl, opts.token, opts.signal, fetchImpl);
-          opts.onProgress?.({ bytesSent: offset, totalBytes });
-          if (offset >= totalBytes) return;
+        let offset = await fetchOffset(resourceUrl, opts.token, opts.signal, fetchImpl);
+        opts.onProgress?.({ bytesSent: offset, totalBytes });
 
+        while (offset < totalBytes) {
+          const chunkBytes = Math.min(chunkSizeBytes, totalBytes - offset);
+          const chunkStart = offset;
           const headers = {
             'Tus-Resumable': TUS_VERSION,
             'Upload-Offset': String(offset),
             'Content-Type': 'application/offset+octet-stream',
             ...authHeaders(opts.token),
           };
-          const result = await opts.uploadRemainder({
+          const result = await opts.uploadChunk({
             resourceUrl,
             offset,
+            chunkBytes,
             totalBytes,
             file: opts.file,
             headers,
             signal: opts.signal,
-            onProgress: (sentThisAttempt) =>
-              opts.onProgress?.({ bytesSent: offset + sentThisAttempt, totalBytes }),
+            onProgress: (sentThisChunk) =>
+              opts.onProgress?.({
+                bytesSent: Math.min(chunkStart + sentThisChunk, totalBytes),
+                totalBytes,
+              }),
           });
           if (result.status !== 204) {
-            throw statusErrorFromRemainder(result, `Upload failed (${result.status})`);
+            throw statusErrorFromChunk(result, `Upload failed (${result.status})`);
           }
-          // Loop back to HEAD again rather than trusting the PATCH response's
-          // offset as "done" — keeps exactly one source of truth for progress.
+          // Advance strictly on the server's word. A 204 without a usable
+          // Upload-Offset, or one that claims no forward progress, means this
+          // loop can no longer trust its position — hand control back to
+          // withRetry, whose next attempt re-HEADs before sending anything.
+          const responseOffset = Number(headerValue(result.headers, 'upload-offset'));
+          if (!Number.isFinite(responseOffset) || responseOffset <= offset) {
+            throw new TusUploadError(
+              'Server acknowledged a chunk without a usable Upload-Offset',
+              { retryable: true },
+            );
+          }
+          offset = responseOffset;
+          opts.onProgress?.({ bytesSent: offset, totalBytes });
         }
       },
       opts.signal,


### PR DESCRIPTION
Fixes #89 — successor to #87 (whose fix, #88, was reverted in da1f0f6; `main` currently has neither the durability nor the behavior #87 was closed for).

## Problem

`tus-client.ts` sends one PATCH from the current offset to EOF. The opensource-server edge buffers the entire request body before `proxy_pass` (mieweb/opensource-server#395), so the upstream never sees a byte until the body completes — an interrupted PATCH commits **zero** bytes. Confirmed against the production container: 31.5 MB sent → `HEAD` returns `Upload-Offset: 0`. Large uploads on flaky networks can loop from byte 0 forever.

Bounded chunks are the standard TUS client answer to body-buffering middleboxes — it's why [`tus-js-client` exposes `chunkSize`](https://github.com/tus/tus-js-client/blob/main/docs/api.md#chunksize) ("a good example of when to use it: if the server or proxy has a limit on the request body size"), and the [tus resumable upload protocol](https://tus.io/protocols/resumable-upload) makes every completed PATCH durable via `Upload-Offset` — so a drop loses at most one chunk instead of everything.

## Why 32 MiB (and why the 10 MiB version was rightly reverted)

The reverted change defaulted to 10 MiB, which measurably hurt throughput. Benchmarked against the production edge (64 MB file):

| Strategy | Speed |
|---|---|
| Single PATCH to EOF (current `main`) | 20.4 MB/s |
| **32 MB chunks, kept-alive connection** | **20.5 MB/s** |
| 16 MB chunks, kept-alive connection | 16.3 MB/s |
| 8 MB chunks, kept-alive connection | 10.1 MB/s |
| 8 MB chunks, fresh TLS conn per chunk | 5.1 MB/s |

Small chunks pay a fixed ~0.4 s per-chunk dead time (the proxy holds each body until complete) plus TLS setup when connections aren't reused. At 32 MiB the overhead is measurement noise — durability without giving up single-PATCH throughput. `chunkSizeBytes` stays configurable so it can be raised toward a single remainder once the edge streams bodies (mieweb/opensource-server#395's `modsecurity off` fix).

## Design

- **Server offset is the sole source of truth.** The loop advances only on each 204's `Upload-Offset` (no per-chunk HEAD on the happy path). Any failure — or a 204 without forward progress — falls back to the retry wrapper, whose next attempt re-`HEAD`s for the authoritative offset before sending more bytes, per the protocol's offset semantics.
- **One code path.** No "fall back to chunking on failure" heuristic: chunk boundaries must exist on the first attempt to make progress durable, not only after something already went wrong.
- **Bounded staging.** `prepareChunkSource` stages exactly one chunk via `FileHandle` seek + bounded read, capping the resume-copy memory spike at 32 MiB — the current code reads the *entire remainder* into memory on every resume, unbounded by anything but the file size. A file that fits in one chunk from offset 0 still uploads directly with no copy.
- The byte-carrying PATCH stays on `expo-file-system`'s native upload task ([`File.upload`](https://docs.expo.dev/versions/latest/sdk/filesystem/#uploadurl-options), `BINARY_CONTENT`), since React Native's `fetch`/`Blob` cannot carry raw byte bodies. Progress reporting only advances on server-acknowledged offsets, so displayed progress is always durable progress.

## Tests

`tus-client.test.ts` covers: sequential bounded chunk sequencing with correct `Upload-Offset` headers, the 32 MiB default, advance-on-204 without per-chunk HEADs, a 204 lacking a usable `Upload-Offset` treated as transient (re-HEAD, continue from authoritative offset), mid-transfer failure resuming from the server's offset, and the existing create/resume/redirect/origin-pinning suite. All logic is dependency-injected and runs under the pure-logic jest config.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint` clean
- `npx jest` — 10 suites, 78 tests pass