### PR TITLE
chore(deps): refresh lockfile to resolve js-yaml and brace-expansion advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2547,15 +2547,15 @@
       }
     },
     "node_modules/@expo/config-plugins/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/glob": {
@@ -2752,15 +2752,15 @@
       }
     },
     "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/glob": {
@@ -3288,9 +3288,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5030,16 +5030,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -6213,9 +6213,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11097,9 +11097,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Refreshes `package-lock.json` to resolve 4 of the 8 open Dependabot security alerts by picking up patched versions that are **already permitted** by the semver ranges Expo's own packages (and our devDependencies) declare. No `package.json` changes, no Expo/framework version bumps, no `overrides`/`resolutions` added.

## Fixes
- Closes #14 — js-yaml quadratic CPU in `!!omap` (3.x): `3.15.0` → `3.15.1` (via `babel-plugin-istanbul`, Jest coverage tooling, dev-only)
- Closes #13 — js-yaml quadratic CPU in `!!omap` (4.x): `4.3.0` → `4.3.1` (via `@expo/xcpretty` and eslint's `@eslint/eslintrc`)
- Closes #11 — brace-expansion unbounded intermediate arrays: `5.0.7` → `5.0.9` (via `minimatch@10` used by `@expo/cli`, `@expo/config`, `@expo/config-plugins`, `@expo/fingerprint`, `@expo/metro-config`)
- Closes #8 — brace-expansion unbounded expansion length: `1.1.16` → `1.1.18` (via eslint's `minimatch@3`)

## Not fixed here (tracked separately, need upstream action)
- **#17 / #16 (image-size ICNS/JXL/HEIF DoS)** — no patched version exists upstream. `image-size`'s repo is archived, and even the latest release (2.0.2) is still within the vulnerable range per the advisories. It's pulled in transitively via `metro` (Expo's bundler) — even the newest `metro@0.87.0` still depends on `image-size@^1.0.2`. This needs a fix/replacement from the Metro team; nothing we change locally can resolve it right now.
- **#2 (uuid missing bounds check in v3/v5/v6 with buf)** — the `xcode` npm package (used internally by `@expo/config-plugins` to edit `.pbxproj` files) pins `uuid@^7.0.3` and hasn't bumped it even in its latest release (3.0.1). Verified it only calls `uuid.v4()` with no output buffer, so this specific vulnerable code path (`v3()`/`v5()`/`v6()` with a caller-supplied buffer) isn't actually reachable in our usage — low practical risk while we wait on upstream.
- **#1 (esbuild dev-server DoS)** — comes from `drizzle-kit`'s deprecated `@esbuild-kit/esm-loader` dependency, unrelated to Expo/Metro's dev server (which already uses a patched esbuild). Dev-only; `@esbuild-kit` only uses esbuild's `transform` API, not the vulnerable `serve()` API, so exploitability is effectively nil.

## Validation
- `npm ci` — reinstalled clean from the updated lockfile, no resolution conflicts
- `npx jest` — 126 passed, 16 skipped (pre-existing skips), 0 failures
- `npx eslint .` — identical problem count before/after (4281; all pre-existing, unrelated to `react-native-video-trim` git submodule not being checked out in this environment)
- `npm audit` — high/moderate count dropped after the update, confirming the 4 alerts are resolved

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
