### PR TITLE
fix(ios): remove CallKit, rebuild call detection on AVAudioSession interruptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ flowchart TB
 
 - Multi-clip segmented recording with [VisionCamera](https://react-native-vision-camera.com) v5 — segments append to one draft with a live segment bar and drag-to-reorder
 - Front/back flip, torch, mic mute, tap-to-focus, pinch-to-zoom, lens selection, and stabilization modes (off / standard / cinematic / auto), all persisted across sessions
-- Call-aware capture: a custom native module (CallKit on iOS, audio-mode detection on Android) gates the microphone during phone/VoIP calls so recordings don't silently freeze
+- Call-aware capture: a custom native module (audio-interruption detection on iOS, audio-mode detection on Android) gates the microphone when the audio session is interrupted so recordings don't silently freeze
 - Import existing videos from Photos instead of recording
 
 ### Editing & export
@@ -112,7 +112,7 @@ Platform notes:
 
 - **Cinematic stabilization** is iOS-only (VisionCamera exposes it via AVFoundation); Android offers off / standard / auto
 - **Whisper transcription** uses Metal GPU acceleration on iOS; Android runs on CPU, so larger models are noticeably slower — Base (en) is the recommended starting point
-- **Call-aware capture** uses CallKit on iOS and an audio-mode heuristic on Android (no extra permissions), so both platforms pause the mic during phone/VoIP calls
+- **Call-aware capture** uses AVAudioSession interruptions on iOS (no CallKit — it must stay out of the binary for China App Store distribution) and an audio-mode heuristic on Android (no extra permissions), so both platforms pause the mic when the session is interrupted
 - On Android, merged exports save through MediaStore into `DCIM/`, and uploads run as a `dataSync` foreground service with a progress notification
 
 ## How it works

--- a/modules/expo-call-detector/android/src/main/java/expo/modules/calldetector/CallDetectorModule.kt
+++ b/modules/expo-call-detector/android/src/main/java/expo/modules/calldetector/CallDetectorModule.kt
@@ -28,9 +28,9 @@ private class ModeChangeObserver(onChange: () -> Unit) {
 }
 
 /**
- * Android counterpart of the iOS CallKit-based detector, built on `AudioManager.getMode()` —
- * telephony/VoIP flips the global audio mode to RINGTONE / IN_CALL / IN_COMMUNICATION, which
- * mirrors CXCallObserver's "ringing, dialing, or connected" semantics without needing the
+ * Android counterpart of the iOS detector (an AVAudioSession-interruption latch), built on
+ * `AudioManager.getMode()` — telephony/VoIP flips the global audio mode to RINGTONE / IN_CALL /
+ * IN_COMMUNICATION, giving "a call holds the audio" semantics without needing the
  * READ_PHONE_STATE permission (and unlike TelephonyCallback it also covers VoIP apps).
  *
  * Change delivery: API 31+ uses `addOnModeChangedListener`; older releases have no

--- a/modules/expo-call-detector/ios/CallDetector.podspec
+++ b/modules/expo-call-detector/ios/CallDetector.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name           = 'CallDetector'
   s.version        = '1.0.0'
-  s.summary        = 'Phone/VoIP call detection (CXCallObserver) + background-task helpers'
-  s.description    = 'Local Expo module: reports active-call state so the recorder can drop the mic during calls, plus iOS background-task helpers to finalize a clip when backgrounded.'
+  s.summary        = 'Phone/VoIP call detection (AVAudioSession interruptions) + background-task helpers'
+  s.description    = 'Local Expo module: reports active-call state (via audio-session interruptions — deliberately NO CallKit, which must stay out of the binary for China App Store distribution) so the recorder can drop the mic during calls, plus iOS background-task helpers to finalize a clip when backgrounded.'
   s.author         = 'Pulse'
   s.homepage       = 'https://docs.expo.dev/modules/'
-  # iOS only: CallKit's CXCallObserver and UIApplication background tasks aren't on the tvOS SDK.
+  # iOS only: UIApplication background tasks aren't on the tvOS SDK.
   s.platforms      = {
     :ios => '16.4'
   }

--- a/modules/expo-call-detector/ios/CallDetectorModule.swift
+++ b/modules/expo-call-detector/ios/CallDetectorModule.swift
@@ -1,31 +1,48 @@
-import CallKit
+import AVFAudio
 import ExpoModulesCore
 import UIKit
 
-// CXCallObserver requires an NSObject delegate, which an Expo `Module` is not — so this thin
-// object holds the observer's delegate role and forwards every call-state change back to the
-// module through a closure.
-final class CallObserverDelegate: NSObject, CXCallObserverDelegate {
-  var onChange: (() -> Void)?
-
-  func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {
-    onChange?()
-  }
-}
-
+// Call detection WITHOUT CallKit: the MIIT requires CallKit to be inactive in apps on the China
+// App Store, and App Review flags the framework linkage itself (Guideline 5, see issue #146) — so
+// nothing here may import it. Instead we observe AVAudioSession interruptions, which Apple
+// documents as the mechanism that fires for incoming phone calls ("System alerts, such as
+// receiving an incoming phone call, interrupt the active audio session"). `.began` latches
+// "something that outranks us holds the audio session" and `.ended` clears it. Interruptions are
+// not strictly call-only (Siri and alarms also fire) — but for "stop capturing audio, we lost the
+// mic" that is the more correct trigger anyway, and it matches the Android detector's semantics
+// (AudioManager.getMode() is likewise not call-exclusive).
+//
+// Ring-time behavior (verified on-device): with the ringer AUDIBLE, the ringtone itself interrupts
+// our session, so the latch fires while the call is still ringing — pre-answer, matching the old
+// CXCallObserver timing in the common case. With the silent switch on there is no ringtone, so
+// nothing fires until the call is actually answered (the system takes the audio session then).
+//
+// Known gaps, all covered by the '!pri' recovery path in recorder.tsx (an AVAudioSession
+// activation attempted during a call fails with ErrorCode.insufficientPriority —
+// '!pri' / 561017449 — which onCameraError matches and recovers from by rebuilding video-only):
+//  - A call already in progress when the recorder opens is invisible to the latch: none of our
+//    audio was active to be interrupted, so isCallActive() reads false and the mic attach fails
+//    reactively instead. If that call then ends while the app stays foreground the whole time
+//    (verified: hanging up from the Dynamic Island does NOT background the app), no event exists
+//    to clear the gate — the next background/foreground cycle recovers it via the force-clear.
+//  - A `.began` has NO guaranteed matching `.ended` (the user answers and the app suspends, or we
+//    deactivate our own session mid-interruption). A stale latch would wedge the recorder
+//    video-only forever, so didBecomeActive force-clears it on every foreground; if a call is
+//    genuinely still active the next mic attach re-gates through the same '!pri' path.
+//  - Any call that never interrupts our session — VoIP or otherwise (verified on-device with
+//    WhatsApp Audio) — is invisible: the latch is app-agnostic and only sees audio-session
+//    interruptions. CXCallObserver would have reported these, but no CallKit-free event source
+//    exists. Acceptable: with no actual audio-session conflict, recording keeps working through
+//    the call, so there is nothing to protect against (tracked as a known limitation, #146).
 public class CallDetectorModule: Module {
-  private let delegate = CallObserverDelegate()
-  // Created eagerly in OnCreate (NOT lazily): isCallActive() is a synchronous Function that runs on
-  // the JS thread, while OnStartObserving runs on the module thread — a lazy first-touch from both
-  // is an unsynchronized race that could construct two observers. CXCallObserver holds its delegate
-  // weakly, so the module owns both.
-  private var callObserver: CXCallObserver?
-
-  // A call (ringing, dialing, or connected) holds the mic until it has ended. Telephony outranks
-  // the app for the microphone, so any non-ended call means we must not capture audio.
-  private var isCallActive: Bool {
-    callObserver?.calls.contains { !$0.hasEnded } ?? false
-  }
+  // The interruption latch. Written on the main queue by the notification handlers, read
+  // synchronously from the JS thread by isCallActive() — hence the lock. `observing` (JS listener
+  // attached) lives under the same lock: it's flipped from the module thread by
+  // OnStart/OnStopObserving while handlers race it on main.
+  private var interruptionActive = false
+  private var observing = false
+  private let stateLock = NSLock()
+  private var notificationTokens: [NSObjectProtocol] = []
 
   // Background tasks we've begun but not yet ended, guarded by a lock. iOS may fire a task's
   // expiration handler before JS calls endBackgroundTask, so we track which ids are still live and
@@ -44,20 +61,95 @@ public class CallDetectorModule: Module {
     UIApplication.shared.endBackgroundTask(taskId)
   }
 
+  private func emitCallState(_ active: Bool) {
+    if Thread.isMainThread {
+      sendEvent("onCallStateChange", ["isActive": active])
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        self?.sendEvent("onCallStateChange", ["isActive": active])
+      }
+    }
+  }
+
+  // Updates the latch; emits onCallStateChange on a real change (or always, when `force`) if JS is
+  // subscribed. `force` exists for the foreground clear: JS treats ANY event as authoritative and
+  // uses it to drop its '!pri' mic-blocked override (see use-call-state.ts), so the clear must emit
+  // even when the latch was already false — e.g. a call the latch never saw that has since ended.
+  private func setInterruptionActive(_ active: Bool, force: Bool = false) {
+    stateLock.lock()
+    let changed = interruptionActive != active
+    interruptionActive = active
+    let shouldEmit = (changed || force) && observing
+    stateLock.unlock()
+    if shouldEmit {
+      emitCallState(active)
+    }
+  }
+
+  private func handleInterruption(_ notification: Notification) {
+    guard let userInfo = notification.userInfo,
+          let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+          let type = AVAudioSession.InterruptionType(rawValue: typeValue) else { return }
+    // A suspended-app interruption would latch a phantom call on resume — two generations of the
+    // same signal, both filtered defensively even though neither is delivered at our 16.4 floor:
+    //  - iOS 14.5–15.x: reason .appWasSuspended (raw value 1); the SDK marks it "not present from
+    //    iOS 16 onwards" (checked by raw value so we don't touch the deprecated symbol).
+    //  - iOS 10.3–14.5: the older wasSuspended boolean key issue #146 names explicitly, superseded
+    //    by the reason key above but still checked here for belt-and-suspenders / older SDKs.
+    if let reason = userInfo[AVAudioSessionInterruptionReasonKey] as? UInt, reason == 1 { return }
+    if let wasSuspended = userInfo[AVAudioSessionInterruptionWasSuspendedKey] as? Bool, wasSuspended {
+      return
+    }
+    switch type {
+    case .began:
+      setInterruptionActive(true)
+    case .ended:
+      setInterruptionActive(false)
+    @unknown default:
+      break
+    }
+  }
+
   public func definition() -> ModuleDefinition {
     Name("CallDetector")
 
     Events("onCallStateChange")
 
     OnCreate {
-      let observer = CXCallObserver()
-      observer.setDelegate(self.delegate, queue: nil) // nil => deliver on the main queue
-      self.callObserver = observer
+      // Registered eagerly (not in OnStartObserving) so the latch is already tracking when JS takes
+      // its synchronous isCallActive() snapshot on first render, before any listener attaches.
+      let center = NotificationCenter.default
+      self.notificationTokens.append(center.addObserver(
+        forName: AVAudioSession.interruptionNotification,
+        object: AVAudioSession.sharedInstance(),
+        queue: .main
+      ) { [weak self] notification in
+        self?.handleInterruption(notification)
+      })
+      self.notificationTokens.append(center.addObserver(
+        forName: UIApplication.didBecomeActiveNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        // Force-clear on every foreground (see the header comment): a missed `.ended` must not
+        // leave the recorder wedged video-only, and JS needs the event even when the latch was
+        // already false so its '!pri' override clears too.
+        self?.setInterruptionActive(false, force: true)
+      })
     }
 
-    // Synchronous snapshot for the very first render, before any event has been delivered.
+    OnDestroy {
+      self.notificationTokens.forEach(NotificationCenter.default.removeObserver)
+      self.notificationTokens.removeAll()
+    }
+
+    // Synchronous snapshot for the very first render, before any event has been delivered. A call
+    // already in progress at cold open reads false here BY DESIGN — the '!pri' fallback above is
+    // the recovery path for that case.
     Function("isCallActive") { () -> Bool in
-      self.isCallActive
+      self.stateLock.lock()
+      defer { self.stateLock.unlock() }
+      return self.interruptionActive
     }
 
     // Background-execution helpers so the recorder can finish writing a clip to disk after the app
@@ -81,17 +173,19 @@ public class CallDetectorModule: Module {
     }
 
     OnStartObserving {
-      self.delegate.onChange = { [weak self] in
-        guard let self else { return }
-        self.sendEvent("onCallStateChange", ["isActive": self.isCallActive])
-      }
-      // Emit the current state immediately — CXCallObserver only pushes future *changes*, so a call
-      // already in progress when the listener attaches would otherwise be missed.
-      self.sendEvent("onCallStateChange", ["isActive": self.isCallActive])
+      self.stateLock.lock()
+      self.observing = true
+      let active = self.interruptionActive
+      self.stateLock.unlock()
+      // Emit the current state immediately — interruptions only push future *changes*, so a latch
+      // set before the listener attached would otherwise be missed.
+      self.emitCallState(active)
     }
 
     OnStopObserving {
-      self.delegate.onChange = nil
+      self.stateLock.lock()
+      self.observing = false
+      self.stateLock.unlock()
     }
   }
 }

--- a/modules/expo-call-detector/src/CallDetector.types.ts
+++ b/modules/expo-call-detector/src/CallDetector.types.ts
@@ -1,5 +1,7 @@
 export type CallStateChangePayload = {
-  /** True while a phone / VoIP call is active (ringing, dialing, or connected). */
+  /** True while the mic is unavailable because the session is interrupted. On iOS that can flip
+   * as soon as the ringtone interrupts an open recorder session, or later when the call is
+   * actually answered if no ringtone was audible. */
   isActive: boolean;
 };
 

