### PR TITLE
Restore mic-capable audio session after in-recorder preview

### DIFF
--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -215,11 +215,28 @@ export default function RecorderScreen() {
     [muted, callActive, audioFocus],
   );
 
+  // Hold-to-record needs more than reacquireThen: acquire() is awaited, and the gesture's
+  // release fires synchronously via runOnJS — a quick press-release could run onHoldEnd
+  // BEFORE the delayed startHoldRecording() (holdInitiatedRef still false, so nothing to
+  // stop), and the start would then fire AFTER the gesture ended, leaving an unheld
+  // in-progress recording. Every hold edge bumps a sequence number; the delayed start is
+  // dropped when its hold is no longer the live one.
+  const holdSeqRef = useRef(0);
+  const onHoldStart = useCallback(async () => {
+    const seq = ++holdSeqRef.current;
+    if (!muted && !callActive) await audioFocus.acquire();
+    if (seq === holdSeqRef.current) startHoldRecording();
+  }, [muted, callActive, audioFocus, startHoldRecording]);
+  const onHoldEnd = useCallback(() => {
+    holdSeqRef.current++;
+    endHoldRecording();
+  }, [endHoldRecording]);
+
   const { zoomSv, holdActive, buttonGesture, screenGesture, resetZoom, setZoomTo } =
     useRecorderGestures({
       onToggle: reacquireThen(toggleRecording),
-      onHoldStart: reacquireThen(startHoldRecording),
-      onHoldEnd: endHoldRecording,
+      onHoldStart,
+      onHoldEnd,
       onFocus,
       enabled: cameraReady && !previewing && !dragging,
       neutralZoom,

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -119,8 +119,15 @@ export default function RecorderScreen() {
   // otherwise leave every post-preview clip recording silence — acquire restores `.playAndRecord`.
   const audioFocus = useAudioFocus();
   useEffect(() => {
-    if (previewing) return; // preview owns the session; re-acquire runs on close
-    if (focused && appActive && !muted && !callActive && prefsReady) void audioFocus.acquire();
+    const shouldHold = focused && appActive && !muted && !callActive && prefsReady;
+    if (previewing) {
+      // Preview owns the session config (expo-video forces `.playback`) — skip acquire so we
+      // don't fight it; re-acquire runs on close. Still release, though: yielding focus on
+      // blur/mute/a call becoming active must keep working even with a preview open.
+      if (!shouldHold) void audioFocus.release();
+      return;
+    }
+    if (shouldHold) void audioFocus.acquire();
     else void audioFocus.release();
   }, [focused, appActive, muted, callActive, prefsReady, previewing, audioFocus]);
   useEffect(() => () => void audioFocus.release(), [audioFocus]);

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -117,20 +117,23 @@ export default function RecorderScreen() {
   // `previewing` is a dep so CLOSING the preview re-runs acquire: expo-video's preview player
   // flips the shared AVAudioSession to `.playback` (no mic input) when it plays, which would
   // otherwise leave every post-preview clip recording silence — acquire restores `.playAndRecord`.
-  const audioFocus = useAudioFocus();
+  // Destructured because useAudioFocus() returns a fresh object each render — depending on
+  // the stable acquire/release callbacks (not the object) keeps the effect from re-running
+  // (and re-applying the session config) on every render.
+  const { acquire: acquireFocus, release: releaseFocus } = useAudioFocus();
   useEffect(() => {
     const shouldHold = focused && appActive && !muted && !callActive && prefsReady;
     if (previewing) {
       // Preview owns the session config (expo-video forces `.playback`) — skip acquire so we
       // don't fight it; re-acquire runs on close. Still release, though: yielding focus on
       // blur/mute/a call becoming active must keep working even with a preview open.
-      if (!shouldHold) void audioFocus.release();
+      if (!shouldHold) void releaseFocus();
       return;
     }
-    if (shouldHold) void audioFocus.acquire();
-    else void audioFocus.release();
-  }, [focused, appActive, muted, callActive, prefsReady, previewing, audioFocus]);
-  useEffect(() => () => void audioFocus.release(), [audioFocus]);
+    if (shouldHold) void acquireFocus();
+    else void releaseFocus();
+  }, [focused, appActive, muted, callActive, prefsReady, previewing, acquireFocus, releaseFocus]);
+  useEffect(() => () => void releaseFocus(), [releaseFocus]);
 
   // Prediction can lose a race: on a cold-open / resume into an in-progress call the call snapshot
   // can read stale, the mic attaches, and AVFoundation throws -11800 / '!pri' — which leaves the
@@ -209,10 +212,10 @@ export default function RecorderScreen() {
   // (acquire never throws and completes in single-digit ms, so stop-taps aren't delayed).
   const reacquireThen = useCallback(
     (action: () => void) => async () => {
-      if (!muted && !callActive) await audioFocus.acquire();
+      if (!muted && !callActive) await acquireFocus();
       action();
     },
-    [muted, callActive, audioFocus],
+    [muted, callActive, acquireFocus],
   );
 
   // Hold-to-record needs more than reacquireThen: acquire() is awaited, and the gesture's
@@ -224,9 +227,9 @@ export default function RecorderScreen() {
   const holdSeqRef = useRef(0);
   const onHoldStart = useCallback(async () => {
     const seq = ++holdSeqRef.current;
-    if (!muted && !callActive) await audioFocus.acquire();
+    if (!muted && !callActive) await acquireFocus();
     if (seq === holdSeqRef.current) startHoldRecording();
-  }, [muted, callActive, audioFocus, startHoldRecording]);
+  }, [muted, callActive, acquireFocus, startHoldRecording]);
   const onHoldEnd = useCallback(() => {
     holdSeqRef.current++;
     endHoldRecording();

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -114,11 +114,15 @@ export default function RecorderScreen() {
   // mic being live — a muted clip has no audio track, so there's nothing to seize focus for.
   // Also released while a call is active: we must yield the audio session to telephony, not fight
   // it for focus. Tied to screen focus (not per segment) to avoid toggling the session mid-draft.
+  // `previewing` is a dep so CLOSING the preview re-runs acquire: expo-video's preview player
+  // flips the shared AVAudioSession to `.playback` (no mic input) when it plays, which would
+  // otherwise leave every post-preview clip recording silence — acquire restores `.playAndRecord`.
   const audioFocus = useAudioFocus();
   useEffect(() => {
+    if (previewing) return; // preview owns the session; re-acquire runs on close
     if (focused && appActive && !muted && !callActive && prefsReady) void audioFocus.acquire();
     else void audioFocus.release();
-  }, [focused, appActive, muted, callActive, prefsReady, audioFocus]);
+  }, [focused, appActive, muted, callActive, prefsReady, previewing, audioFocus]);
   useEffect(() => () => void audioFocus.release(), [audioFocus]);
 
   // Prediction can lose a race: on a cold-open / resume into an in-progress call the call snapshot
@@ -191,10 +195,23 @@ export default function RecorderScreen() {
     isRecording,
   });
 
+  // Re-assert the recording session config right before capture starts — cheap insurance
+  // against anything else (another expo-video player, a system event) having flipped the
+  // session category since the last acquire. No-op when the config is already correct.
+  // Awaited so the session is `.playAndRecord` BEFORE the recorder attaches the mic input
+  // (acquire never throws and completes in single-digit ms, so stop-taps aren't delayed).
+  const reacquireThen = useCallback(
+    (action: () => void) => async () => {
+      if (!muted && !callActive) await audioFocus.acquire();
+      action();
+    },
+    [muted, callActive, audioFocus],
+  );
+
   const { zoomSv, holdActive, buttonGesture, screenGesture, resetZoom, setZoomTo } =
     useRecorderGestures({
-      onToggle: toggleRecording,
-      onHoldStart: startHoldRecording,
+      onToggle: reacquireThen(toggleRecording),
+      onHoldStart: reacquireThen(startHoldRecording),
       onHoldEnd: endHoldRecording,
       onFocus,
       enabled: cameraReady && !previewing && !dragging,

--- a/src/features/recorder/use-audio-focus.ts
+++ b/src/features/recorder/use-audio-focus.ts
@@ -20,12 +20,17 @@ import { useCallback, useRef } from 'react';
  * Callers gate `acquire` on `!muted` (a muted clip has no audio track, so seizing the user's
  * playback would be pointless). Both calls are idempotent and never throw — an audio-session
  * failure must not break recording.
+ *
+ * `acquire` always re-applies the session config, even when focus is already held: expo-video's
+ * VideoManager forces the shared AVAudioSession to `.playback` (a category with NO mic input)
+ * whenever one of its players changes state — e.g. the in-recorder preview. If acquire
+ * short-circuited on "already held", nothing would ever restore `.playAndRecord`, and every
+ * clip recorded after a preview would silently capture an audio track of digital silence.
  */
 export function useAudioFocus() {
   const heldRef = useRef(false);
 
   const acquire = useCallback(async () => {
-    if (heldRef.current) return;
     heldRef.current = true;
     try {
       await setAudioModeAsync({

--- a/src/features/recorder/use-audio-focus.ts
+++ b/src/features/recorder/use-audio-focus.ts
@@ -26,6 +26,11 @@ import { useCallback, useRef } from 'react';
  * whenever one of its players changes state — e.g. the in-recorder preview. If acquire
  * short-circuited on "already held", nothing would ever restore `.playAndRecord`, and every
  * clip recorded after a preview would silently capture an audio track of digital silence.
+ *
+ * Because of that, an `acquire` can overlap a `release` (e.g. the effect releases on blur while
+ * a pre-record `acquire` is mid-await) — so both re-check `heldRef` after each await and bail
+ * when the other call flipped it meanwhile: the LAST requested state wins, and a slow stale
+ * continuation can't re-seize focus after a release (or tear down a fresh acquire's config).
  */
 export function useAudioFocus() {
   const heldRef = useRef(false);
@@ -38,6 +43,7 @@ export function useAudioFocus() {
         playsInSilentMode: true,
         interruptionMode: 'doNotMix',
       });
+      if (!heldRef.current) return; // release() won while we awaited — don't re-seize focus
       await setIsAudioActiveAsync(true);
     } catch {
       // session unavailable — recording continues, audio just mixes
@@ -49,6 +55,7 @@ export function useAudioFocus() {
     heldRef.current = false;
     try {
       await setIsAudioActiveAsync(false);
+      if (heldRef.current) return; // acquire() won while we awaited — leave its config alone
       await setAudioModeAsync({
         allowsRecording: false,
         interruptionMode: 'mixWithOthers',


### PR DESCRIPTION
Addresses the preview-induced silent-mic failure from #124 (the `.playback` session flip named in that issue's title). #124 also documents a second, separate failure mode — the `micBlocked` latch in `use-call-state.ts` staying set after non-call interruptions — which this PR does NOT touch; the issue stays open to track that.

## Problem

Clips recorded after using the in-recorder preview captured a silent audio track. ffprobe/volumedetect on exported segments showed the dead clips contain a flat ~-66 to -70 dB noise floor for their full duration — the mic input delivered digital silence with no error surfaced.

## Root cause

`expo-video`'s `VideoManager.setAudioSession()` forces the shared `AVAudioSession` to `.playback` / `.moviePlayback` whenever one of its players changes state. `.playback` has no microphone input, and the preview player (`use-preview.ts`) lives on the recorder screen — so previewing clips mid-session silently flipped the session out of `.playAndRecord`. VisionCamera kept capturing without error.

The app couldn't recover because `useAudioFocus.acquire()` short-circuited on `heldRef` ("already held"), so nothing ever re-applied the recording config until something rebuilt the session (mute toggle, camera flip, screen leave). Same failure mode as mrousavy/react-native-vision-camera#3560.

## Fix

- `use-audio-focus.ts`: `acquire()` always re-applies the session config instead of returning early when focus is already held.
- `recorder.tsx`:
  - the audio-focus effect keys on `previewing`, so closing the preview re-runs `acquire()` and restores `.playAndRecord`
  - record start awaits a session re-assert before the mic attaches (`reacquireThen` wrapping `onToggle` / `onHoldStart`) — cheap, idempotent insurance against any other session-stealer

## Testing

- `tsc`, `eslint`, full jest suite pass
- Diagnosed on device: instrumented session reproduced silent clips after preview; per-segment ffprobe confirmed full-length silent audio tracks with identical encoder params

Repro to verify: record a clip → preview it → record again → second clip should now have audio.


## Related upstream reports

- mrousavy/react-native-vision-camera#3560 — same symptom (audio missing from recordings on iOS); resolved there by stopping the video-player library from managing the audio session (`disableAudioSessionManagement` in react-native-video — expo-video exposes no equivalent)
- expo/expo#42709 — expo-audio/AVAudioSession interrupt-resume failure leaving a "zombie" mic state
- expo/expo#38671 — expo-audio and expo-video fighting over the shared audio session

