### PR TITLE
fix(ios): App Review purpose strings and background audio mode

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,8 +15,8 @@
       "appleTeamId": "X5873NL7XM",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSCameraUsageDescription": "Pulse uses your camera to record videos.",
-        "NSMicrophoneUsageDescription": "Pulse uses your microphone to record audio with your videos."
+        "NSCameraUsageDescription": "Pulse needs camera access to record video clips for your drafts. For example, when you film a video note, the camera captures the footage that you can then trim, merge, and upload.",
+        "NSMicrophoneUsageDescription": "Pulse needs microphone access to record sound with your video clips. For example, when you narrate a video note, your voice is captured alongside the footage and saved with the clip."
       }
     },
     "android": {
@@ -81,7 +81,8 @@
       [
         "expo-audio",
         {
-          "microphonePermission": false
+          "microphonePermission": "Pulse needs microphone access to record sound with your video clips. For example, when you narrate a video note, your voice is captured alongside the footage and saved with the clip.",
+          "enableBackgroundPlayback": false
         }
       ],
       "expo-asset",


### PR DESCRIPTION
Fixes the two config-level rejections from App Store review of 2.0.0 (28).

**Purpose strings (#144).** The string review actually saw was the generic `Allow $(PRODUCT_NAME) to access your microphone` — our `app.json` string never shipped. `expo-audio`'s `microphonePermission: false` deletes the key from the generated Info.plist and `expo-image-picker`'s plugin refills it with its default. Fixed by passing the real string through `expo-audio`, and rewrote both camera and mic strings in the purpose-plus-example format (referencing pulse-orig's approved strings, adapted to this app's recorder flow).

**Background audio (#145).** `expo-audio` injects `audio` into `UIBackgroundModes` by default (`enableBackgroundPlayback` defaults to true). Pulse has no background audio feature, so opted out. `UIBackgroundModes` now carries only `fetch` and `processing`.

Verified with `expo prebuild -p ios`: both strings land in Info.plist verbatim, `audio` gone.

Fixes #144
Fixes #145