### PR TITLE
chore: bump react-native-video-trim fork to 8.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "react-native-screens": "4.25.2",
         "react-native-sortables": "^1.9.4",
         "react-native-svg": "15.15.4",
-        "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#354f09110e4332ec0c8abdd061d7b3c5b779c3ef",
+        "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#5924ac3300248606471716a76b64a131f8763c73",
         "react-native-vision-camera": "^5.1.1",
         "react-native-vision-camera-worklets": "^5.1.1",
         "react-native-web": "~0.21.0",
@@ -13708,9 +13708,9 @@
       }
     },
     "node_modules/react-native-video-trim": {
-      "version": "8.2.2",
-      "resolved": "git+ssh://git@github.com/morepriyam/react-native-video-trim.git#354f09110e4332ec0c8abdd061d7b3c5b779c3ef",
-      "integrity": "sha512-vfC/MM9Ud9uX46TrJTcOWlKhCdJknRTA5Y970XJqKBa8QDrkBBjfxGtiy4FJFJR10/ou7IGy5mhlz9BFXgwUGw==",
+      "version": "8.2.3",
+      "resolved": "git+ssh://git@github.com/morepriyam/react-native-video-trim.git#5924ac3300248606471716a76b64a131f8763c73",
+      "integrity": "sha512-4w9sZ0nXbsm68sbMusikJB626Spz2KbQ6h4jUIKog59KSUcLKCrGO4jUUzz+S/iuiEXzKyVDS6JFNmxG/Eociw==",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "react-native-screens": "4.25.2",
         "react-native-sortables": "^1.9.4",
         "react-native-svg": "15.15.4",
-        "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#5924ac3300248606471716a76b64a131f8763c73",
+        "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#1ea7a121c4161ed3647c5de3be11bb6c19468d47",
         "react-native-vision-camera": "^5.1.1",
         "react-native-vision-camera-worklets": "^5.1.1",
         "react-native-web": "~0.21.0",
@@ -13708,9 +13708,9 @@
       }
     },
     "node_modules/react-native-video-trim": {
-      "version": "8.2.3",
-      "resolved": "git+ssh://git@github.com/morepriyam/react-native-video-trim.git#5924ac3300248606471716a76b64a131f8763c73",
-      "integrity": "sha512-4w9sZ0nXbsm68sbMusikJB626Spz2KbQ6h4jUIKog59KSUcLKCrGO4jUUzz+S/iuiEXzKyVDS6JFNmxG/Eociw==",
+      "version": "8.3.0",
+      "resolved": "git+ssh://git@github.com/morepriyam/react-native-video-trim.git#1ea7a121c4161ed3647c5de3be11bb6c19468d47",
+      "integrity": "sha512-0Z6u/KyDks8nhHUJ5pQFxVPCL775l3TWQdB9vLP3WA2/e3e6v9PKzC4I1Zs+hIWsQty8KlLQ+FHvKi6ZFxqbXw==",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-native-screens": "4.25.2",
     "react-native-sortables": "^1.9.4",
     "react-native-svg": "15.15.4",
-    "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#5924ac3300248606471716a76b64a131f8763c73",
+    "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#1ea7a121c4161ed3647c5de3be11bb6c19468d47",
     "react-native-vision-camera": "^5.1.1",
     "react-native-vision-camera-worklets": "^5.1.1",
     "react-native-web": "~0.21.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-native-screens": "4.25.2",
     "react-native-sortables": "^1.9.4",
     "react-native-svg": "15.15.4",
-    "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#354f09110e4332ec0c8abdd061d7b3c5b779c3ef",
+    "react-native-video-trim": "git+https://github.com/morepriyam/react-native-video-trim.git#5924ac3300248606471716a76b64a131f8763c73",
     "react-native-vision-camera": "^5.1.1",
     "react-native-vision-camera-worklets": "^5.1.1",
     "react-native-web": "~0.21.0",


### PR DESCRIPTION
## What

Updates the pinned `react-native-video-trim` fork from `354f091` to [`1ea7a12`](https://github.com/morepriyam/react-native-video-trim/commit/1ea7a121c4161ed3647c5de3be11bb6c19468d47) (v8.3.0), in two steps:

### v8.2.3 — upstream sync ([`5924ac3`](https://github.com/morepriyam/react-native-video-trim/commit/5924ac3300248606471716a76b64a131f8763c73))

Merges the two latest upstream commits from [maitrungduc1410/react-native-video-trim](https://github.com/maitrungduc1410/react-native-video-trim):

- **fix(ios): normalize pixel format and preserve audio passthrough on re-encode** ([bf258cb](https://github.com/maitrungduc1410/react-native-video-trim/commit/bf258cb)) — HDR/10-bit sources (iPhone HDR, HEVC 10-bit) get an explicit `format=yuv420p` before `h264_videotoolbox`, which [fails to open on a 10-bit input pixel format](https://developer.apple.com/documentation/videotoolbox/vtcompressionsession). MP4-compatible audio (AAC family / ALAC) keeps the lossless `-c:a copy`; only container-incompatible codecs (e.g. Opus) are transcoded to AAC. FFmpeg error classification now distinguishes muxer incompatibility (new `OUTPUT_FORMAT_INCOMPATIBLE` code) from genuine hardware-encoder failure.
- **feat(mix): headless `mixAudio` API** ([fa9094b](https://github.com/maitrungduc1410/react-native-video-trim/commit/fa9094b)) — background-audio mixing with `-c:v copy` (video untouched).

### v8.3.0 — probe + normalization API ([`1ea7a12`](https://github.com/morepriyam/react-native-video-trim/commit/1ea7a121c4161ed3647c5de3be11bb6c19468d47))

- **`probeVideo(url)`** — FFprobe-backed metadata with an identical result shape on iOS and Android: codec, coded dimensions, display rotation, nominal/average fps, bitrate, pixel format (10-bit detection), color transfer (HDR detection), audio codec/rate/channels, duration, size.
- **`compress()` options** — `codec: 'h264' | 'hevc'` (hardware encoders, `hvc1`-tagged), `audioSampleRate`/`audioChannels` (AAC conform), `copyVideo` (audio-only conform with the video track stream-copied).
- **`compress()` 10-bit fix** — the re-encode path now casts to 8-bit 4:2:0 (`format=yuv420p`), same normalization upstream applied to the trim path; a no-op for 8-bit sources.

## Why

Users add clips from the Photos library, where HDR 10-bit video is the iPhone 12+ camera default and Opus-audio downloads are common. Both previously surfaced as hardware-encoder failures on the re-encode path. `probeVideo` + the new `compress` options are the native half of import normalization (fixture corpus in #109): probe an imported clip, and only re-encode when it is hostile to the merge pipeline (HDR/10-bit, >1080p, >30fps, non-AAC audio).

## Testing

- Fork: `yarn typecheck`, `yarn lint`, `yarn test` green at `1ea7a12`
- App: `tsc --noEmit` green with the new pin; installed package verified to contain the new code (`probeVideo` in `lib/` and `ios/VideoTrim.swift`)
- No behavior changes to existing call sites (`merge`, `compress` defaults, trim); native rebuild required (`pod install` on next iOS build)
