### PR TITLE
fix(recorder): record .mov on iOS so >10s clips keep audible audio

### DIFF
--- a/assets/dev/README.md
+++ b/assets/dev/README.md
@@ -14,9 +14,10 @@ while trimming.
 **Portrait** is the primary surface (short-form — the recorder & iPhone Camera). iPhone stores
 portrait as a **coded-landscape buffer + 90° rotation matrix**, _not_ baked-portrait pixels — these
 fixtures replicate that exactly (so the rotation/normalization path is actually tested). The
-recorder writes a true **MP4** container; the iPhone Camera app writes **QuickTime**, which reaches
-the app via Photos imports — the portrait fixtures keep QuickTime bytes under a `.mp4` name so that
-import surface stays covered (the container is not part of the merge signature). The **landscape**
+recorder and the iPhone Camera app both write **QuickTime** bytes (on iOS the recorder records
+`.mov` — a `.mp4`-named output triggers AVFoundation's movieFragmentInterval silent-audio bug on
+clips >10s — and persists under a `.mp4` name); the portrait fixtures keep QuickTime bytes under a
+`.mp4` name so that surface stays covered (the container is not part of the merge signature). The **landscape**
 clips stand in for video added later from the Photos app that must be normalized into the portrait
 timeline.
 
@@ -30,7 +31,7 @@ timeline.
 | `landscape-4k-30fps-hevc.mp4`    | 3840×2160 | 3840×2160 | —   | 30  | HEVC  | QuickTime | 14s |
 
 The `portrait-1080p-30fps-h264` clip mirrors **the recorder's stream format** (H.264/AAC 1080p30
-portrait; the recorder itself now writes a true MP4 container). All have AAC audio and are ~12–24s
+portrait; on iOS the container is QuickTime under a `.mp4` name). All have AAC audio and are ~12–24s
 so there's room to trim.
 Regenerate with [`scripts/make-dev-fixtures.sh`](../../scripts/make-dev-fixtures.sh).
 

