### PR TITLE
Default TUS uploads back to a single remainder PATCH (chunking stays an opt-in knob)

### DIFF
--- a/src/features/upload/native-chunk-upload.ts
+++ b/src/features/upload/native-chunk-upload.ts
@@ -31,13 +31,21 @@ export function cleanupStaleUploadTempFiles(): void {
 }
 
 /**
- * Stages the bytes for one chunk — `[offset, offset + chunkBytes)` — as a
- * file the native upload task can point at, via `FileHandle` (seek + bounded
- * read, never touching bytes outside the chunk). The one no-copy fast path:
- * a file that fits in a single chunk uploads `source` directly. Everything
- * else gets a bounded temp copy, which also caps the staging cost per PATCH
- * at the chunk size — the pre-chunking code read the *entire remainder* into
- * memory at once on every resume, unbounded by anything but the file size.
+ * Bound on each `FileHandle.readBytes` while staging a resume/chunk temp copy.
+ * Staging streams the range through this much memory at a time instead of
+ * materializing the whole remainder as one buffer — the pre-existing behavior
+ * this replaces read `totalBytes - offset` in ONE call, an allocation bounded
+ * only by file size (the OOM half of #92).
+ */
+const STAGING_READ_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Stages the bytes for one PATCH — `[offset, offset + chunkBytes)` — as a
+ * file the native upload task can point at. The common case (a fresh upload,
+ * offset 0, whole file in one PATCH) uploads `source` directly with no copy
+ * at all. A resume (offset > 0) or an explicitly bounded chunk gets a temp
+ * copy, streamed via `FileHandle` in `STAGING_READ_BYTES` reads so memory
+ * stays bounded no matter how large the staged range is.
  */
 function prepareChunkSource(
   source: File,
@@ -51,13 +59,23 @@ function prepareChunkSource(
   dir.create({ intermediates: true, idempotent: true });
   const temp = new File(dir, `${randomId()}.bin`);
   if (temp.exists) temp.delete();
+  // FileHandle open-for-writing requires an existing file on iOS
+  // (FileHandle(forWritingTo:) does not create) — create it empty first.
+  temp.create();
 
   const reader = source.open(FileMode.ReadOnly);
+  const writer = temp.open(FileMode.WriteOnly);
   try {
     reader.offset = offset;
-    const chunk = reader.readBytes(chunkBytes);
-    temp.write(chunk);
+    let remaining = chunkBytes;
+    while (remaining > 0) {
+      const bytes = reader.readBytes(Math.min(STAGING_READ_BYTES, remaining));
+      if (bytes.length === 0) break;
+      writer.writeBytes(bytes);
+      remaining -= bytes.length;
+    }
   } finally {
+    writer.close();
     reader.close();
   }
   return {
@@ -99,6 +117,7 @@ export const uploadChunkNative: UploadChunk = async ({
   file,
   headers,
   signal,
+  onProgress,
 }) => {
   const { file: source, cleanup } = prepareChunkSource(file, offset, chunkBytes, totalBytes);
   try {
@@ -108,6 +127,9 @@ export const uploadChunkNative: UploadChunk = async ({
       sessionType: 'background', //explicit
       headers,
       signal,
+      // Native task ticks (URLSession/OkHttp didSendBodyData) — relative to
+      // this PATCH's body, which is exactly the contract of the callback.
+      onProgress: onProgress ? ({ bytesSent }) => onProgress(bytesSent) : undefined,
     });
     return { status: result.status, headers: result.headers };
   } finally {

--- a/src/features/upload/transports/tus-server-transport.ts
+++ b/src/features/upload/transports/tus-server-transport.ts
@@ -4,9 +4,11 @@ import type { UploadTransport } from '../types';
 
 /**
  * The local-backend transport: uploads one artifact to a pulsevault-compatible
- * server over TUS. A thin adapter over the existing `uploadViaTus` (protocol,
- * always-chunked) + `uploadChunkNative` (the native byte-carrying PATCH) — no
- * protocol logic lives here, and neither of those files is touched.
+ * server over TUS. A thin adapter over the existing `uploadViaTus` (protocol;
+ * single remainder PATCH by default, bounded chunks behind the
+ * `chunkSizeBytes` knob) + `uploadChunkNative` (the native byte-carrying
+ * PATCH) — no protocol logic lives here, and neither of those files is
+ * touched.
  *
  * Historical note: the old export-screen hook passed `uploadViaTus` an AppState
  * gate (`waitUntilForeground`) that paused the retry loop whenever the app

--- a/src/features/upload/tus-client.test.ts
+++ b/src/features/upload/tus-client.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, jest } from '@jest/globals';
 
 import {
   cancelTusUpload,
-  DEFAULT_TUS_CHUNK_SIZE_BYTES,
   TusUploadError,
   type UploadChunk,
   uploadViaTus,
@@ -40,14 +39,23 @@ type ChunkCall = {
   headers: Record<string, string>;
 };
 
-/** Hand-rolled stand-in for the native per-chunk upload task: records calls, returns the next programmed result. */
-function createChunkStub(results: { status: number; headers?: Record<string, string> }[]) {
+/** Hand-rolled stand-in for the native per-chunk upload task: records calls, returns the next programmed result. Each programmed result may carry `ticks` — in-flight byte counts to report through `onProgress` before resolving. */
+function createChunkStub(
+  results: { status: number; headers?: Record<string, string>; ticks?: number[] }[],
+) {
   const calls: ChunkCall[] = [];
   const queue = [...results];
-  const uploadChunk: UploadChunk = async ({ offset, chunkBytes, totalBytes, headers }) => {
+  const uploadChunk: UploadChunk = async ({
+    offset,
+    chunkBytes,
+    totalBytes,
+    headers,
+    onProgress,
+  }) => {
     calls.push({ offset, chunkBytes, totalBytes, headers });
     const next = queue.shift();
     if (!next) throw new Error('No stubbed chunk result');
+    for (const tick of next.ticks ?? []) onProgress?.(tick);
     return { status: next.status, headers: next.headers ?? {} };
   };
   return { uploadChunk, calls };
@@ -180,23 +188,23 @@ describe('uploadViaTus', () => {
       [20, 5],
     ]);
     expect(chunkCalls.map((c) => c.headers['Upload-Offset'])).toEqual(['0', '10', '20']);
-    // Displayed progress advances only on durable (server-acknowledged) offsets.
+    // No in-flight ticks programmed — progress here is the durable offsets only.
     expect(progress).toEqual([0, 10, 20, 25]);
     // Still exactly one HEAD — no per-chunk offset polling on the happy path.
     expect(calls.filter((c) => c.init?.method === 'HEAD')).toHaveLength(1);
   });
 
-  it('defaults the chunk size to 32 MiB', async () => {
-    expect(DEFAULT_TUS_CHUNK_SIZE_BYTES).toBe(32 * 1024 * 1024);
-    const file = fakeFile(DEFAULT_TUS_CHUNK_SIZE_BYTES + 1);
+  it('defaults to a single PATCH carrying the whole remainder (offset → EOF)', async () => {
+    // Standard TUS shape (tus-js-client defaults chunkSize to Infinity): a
+    // fresh 100 MB upload is ONE PATCH — one native background transfer, no
+    // per-chunk staging or dead time. Bounding requires opting in.
+    const size = 100 * 1024 * 1024;
+    const file = fakeFile(size);
     const { fetchImpl } = createFetchStub({
       POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
       HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '0' } })],
     });
-    const { uploadChunk, calls: chunkCalls } = createChunkStub([
-      chunkOk(DEFAULT_TUS_CHUNK_SIZE_BYTES),
-      chunkOk(DEFAULT_TUS_CHUNK_SIZE_BYTES + 1),
-    ]);
+    const { uploadChunk, calls: chunkCalls } = createChunkStub([chunkOk(size)]);
 
     await uploadViaTus({
       server: SERVER,
@@ -209,7 +217,58 @@ describe('uploadViaTus', () => {
       uploadChunk,
     });
 
-    expect(chunkCalls.map((c) => c.chunkBytes)).toEqual([DEFAULT_TUS_CHUNK_SIZE_BYTES, 1]);
+    expect(chunkCalls.map((c) => [c.offset, c.chunkBytes])).toEqual([[0, size]]);
+  });
+
+  it('forwards in-flight progress ticks, then re-anchors on the server-acknowledged offset', async () => {
+    const file = fakeFile(100);
+    const { fetchImpl } = createFetchStub({
+      POST: [new Response(null, { status: 201, headers: { location: '/pulsevault/upload/abc' } })],
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '0' } })],
+    });
+    // Native ticks are relative to the PATCH body; the last tick may claim
+    // more than the wire has durably committed — the 204's offset re-anchors.
+    const { uploadChunk } = createChunkStub([{ ...chunkOk(100), ticks: [30, 70, 100] }]);
+
+    const progress: number[] = [];
+    await uploadViaTus({
+      server: SERVER,
+      token: null,
+      artifactId: ARTIFACT_ID,
+      filename: 'clip.mp4',
+      kind: 'video',
+      file: file as never,
+      fetchImpl,
+      uploadChunk,
+      onProgress: ({ bytesSent }) => progress.push(bytesSent),
+    });
+
+    expect(progress).toEqual([0, 30, 70, 100, 100]);
+  });
+
+  it('reports resumed in-flight progress as offset + bytes sent this attempt, clamped to the total', async () => {
+    const file = fakeFile(100);
+    const { fetchImpl } = createFetchStub({
+      HEAD: [new Response(null, { status: 200, headers: { 'upload-offset': '40' } })],
+    });
+    // 70 sent on a 60-byte remainder would claim 110/100 — must clamp.
+    const { uploadChunk } = createChunkStub([{ ...chunkOk(100), ticks: [20, 70] }]);
+
+    const progress: number[] = [];
+    await uploadViaTus({
+      server: SERVER,
+      token: null,
+      artifactId: ARTIFACT_ID,
+      filename: 'clip.mp4',
+      kind: 'video',
+      file: file as never,
+      resourceUrl: `${SERVER}/upload/abc`,
+      fetchImpl,
+      uploadChunk,
+      onProgress: ({ bytesSent }) => progress.push(bytesSent),
+    });
+
+    expect(progress).toEqual([40, 60, 100, 100]);
   });
 
   it.each([0, -1, 0.5, NaN, Infinity])(

--- a/src/features/upload/tus-client.ts
+++ b/src/features/upload/tus-client.ts
@@ -4,27 +4,6 @@ const MAX_RETRY_ATTEMPTS = 5;
 const RETRY_BASE_DELAY_MS = 500;
 const TUS_VERSION = '1.0.0';
 
-/**
- * Default size of each byte-carrying PATCH, in bytes (32 MiB). Uploads are
- * always sent as a sequence of bounded chunks rather than one PATCH for the
- * whole file — the standard TUS answer to any body-buffering middlebox (it's
- * why `tus-js-client` exposes `chunkSize`), and what makes resume actually
- * work through a proxy that spools entire request bodies: every completed
- * chunk is durably on the server, so a drop loses at most one chunk.
- *
- * 32 MiB specifically is the throughput-neutral point, measured against the
- * production edge (64 MB file, per-chunk figures include the proxy holding
- * each body until complete): single PATCH to EOF 20.4 MB/s; 32 MB chunks on
- * a kept-alive connection 20.5 MB/s; 16 MB 16.3 MB/s; 8 MB 10.1 MB/s; 8 MB
- * with a fresh TLS connection per chunk 5.1 MB/s. Below ~32 MB the fixed
- * per-chunk dead time (~0.4 s while the proxy spools) starts to dominate;
- * at 32 MB it is measurement noise. It also bounds what one drop can lose
- * and caps the per-chunk staging copy (`prepareChunkSource`) at 32 MiB of
- * memory. A config knob, not a tuning surface: drop it toward "remainder"
- * only when the deployment's edge is known to stream request bodies.
- */
-export const DEFAULT_TUS_CHUNK_SIZE_BYTES = 32 * 1024 * 1024;
-
 export type ArtifactKind = 'video' | 'project' | 'captions' | 'thumbnail';
 
 export type TusUploadProgress = { bytesSent: number; totalBytes: number };
@@ -49,6 +28,14 @@ export type UploadChunk = (params: {
   file: File;
   headers: Record<string, string>;
   signal?: AbortSignal;
+  /**
+   * In-flight progress for THIS attempt: bytes handed to the network so far,
+   * relative to `offset` (not an absolute file position). Bytes "sent" are not
+   * bytes committed — behind a body-buffering proxy the server may still hold
+   * everything — so callers treat this as display-only; durable position always
+   * comes from `Upload-Offset` (the 204 header, or a re-HEAD after a failure).
+   */
+  onProgress?: (bytesSentThisAttempt: number) => void;
 }) => Promise<ChunkUploadResult>;
 
 export type TusUploadOptions = {
@@ -73,7 +60,21 @@ export type TusUploadOptions = {
   onResourceCreated?: (resourceUrl: string) => void;
   signal?: AbortSignal;
   onProgress?: (progress: TusUploadProgress) => void;
-  /** Size of each byte-carrying PATCH; must be a positive integer. Defaults to `DEFAULT_TUS_CHUNK_SIZE_BYTES` (32 MiB) — see its doc for why. A config knob, not a tuning surface: change it only when the deployment's edge changes how it handles request bodies. */
+  /**
+   * Size of each byte-carrying PATCH; must be a positive integer if provided.
+   * UNSET by default — each PATCH then carries the whole remainder (offset →
+   * EOF), i.e. a fresh upload is ONE PATCH. That is standard TUS practice
+   * (`tus-js-client` defaults `chunkSize` to `Infinity`) and the fastest,
+   * smoothest path on device: one native background transfer that survives
+   * iOS lock/backgrounding, no per-chunk staging copy, no per-chunk dead time.
+   *
+   * Set a bound only for a deployment whose edge is known to spool entire
+   * request bodies before forwarding them (e.g. a ModSecurity-fronted proxy —
+   * mieweb/opensource-server#395): there, a bounded chunk caps how much an
+   * interruption can lose, at the cost of the above. Measured against that
+   * edge (64 MB file): single PATCH 20.4 MB/s; 32 MiB chunks kept-alive
+   * 20.5 MB/s; 16 MiB 16.3 MB/s; 8 MiB 10.1 MB/s — don't go below 32 MiB.
+   */
   chunkSizeBytes?: number;
   /** Dependency-injected for testing; defaults to the global `fetch`. Only used for the headers-only requests (create/HEAD/DELETE) — never for the byte-carrying PATCHes, see `uploadChunk`. */
   fetchImpl?: typeof fetch;
@@ -274,12 +275,13 @@ async function fetchOffset(
 }
 
 /**
- * Upload a file to a pulsevault-compatible server over TUS, always as a
- * sequence of bounded chunks (`chunkSizeBytes`, default 32 MiB — see
- * `DEFAULT_TUS_CHUNK_SIZE_BYTES` for the full rationale). One code path, no
- * "fall back to chunking on failure" heuristic: chunk boundaries are what
- * make progress durable through a body-buffering proxy, so they must exist
- * on the first attempt, not only after something already went wrong.
+ * Upload a file to a pulsevault-compatible server over TUS. By default each
+ * byte-carrying PATCH runs from the current offset to EOF — a fresh upload is
+ * ONE PATCH, the standard TUS shape — while `chunkSizeBytes` bounds it into a
+ * sequence of chunks for deployments behind a body-buffering edge (see its
+ * doc). Either way the transfer loop, retry and offset discipline below are
+ * identical; a bounded chunk size just adds boundaries at which progress is
+ * durable through a proxy that spools whole request bodies.
  *
  * The byte-carrying PATCHes are delegated to `opts.uploadChunk` rather than
  * sent via `fetch` with a JS-constructed body: React Native's `fetch`
@@ -292,10 +294,15 @@ async function fetchOffset(
  * native upload task, which streams bytes via the platform's
  * URLSession/OkHttp APIs and never goes through that bridge at all.
  *
+ * Progress: in-flight ticks from the native task are forwarded as they happen
+ * (`offset + bytesSentThisAttempt`) so the bar moves smoothly, and each 204's
+ * server-acknowledged `Upload-Offset` re-anchors it to durable truth. After a
+ * failure the re-HEAD's offset is reported as-is — the bar may step back to
+ * the last durable byte, which is honest.
+ *
  * Offset discipline — the server's offset is the only source of truth:
- * - Each successful chunk's 204 carries the new `Upload-Offset`; the loop
- *   (and the progress callback) advance on exactly that value, so displayed
- *   progress is always durable progress and no extra HEAD is paid per chunk.
+ * - Each successful PATCH's 204 carries the new `Upload-Offset`; the loop
+ *   advances on exactly that value, never on what was "sent".
  * - On ANY failure or retry, the next attempt re-`HEAD`s for the
  *   authoritative offset before sending more bytes — never trusting what the
  *   previous attempt assumed (it may have landed some bytes before failing;
@@ -304,10 +311,14 @@ async function fetchOffset(
 export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadResult> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const totalBytes = opts.file.size ?? 0;
-  const chunkSizeBytes = opts.chunkSizeBytes ?? DEFAULT_TUS_CHUNK_SIZE_BYTES;
-  // Fail fast on a nonsensical chunk size (0, negative, NaN, Infinity, fractional): it would
-  // produce a 0-byte or invalid PATCH and a loop that retries forever without advancing.
-  if (!Number.isSafeInteger(chunkSizeBytes) || chunkSizeBytes <= 0) {
+  const chunkSizeBytes = opts.chunkSizeBytes;
+  // Fail fast on a nonsensical explicit chunk size (0, negative, NaN, Infinity, fractional): it
+  // would produce a 0-byte or invalid PATCH and a loop that retries forever without advancing.
+  // (Unset means "whole remainder per PATCH" — the default.)
+  if (
+    chunkSizeBytes !== undefined &&
+    (!Number.isSafeInteger(chunkSizeBytes) || chunkSizeBytes <= 0)
+  ) {
     throw new TusUploadError(`chunkSizeBytes must be a positive integer (got ${chunkSizeBytes})`, {
       retryable: false,
     });
@@ -325,17 +336,17 @@ export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadRes
         opts.onProgress?.({ bytesSent: offset, totalBytes });
 
         while (offset < totalBytes) {
-          const chunkBytes = Math.min(chunkSizeBytes, totalBytes - offset);
+          const chunkBytes = Math.min(chunkSizeBytes ?? totalBytes - offset, totalBytes - offset);
           const headers = {
             'Tus-Resumable': TUS_VERSION,
             'Upload-Offset': String(offset),
             'Content-Type': 'application/offset+octet-stream',
             ...authHeaders(opts.token),
           };
-          // No in-flight per-chunk progress is forwarded: behind a body-buffering
-          // proxy, bytes "sent" are not bytes committed, and reporting them would
-          // over-state durable progress. Progress advances only on the 204's
-          // server-acknowledged Upload-Offset below.
+          // In-flight ticks make the bar move smoothly while bytes flow; the
+          // server-acknowledged Upload-Offset below re-anchors to durable
+          // truth on completion (and the re-HEAD does after any failure).
+          const patchStart = offset;
           const result = await opts.uploadChunk({
             resourceUrl,
             offset,
@@ -344,6 +355,11 @@ export async function uploadViaTus(opts: TusUploadOptions): Promise<TusUploadRes
             file: opts.file,
             headers,
             signal: opts.signal,
+            onProgress: (sentThisAttempt) =>
+              opts.onProgress?.({
+                bytesSent: Math.min(patchStart + sentThisAttempt, totalBytes),
+                totalBytes,
+              }),
           });
           if (result.status !== 204) {
             throw statusErrorFromChunk(result, `Upload failed (${result.status})`);


### PR DESCRIPTION
Relates to #89 — this deliberately reverses its direction. The always-chunked default from #108 is not feasible on device; this returns the app to the pre-#108 single-PATCH behavior while we wait for the server-side fix (mieweb/opensource-server#395).

## Why the 32 MiB chunk default had to go

A real-world 250 MB merged upload (20 clips) crawled with ~13% progress jumps — which is literally the chunk size: 250 MB ÷ 32 MiB ≈ 8 chunks. Per chunk, the app paid four costs the old single-PATCH path never did:

1. **A full temp copy per chunk** — `prepareChunkSource` read 32 MiB + wrote 32 MiB to flash for *every* chunk of a multi-chunk file (~500 MB of extra serial disk I/O for that video). Pre-#108, an offset-0 upload pointed the native task directly at the source file — zero copies.
2. **A fresh background-URLSession task per chunk** — out-of-process `nsurlsessiond` startup/IPC, once per chunk instead of once per file.
3. **The edge's spool dead time × N** — the proxy holds each request body until complete (mieweb/opensource-server#395); that end-of-body stall was paid per chunk instead of per file.
4. **The killer: screen lock froze the loop.** The JS loop must run *between* chunks, and JS is suspended the moment the app backgrounds. A single PATCH survives lock as one native background transfer; chunked, the in-flight chunk finishes and then everything stalls until the next foreground or a BG resume wake (15-min OS floor). That's the "took forever" experience.

And the durability the chunks were buying is not needed as a permanent client workaround: the maintainer has confirmed the root cause (ModSecurity's connector unconditionally reads the whole body before `proxy_pass`) and a scoped `modsecurity off` fix is queued behind mieweb/opensource-server#407. Verified today the edge still buffers (killed a PATCH at ~30 MB → `HEAD` returns `Upload-Offset: 0`), so until that lands an interrupted upload resumes from 0 — an accepted, temporary trade-off.

## What this PR does

- **`chunkSizeBytes` is unset by default** → each PATCH carries the whole remainder (offset → EOF). A fresh upload is ONE PATCH: one native background transfer, streamed straight from the source file, no staging copy, survives lock/backgrounding. This is standard TUS practice — `tus-js-client` defaults `chunkSize` to `Infinity`; bounded chunks are only for body-buffering middleboxes.
- **Chunking stays fully intact as an explicit opt-in knob**, with the 32 MiB benchmark table preserved in its doc (single PATCH 20.4 MB/s ≈ 32 MiB chunks 20.5 MB/s; 16 MiB 16.3; 8 MiB 10.1) so nobody tunes it downward again.
- **In-flight progress restored** (removed by #108): native task ticks are forwarded as `offset + bytesSentThisAttempt` (clamped to total), and each 204's server-acknowledged `Upload-Offset` re-anchors the bar to durable truth. After a failure, the re-HEAD's offset is reported as-is — the bar may honestly step back to the last durable byte.
- **Resume staging is now memory-bounded**: the remainder temp copy streams through 8 MiB `FileHandle` reads into the temp file instead of one whole-remainder `readBytes` allocation — so returning to remainder-sized PATCHes does NOT reintroduce the OOM half of #92 (the pre-#108 code materialized the entire remainder in memory on every resume).
- Offset discipline is unchanged: server offset is the sole source of truth, re-HEAD before any retry, advance only on the 204's `Upload-Offset`, 404-on-persisted-URL recreate, redirect rejection + origin pinning all preserved.

## When mieweb/opensource-server#395's fix ships

Nothing more to do here — the edge streams bodies, so a killed single PATCH keeps every byte the server received and resume works from wherever it died. Fastest and durable, no client change needed.

## Verification

- `npx tsc --noEmit` clean
- `npx eslint src/features/upload/` clean
- `npx jest` — 11 suites, 110 tests pass; tus-client suite now 22 tests including three new ones: remainder-by-default (a 100 MB file is exactly one PATCH), in-flight tick forwarding + 204 re-anchoring, and resumed-progress clamping (`offset + sent` never exceeds total)
