### PR TITLE
fix(recorder): attach the mic from the first configure - the cameraReady gate flashed every cold open

### DIFF
--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -72,10 +72,16 @@ export function useRecorder(initialDraftId?: string) {
   // the mic into a call that began in the background.
   const { callActive, appActive, reportMicPriorityError } = useCallState();
 
-  // The mic config the session SHOULD have. `cameraReady` gates it so a cold open comes up
-  // video-only first (call detection lands before the mic is ever requested); dropped while a call
-  // holds the mic (`callActive`) or the user muted, so that clip has no audio track.
-  const micWanted = cameraReady && !muted && !callActive;
+  // The mic config the session SHOULD have: dropped while a call holds the mic (`callActive`)
+  // or the user muted, so that clip has no audio track. Deliberately NOT gated on cameraReady:
+  // call state is read synchronously at first render (useCallState's initializer), so the mic
+  // can attach from the session's FIRST configure. Gating on cameraReady made every cold open
+  // come up video-only and then rebuild the output audio-ful at `onStarted` — a second full
+  // session reconfigure ~25ms after the first preview frame, i.e. a visible flash on every
+  // open (and two extra rebuilds on every camera flip). The '!pri' -11800 recovery path
+  // (reportMicPriorityError) remains the backstop for the rare cold open that races an
+  // in-progress call the synchronous snapshot missed.
+  const micWanted = !muted && !callActive;
   // Freeze the mic config for the duration of a recording: an enableAudio change rebuilds the video
   // output, which tears down the in-flight recorder before it can finalize — dropping the clip. We
   // hold the value captured while idle and only let it change once recording stops, so a call


### PR DESCRIPTION
## Problem

Every cold open of the recorder flashed a beat after the first preview frame — the session came up, rendered, then visibly renegotiated. Root cause (full analysis in #149): `micWanted` was gated on `cameraReady`, so the session always configured **video-only** first, then the `onStarted` -> `enableAudio` flip rebuilt the whole video output on the live session — a second full configure ~25ms after `previewStarted`:

```
+115ms  sessionConfigSelected        (video-only session)
+303ms  previewStarted               (first frame visible)
+304ms  started -> cameraReady=true
+319ms  videoOutput rebuilt          (enableAudio: true)
+329ms  sessionConfigSelected AGAIN  <- the visible flash
```

The same gate also made the H.264 pin (#143) race the post-start reconfigure (first `setOutputSettings` attempt always rejected, riding on the retry), and camera flips paid two extra output rebuilds since flipping resets `cameraReady`.

## Change

One line plus documentation — drop the `cameraReady` term:

```ts
const micWanted = !muted && !callActive;
```

The gate's stated purpose ("call detection lands before the mic is requested") was already satisfied without it: `useCallState` reads `CallDetector.isCallActive()` synchronously in its state initializer, so the render that first configures the session already knows the call state. The `'!pri'` -11800 recovery path (`reportMicPriorityError`) remains the backstop for the rare cold open that races an in-progress call the snapshot missed. Mute and in-call gating are unchanged, as is the mid-recording freeze (`frozenMicRef`).

## Verification (on-device, iPhone)

Instrumented the full session lifecycle (`onSessionConfigSelected` / `onConfigured` / `onPreviewStarted` / `onStarted` + output-identity and codec-pin tracing), reproduced the double-configure, then re-ran with the fix across multiple cold opens:

- exactly **one** `sessionConfigSelected`/`configured` pair per open; nothing reconfigures after the first frame — flash gone
- `videoOutput` is created audio-ful from the first render (one instance, no rebuild)
- H.264 pin resolves on its **first** attempt (~2ms; previously always rejected once with "VideoOutput is not yet connected")
- recorded clips probed from disk: `h264` / `aac`, 1920x1080 @ 29.97 — the pipeline contract holds
- preview-close audio handoff (#136) still sequences correctly; post-preview clips carry a live audio track

Instrumentation was removed after verification; the shipped diff is the one-line gate change with an explanatory comment.

`tsc --noEmit` clean, eslint clean, full jest suite green (122 tests).

Fixes #149