--- a/src/app/recorder.tsx
+++ b/src/app/recorder.tsx
@@ -178,8 +178,9 @@ export default function RecorderScreen() {
   // react to the error directly and bounce the session off→on for a tick to force a clean restart
   // out of the failed state (`recovering` drives the bounce). The -11800 family has two flavors
   // needing different handling:
-  //  - '!pri' (561017449): telephony owns the mic — prediction lost the cold-open/resume race
-  //    against an in-progress call (the call snapshot read stale and the mic attached anyway).
+  //  - '!pri' (561017449): telephony owns the mic — a call the interruption latch couldn't see
+  //    (already in progress at cold open / resume, so none of our audio was active to be
+  //    interrupted; the snapshot read "no call" and the mic attached anyway).
   //    Drop the mic until the next authoritative call event (reportMicPriorityError rebuilds the
   //    output video-only); recording with it would just re-throw.
   //  - plain -11800 (e.g. underlying -10868, kAudioUnitErr_FormatNotSupported): the session

--- a/src/features/recorder/use-call-state.ts
+++ b/src/features/recorder/use-call-state.ts
@@ -9,23 +9,28 @@ import CallDetector from '../../../modules/expo-call-detector/src/CallDetectorMo
  * live during a call throws the AVFoundation -11800 / '!pri' error that freezes the capture session.
  *
  * Signals:
- *  - callActive: on iOS live from CallKit's CXCallObserver; on Android from AudioManager's mode
- *    (RINGTONE / IN_CALL / IN_COMMUNICATION) — both via our local expo-call-detector module. The
- *    native delegate does NOT fire while the app is suspended, so a call that *starts* while the
- *    app is backgrounded is invisible until resume — we therefore re-poll the live state on
- *    foreground (isCallActive() reads the native call state directly).
+ *  - callActive: on iOS from an AVAudioSession-interruption latch (deliberately NO CallKit — the
+ *    framework must stay out of the binary for China App Store distribution, see issue #146); on
+ *    Android from AudioManager's mode (RINGTONE / IN_CALL / IN_COMMUNICATION) — both via our local
+ *    expo-call-detector module. The native side does NOT fire while the app is suspended, so a
+ *    call that *starts* while the app is backgrounded is invisible until resume — we therefore
+ *    re-poll the live state on foreground (isCallActive() reads the native latch directly; the iOS
+ *    module also force-clears a possibly-stale latch on every foreground and emits, since a
+ *    `.began` interruption has no guaranteed matching `.ended`).
  *  - appActive: false while backgrounded. VisionCamera has no lifecycle handling of its own, so
  *    iOS auto-resumes the capture session on foreground with the mic still attached — straight into
  *    a call that began in the background. The recorder stops the session while backgrounded (via
  *    `isActive`) and only restarts it once foreground, by which point callActive has been re-polled,
  *    so the mic is never resumed into an in-progress call.
- *  - micBlocked: the prediction above can still lose a race — on a cold-open / resume into an
- *    *in-progress* call, CXCallObserver.calls may not have synced on the first foreground frame, so
- *    the snapshot reads "no call" and the mic attaches → -11800. We can't out-predict the OS here,
- *    so we react to ground truth: when the capture session reports the '!pri' error (see
- *    reportMicPriorityError), force the mic off until the next authoritative call-state event proves
- *    it safe. That event fires reliably when the call ends, and an isActive=true correction keeps
- *    the mic gated anyway — so clearing on ANY event is safe.
+ *  - micBlocked: the latch above cannot know about a call already in progress at a cold open /
+ *    resume (on iOS none of our audio was active to be interrupted), so the snapshot reads "no
+ *    call" and the mic attaches → -11800 '!pri'. We can't out-predict the OS here, so we react to
+ *    ground truth: when the capture session reports the '!pri' error (see reportMicPriorityError),
+ *    force the mic off until the next authoritative call-state event proves it safe. On iOS that
+ *    event arrives from the interruption `.ended` or the module's foreground force-clear — a call
+ *    that ends while the app stays foreground the whole time (cold-opened into it) un-gates only
+ *    on the next foreground transition; an isActive=true correction keeps the mic gated anyway —
+ *    so clearing on ANY event is safe.
  */
 export function useCallState() {
   const [rawCallActive, setRawCallActive] = useState(() => CallDetector.isCallActive());

--- a/src/features/recorder/use-recorder.ts
+++ b/src/features/recorder/use-recorder.ts
@@ -79,8 +79,8 @@ export function useRecorder(initialDraftId?: string) {
   // come up video-only and then rebuild the output audio-ful at `onStarted` — a second full
   // session reconfigure ~25ms after the first preview frame, i.e. a visible flash on every
   // open (and two extra rebuilds on every camera flip). The '!pri' -11800 recovery path
-  // (reportMicPriorityError) remains the backstop for the rare cold open that races an
-  // in-progress call the synchronous snapshot missed.
+  // (reportMicPriorityError) remains the backstop for a cold open into an in-progress call,
+  // which the interruption latch cannot see (nothing of ours was active to be interrupted).
   const micWanted = !muted && !callActive;
   // Freeze the mic config for the duration of a recording: an enableAudio change rebuilds the video
   // output, which tears down the in-flight recorder before it can finalize — dropping the clip. We
@@ -350,11 +350,27 @@ export function useRecorder(initialDraftId?: string) {
       // honored as soon as the recorder exists.
       const recorder = await videoOutput.createRecorder({});
       recorderRef.current = recorder;
+      // The temp file the recorder writes to, captured up front for the salvage path below.
+      const recordingPath = recorder.filePath;
       const filePath = await new Promise<string>((resolve, reject) => {
         recorder
           .startRecording(
             (path) => resolve(path),
-            (err) => reject(err),
+            (err) => {
+              // An audio-session interruption mid-write (alarm / timer / a call seizing the mic)
+              // ends the recording with an error — but AVFoundation finalizes the movie on disk
+              // first, so the file is usually complete up to the cut. VisionCamera surfaces every
+              // such stop as an error; probe the file and treat a playable clip as a successful
+              // stop instead of dropping it. A dead / zero-length file still rejects as before.
+              const recordingUri = recordingPath.startsWith('file://')
+                ? recordingPath
+                : `file://${recordingPath}`;
+              void isValidFile(recordingUri).then(
+                (info) =>
+                  info.isValid && info.duration > 0 ? resolve(recordingPath) : reject(err),
+                () => reject(err),
+              );
+            },
           )
           .then(() => {
             // Capture has actually started — honor a stop requested while we were preparing
@@ -373,7 +389,8 @@ export function useRecorder(initialDraftId?: string) {
       const durationMs = await getDurationMs(absolutize(originalFilename));
       await persistSegment(id, segmentId, originalFilename, durationMs);
     } catch {
-      // interrupted mid-record — drop the clip
+      // Recording died with no salvageable file (see the error probe above), or the persist
+      // itself failed — nothing to keep.
     } finally {
       recorderRef.current = null;
       stopRequestedRef.current = false;


### PR DESCRIPTION
Closes #146 (part of #147 — the last resubmission blocker).

## Why

App Review rejected 2.0.0 (28) under Guideline 5: the MIIT requires CallKit to be inactive in apps on the China App Store, and Apple flags the framework **linkage itself**. China distribution stays, so CallKit goes. Call detection is rebuilt on `AVAudioSession.interruptionNotification` — the mechanism Apple documents as firing for incoming phone calls — bringing iOS to the same audio-centric architecture Android already uses (`AudioManager.getMode()`).

## What changed

- **`CallDetectorModule.swift`** (the main behavior change): `import CallKit` / `CallObserverDelegate` / `CXCallObserver` removed. An interruption latch replaces it: `.began` → active, `.ended` → clear. Registered in `OnCreate` so the synchronous `isCallActive()` first-render snapshot is live before JS subscribes; `NSLock`-guarded (JS thread reads, main queue writes).
- **Foreground force-clear**: `.began` has no guaranteed matching `.ended` (answered call → app suspends; or we deactivate our own session mid-interruption). A stale latch would wedge the recorder video-only forever, so `didBecomeActive` force-clears **and force-emits** — JS's `'!pri'` `micBlocked` override clears on any authoritative event, so the emit fires even when the latch was already false.
- **Suspended-app interruption filter** (defensive — neither key is delivered at our 16.4 floor): both the `.appWasSuspended` reason (iOS 14.5–16.0, checked by raw value) and the legacy `AVAudioSessionInterruptionWasSuspendedKey` boolean (iOS 10.3–14.5) are ignored, so a backgrounded recorder can never report a phantom call on resume.
- **Clip salvage on interruption mid-recording** (`use-recorder.ts`, found during on-device testing): an alarm/timer/call seizing the audio session mid-write ends the recording with an AVFoundation error, but the movie on disk is finalized and complete up to the cut — VisionCamera surfaces every such stop as `onRecordingError`, and we previously dropped the playable file. Now the error path probes `Recorder.filePath` and persists a valid clip through the normal segment path. (Pre-existing loss — the old CallKit build had identical session-death physics and couldn't even see alarms — but this rebuild made it visible, so it's fixed here.)
- **JS API surface unchanged** (`isCallActive`, `onCallStateChange`, background-task helpers) — `use-call-state.ts` logic untouched; **Android unchanged**.
- Doc sweep: README, podspec, and every comment that referenced CallKit / `CXCallObserver`.

## Intentional behavior differences (documented in the module, not bugs)

- **Ring-time detection depends on the ringer**: with the ringer audible, the ringtone itself interrupts the session, so the mic gates while still ringing (verified on-device — better than CallKit-parity in the common case). With the silent switch on, no ringtone → no interruption → nothing fires until the call is answered.
- **A call already in progress at recorder open is invisible to the latch** (nothing of ours was active to be interrupted) → mic attach fails `'!pri'` → existing recovery rebuilds video-only. If that call ends while the user never leaves the app (verified on-device: hanging up from the **Dynamic Island** keeps the app foreground), the mic stays gated until the next background/foreground cycle — one bg/fg cycle recovers it, also verified. Hanging up via the full call UI backgrounds the app, so it self-recovers.
- **Interruptions aren't call-exclusive** (Siri, alarms also latch) — for "something outranks us for the mic" that's the more correct trigger, and it matches Android's semantics.
- **Any call that never interrupts our session is invisible — VoIP or otherwise** (verified on-device with WhatsApp Audio: the badge never flips; the latch is app-agnostic and only sees audio-session interruptions). `CXCallObserver` would have reported these; without CallKit no event source exists. Acceptable in practice: the recording itself never breaks — a full clip recorded through an entire WhatsApp call with intact audio, because there was no actual audio-session conflict to react to.

## Verification

### Machine-level
- [x] `grep -ri callkit modules/ src/` → only "deliberately NO CallKit" prose, zero code refs
- [x] No other dependency links CallKit (`grep -rl CXCall node_modules/*/ios` → nothing)
- [x] `xcodebuild` of the `CallDetector` pod target → **BUILD SUCCEEDED**
- [x] `strings libCallDetector.a` (fresh artifact) → 0 CallKit refs; AVFAudio autolink present
- [x] eslint + prettier + tsc clean on touched TS files
- [x] Full clean-slate rebuild (`rm -rf node_modules ios android` → `npm ci` → `prebuild -p ios --clean`) → **BUILD SUCCEEDED**, `otool -L` + `strings` on the app binary and all 26 embedded frameworks → 0 CallKit hits

### On-device (physical iPhone 17 Pro Max, iOS 26.5.1, Release build, second phone + SIM)
- [x] `otool -L Pulse.app/Pulse | grep -i callkit` on the full app binary → empty (clean `npm ci` + `prebuild --clean` + Release device build; all embedded frameworks scanned — 0 hits)
- [x] Recording → call rings → **decline** → clip intact, next clip has audio
- [x] Recording → **answer** → hang up → return: clip finalized (background-finalize path), no stuck "On call", mic returns
- [x] Recorder open idle → call rings → gates at **ring time** with ringer audible; camera preview unaffected
- [x] Open recorder **during** an active call → video-only via `'!pri'` recovery, no wedge
- [x] …then hang up + background/foreground → mic returns (Dynamic Island hangup needs the bg/fg cycle — documented above; full-call-UI hangup self-recovers)
- [x] Background mid-recording → resume → no phantom "On call", clip finalized with audio
- [x] Call arrives while backgrounded → answer/decline → resume → correct gating
- [x] Siri (side button) → gates; dismiss → clears. Timer fires mid-recording → gates, **clip salvaged as a segment** (the new salvage path), mic returns on dismiss
- [x] Preview open/close → record → next clip has audio (**#158 regression guard**)
- [x] Spotify/Apple Music pauses when the recorder opens, resumes on leave (expo-audio focus untouched)
- [x] Fresh `npx expo prebuild -p ios` → no CallKit in `ios/`, specific mic string present, no `audio` in `UIBackgroundModes` (#144/#145)

## After merge

Resubmit with China still listed and reply to the App Review message confirming CallKit has been removed from the binary.