--- a/scripts/analyze-draft-audio.py
+++ b/scripts/analyze-draft-audio.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Analyze a .pulse draft export for silent-audio segments (issue #157).
+
+Background: iOS AVCaptureMovieFileOutput + a .mp4-named output arms Apple's
+movieFragmentInterval bug — recordings that cross the 10s fragment interval
+consolidate with an ISO-style v0 mp4a+esds sound entry inside the recorder's
+'qt'-brand container, which AVFoundation itself refuses to read back. The clip
+then plays back SILENT in the app (preview/merge/transcription) while the audio
+bytes sit intact in the file. Fixed forward by recording fileType 'mov' on iOS;
+this script triages drafts (old or new) without needing ffmpeg or a device.
+
+For every media segment, reports:
+  - ftyp brand (qt vs mp42/isom)
+  - video codec, audio presence/bytes (structural, ffmpeg-level truth)
+  - audio sample-entry STYLE: QuickTime v1+wave vs ISO v0+esds
+  - stsd channel count vs actual AAC bitstream element (SCE mono / CPE stereo)
+  - device model (from QuickTime metadata)
+  - VERDICT: whether AVFoundation (app preview/merge) will see the audio.
+    Rule (validated empirically on affected drafts): audio is INVISIBLE to
+    AVFoundation iff brand == 'qt' AND the sound entry is ISO-style v0+esds.
+
+Usage: python3 scripts/analyze-draft-audio.py <draft.pulse | directory-with-media/>
+"""
+import io
+import json
+import re
+import struct
+import sys
+import zipfile
+from pathlib import Path
+
+
+def boxes_in(data, start, end):
+    o = start
+    while o < end:
+        if end - o < 8:
+            return
+        (size,) = struct.unpack(">I", data[o : o + 4])
+        typ = data[o + 4 : o + 8].decode("latin1")
+        hdr = 8
+        if size == 1:
+            (size,) = struct.unpack(">Q", data[o + 8 : o + 16])
+            hdr = 16
+        elif size == 0:
+            size = end - o
+        yield typ, o + hdr, o + size
+        o += size
+
+
+def find(data, start, end, path):
+    if not path:
+        yield (start, end)
+        return
+    for typ, cs, ce in boxes_in(data, start, end):
+        if typ == path[0]:
+            yield from find(data, cs, ce, path[1:])
+
+
+def audio_track_info(data):
+    """Return dict about the first soun trak, or None."""
+    for trak_s, trak_e in find(data, 0, len(data), ["moov", "trak"]):
+        handler = None
+        for mdia_s, mdia_e in find(data, trak_s, trak_e, ["mdia"]):
+            for typ, cs, ce in boxes_in(data, mdia_s, mdia_e):
+                if typ == "hdlr":
+                    handler = data[cs + 8 : cs + 12].decode("latin1")
+        if handler != "soun":
+            continue
+        info = {}
+        for stsd_s, stsd_e in find(data, trak_s, trak_e, ["mdia", "minf", "stbl", "stsd"]):
+            o = stsd_s + 8
+            (esize,) = struct.unpack(">I", data[o : o + 4])
+            entry = data[o : o + esize]
+            info["entry4cc"] = entry[4:8].decode("latin1")
+            (version,) = struct.unpack(">H", entry[16:18])
+            (ch,) = struct.unpack(">H", entry[24:26])
+            info["stsd_version"] = version
+            info["stsd_ch"] = ch
+            info["has_wave"] = b"wave" in entry
+            info["has_esds"] = b"esds" in entry
+        # sample count + payload bytes
+        for stbl_s, stbl_e in find(data, trak_s, trak_e, ["mdia", "minf", "stbl"]):
+            for typ, cs, ce in boxes_in(data, stbl_s, stbl_e):
+                if typ == "stsz":
+                    ss, count = struct.unpack(">II", data[cs + 4 : cs + 12])
+                    info["samples"] = count
+                    if ss == 0:
+                        sizes = struct.unpack(f">{count}I", data[cs + 12 : cs + 12 + 4 * count])
+                        info["audio_bytes"] = sum(sizes)
+                    else:
+                        info["audio_bytes"] = ss * count
+        # first AAC element type (SCE=mono bitstream, CPE=stereo bitstream)
+        first = first_audio_sample(data, trak_s, trak_e)
+        if first is not None:
+            off, _ = first
+            elem = data[off] >> 5
+            info["aac_element"] = {0: "SCE(mono)", 1: "CPE(stereo)"}.get(elem, f"id{elem}")
+        return info
+    return None
+
+
+def first_audio_sample(data, trak_s, trak_e):
+    for stbl_s, stbl_e in find(data, trak_s, trak_e, ["mdia", "minf", "stbl"]):
+        sizes = None
+        chunk_offsets = None
+        stsc = []
+        for typ, cs, ce in boxes_in(data, stbl_s, stbl_e):
+            if typ == "stsz":
+                ss, n = struct.unpack(">II", data[cs + 4 : cs + 12])
+                sizes = list(struct.unpack(f">{n}I", data[cs + 12 : cs + 12 + 4 * n])) if ss == 0 else [ss] * n
+            elif typ == "stco":
+                (n,) = struct.unpack(">I", data[cs + 4 : cs + 8])
+                chunk_offsets = struct.unpack(f">{n}I", data[cs + 8 : cs + 8 + 4 * n])
+            elif typ == "co64":
+                (n,) = struct.unpack(">I", data[cs + 4 : cs + 8])
+                chunk_offsets = struct.unpack(f">{n}Q", data[cs + 8 : cs + 8 + 8 * n])
+        if sizes and chunk_offsets:
+            return chunk_offsets[0], sizes[0]
+    return None
+
+
+def video_codec(data):
+    for trak_s, trak_e in find(data, 0, len(data), ["moov", "trak"]):
+        for stsd_s, stsd_e in find(data, trak_s, trak_e, ["mdia", "minf", "stbl", "stsd"]):
+            o = stsd_s + 8
+            fourcc = data[o + 4 : o + 8].decode("latin1")
+            if fourcc in ("avc1", "avc3", "hvc1", "hev1"):
+                return fourcc
+    return "?"
+
+
+def device_strings(data):
+    models = set(m.group().decode(errors="replace") for m in re.finditer(rb"iPhone[^\x00]{0,40}", data))
+    return sorted(models)
+
+
+def analyze_file(name, data):
+    (fsize,) = struct.unpack(">I", data[:4])
+    brand = data[8:12].decode("latin1").strip() if data[4:8] == b"ftyp" else "?"
+    vcodec = video_codec(data)
+    a = audio_track_info(data)
+    row = {"file": name, "brand": brand, "video": vcodec}
+    if a is None:
+        row.update(audio="NONE", verdict="NO AUDIO TRACK AT ALL (capture-level loss)")
+        return row
+    style = (
+        "QT v1+wave"
+        if a.get("stsd_version") == 1 and a.get("has_wave")
+        else "ISO v0+esds"
+        if a.get("stsd_version") == 0 and a.get("has_esds")
+        else f"v{a.get('stsd_version')}?"
+    )
+    invisible = brand == "qt" and style == "ISO v0+esds"
+    row.update(
+        audio=f"{a.get('samples', '?')} frames / {a.get('audio_bytes', '?')} B",
+        entry_style=style,
+        stsd_ch=a.get("stsd_ch"),
+        bitstream=a.get("aac_element", "?"),
+        verdict="SILENT in app (AVFoundation drops track)" if invisible else "OK (audio visible)",
+    )
+    return row
+
+
+def main(path):
+    p = Path(path)
+    entries = []
+    if p.is_dir():
+        for f in sorted(p.glob("**/*.mp4")):
+            entries.append((str(f.relative_to(p)), f.read_bytes()))
+    else:
+        with zipfile.ZipFile(p) as z:
+            manifest = None
+            for n in z.namelist():
+                if n == "manifest.json":
+                    manifest = json.loads(z.read(n))
+                elif n.endswith(".mp4"):
+                    entries.append((n, z.read(n)))
+            if manifest:
+                d = manifest["drafts"][0]
+                print(f"Draft: {d.get('name') or '(untitled)'}  mode={d.get('mode')}  segments={len(d.get('segments', []))}")
+
+    def seg_key(item):
+        m = re.search(r"s(\d+)", item[0])
+        return (int(m.group(1)) if m else 0, item[0])
+
+    entries.sort(key=seg_key)
+
+    devices = set()
+    silent = []
+    for name, data in entries:
+        devices.update(device_strings(data))
+        row = analyze_file(name, data)
+        mark = "❌" if "SILENT" in row["verdict"] or "NO AUDIO" in row["verdict"] else "✅"
+        print(
+            f"{mark} {row['file']:26s} brand={row['brand']:4s} video={row['video']} "
+            f"audio={row.get('audio', '?'):24s} style={row.get('entry_style', '-'):11s} "
+            f"stsd_ch={row.get('stsd_ch', '-')} bitstream={row.get('bitstream', '-'):11s} -> {row['verdict']}"
+        )
+        if mark == "❌":
+            silent.append(row["file"])
+    print()
+    if devices:
+        print("Recording device(s):", "; ".join(devices))
+    if silent:
+        print(f"\n{len(silent)}/{len(entries)} segment(s) will be SILENT in the app: {', '.join(silent)}")
+    else:
+        print(f"\nAll {len(entries)} segments have app-visible audio.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(1)
+    main(sys.argv[1])

--- a/scripts/analyze-draft-audio.py
+++ b/scripts/analyze-draft-audio.py
@@ -21,7 +21,6 @@ For every media segment, reports:
 
 Usage: python3 scripts/analyze-draft-audio.py <draft.pulse | directory-with-media/>
 """
-import io
 import json
 import re
 import struct
@@ -103,7 +102,6 @@ def first_audio_sample(data, trak_s, trak_e):
     for stbl_s, stbl_e in find(data, trak_s, trak_e, ["mdia", "minf", "stbl"]):
         sizes = None
         chunk_offsets = None
-        stsc = []
         for typ, cs, ce in boxes_in(data, stbl_s, stbl_e):
             if typ == "stsz":
                 ss, n = struct.unpack(">II", data[cs + 4 : cs + 12])
@@ -135,10 +133,16 @@ def device_strings(data):
 
 
 def analyze_file(name, data):
-    (fsize,) = struct.unpack(">I", data[:4])
-    brand = data[8:12].decode("latin1").strip() if data[4:8] == b"ftyp" else "?"
-    vcodec = video_codec(data)
-    a = audio_track_info(data)
+    # Fail gracefully per-file: a truncated/corrupt segment (or a stray non-media
+    # file swept up by directory mode) shouldn't abort the whole triage run.
+    if len(data) < 12 or data[4:8] != b"ftyp":
+        return {"file": name, "brand": "?", "video": "?", "verdict": "NOT AN MP4/MOV (no ftyp header)"}
+    try:
+        brand = data[8:12].decode("latin1").strip()
+        vcodec = video_codec(data)
+        a = audio_track_info(data)
+    except (struct.error, IndexError, UnicodeDecodeError) as e:
+        return {"file": name, "brand": "?", "video": "?", "verdict": f"UNPARSEABLE ({e.__class__.__name__}: truncated or corrupt)"}
     row = {"file": name, "brand": brand, "video": vcodec}
     if a is None:
         row.update(audio="NONE", verdict="NO AUDIO TRACK AT ALL (capture-level loss)")
@@ -165,7 +169,7 @@ def main(path):
     p = Path(path)
     entries = []
     if p.is_dir():
-        for f in sorted(p.glob("**/*.mp4")):
+        for f in sorted(q for ext in ("*.mp4", "*.mov", "*.m4v") for q in p.glob(f"**/{ext}")):
             entries.append((str(f.relative_to(p)), f.read_bytes()))
     else:
         with zipfile.ZipFile(p) as z:
@@ -173,7 +177,7 @@ def main(path):
             for n in z.namelist():
                 if n == "manifest.json":
                     manifest = json.loads(z.read(n))
-                elif n.endswith(".mp4"):
+                elif n.endswith((".mp4", ".mov", ".m4v")):
                     entries.append((n, z.read(n)))
             if manifest:
                 d = manifest["drafts"][0]
@@ -190,7 +194,8 @@ def main(path):
     for name, data in entries:
         devices.update(device_strings(data))
         row = analyze_file(name, data)
-        mark = "❌" if "SILENT" in row["verdict"] or "NO AUDIO" in row["verdict"] else "✅"
+        ok = row["verdict"].startswith("OK")
+        mark = "✅" if ok else "❌"
         print(
             f"{mark} {row['file']:26s} brand={row['brand']:4s} video={row['video']} "
             f"audio={row.get('audio', '?'):24s} style={row.get('entry_style', '-'):11s} "

--- a/scripts/make-dev-fixtures.sh
+++ b/scripts/make-dev-fixtures.sh
@@ -6,10 +6,11 @@
 #
 #   - SHORT-FORM PORTRAIT is the primary surface (the recorder + iPhone Camera output).
 #     iPhone stores portrait as a CODED-LANDSCAPE buffer + a 90 rotation matrix (not baked
-#     portrait pixels). The recorder writes a true MP4 container (fileType 'mp4'); the iPhone
-#     Camera app writes QuickTime (.mov), which reaches the app via Photos imports. Portrait
-#     fixtures keep QuickTime bytes under a .mp4 name so that import surface stays covered —
-#     the container is not part of the merge signature, only the streams are.
+#     portrait pixels). The recorder writes QuickTime bytes under a .mp4 name (fileType only
+#     controls the temp file's extension on iOS — see #157; recording is .mov there now); the
+#     iPhone Camera app writes QuickTime (.mov), which reaches the app via Photos imports.
+#     Portrait fixtures keep QuickTime bytes under a .mp4 name so that import surface stays
+#     covered — the container is not part of the merge signature, only the streams are.
 #   - LANDSCAPE clips stand in for video added later from the Photos app (HEVC .mov from the
 #     camera, or a plain H.264 .mp4 shared/downloaded) that must be normalized into the
 #     portrait timeline.

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -95,10 +95,11 @@ export function useRecorder(initialDraftId?: string) {
   // the codec is forced to H.264 below (see the setOutputSettings effect) so every clip is
   // format-uniform, exports on the merge engine's zero-re-encode fast path, AND plays in every
   // browser — VisionCamera's device default is HEVC on modern iPhones, which Firefox never
-  // decodes and Chrome usually can't without hardware support. `fileType: 'mp4'`
-  // makes iOS write a true MP4 container (Android always does) — segments are persisted and
-  // uploaded as `{segmentId}.mp4`, so the bytes now match the extension end to end instead of
-  // QuickTime bytes under an .mp4 name.
+  // decodes and Chrome usually can't without hardware support.
+  // fileType 'mov' on iOS: a `.mp4`-named output arms Apple's movieFragmentInterval bug — clips
+  // >10s consolidate with an audio sample entry AVFoundation refuses to read back, playing back
+  // SILENT in preview/merge/transcription. Full RCA in #157. Android ignores fileType (CameraX
+  // always writes a real MP4). Segments are persisted and uploaded as `{segmentId}.mp4` either way.
   // targetBitRate ~5 Mbps: the mobile-feed sweet spot for 1080p. CAVEAT (measured on-device,
   // see PR #142): VisionCamera applies this inside the session-configuration batch, where it
   // can silently fail to land — real 1080p clips have probed at ~8 Mbps (the encoder default
@@ -108,7 +109,7 @@ export function useRecorder(initialDraftId?: string) {
     targetResolution: CommonResolutions.FHD_16_9,
     targetBitRate: 5_000_000,
     enableAudio: micEnabled,
-    fileType: 'mp4',
+    fileType: Platform.OS === 'ios' ? 'mov' : 'mp4',
   });
 
   // Force H.264 (iOS only — Android's CameraX camcorder profiles are already AVC, and its


### PR DESCRIPTION
## Problem

Any iOS segment recorded longer than ~10s played back **silent** in the app — preview, merged export, and transcription — while the audio bytes sat intact in the file. Full root-cause analysis in #157 (comment): `AVCaptureMovieFileOutput`'s default 10s `movieFragmentInterval`, combined with a `.mp4`-named output, consolidates fragments with an audio sample entry that AVFoundation itself refuses to read back. ffmpeg/VLC/Chrome read the same file fine.

## Fix

Record with `fileType: 'mov'` on iOS. The fileType only ever controlled the temp file's extension (the container is QuickTime either way), but the `.mov` name makes the >10s fragment consolidation write the readable audio header — correct at any length, crash-recovery fragments intact. This is the long-standing community fix for this Apple bug, and what this app did before 2.0.

- Android unaffected: it ignores `fileType` entirely (CameraX always writes a real MP4)
- Downstream unchanged: clips are persisted/uploaded as `{segmentId}.mp4` either way; merge paths probe content, not extensions; merged export stays a true faststart MP4
- Forward-only: previously recorded >10s segments remain silent in-app (their audio bytes are intact)

## Testing

- `tsc --noEmit` and `eslint` pass
- Verified on device: recorded a >10s segment on this branch, audio plays in preview

Addresses the root-cause item of #157.