### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-ios-from-expo.yml
+++ b/.github/workflows/build-ios-from-expo.yml
@@ -31,6 +31,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   ios:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/morepriyam/pulse/security/code-scanning/1](https://github.com/morepriyam/pulse/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best fix here: define workflow-level permissions right after `on:` (or before `jobs:`) as:

- `contents: read`

This is the minimal safe baseline for most CI workflows and aligns with CodeQL guidance. It applies to all jobs unless overridden and avoids granting implicit write access if repo/org defaults change later. No imports, methods, or dependencies are needed—just YAML config in `.github/workflows/build-ios-from-expo.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
