### PR TITLE
recorder: auto-scroll segment bar when a clip is added

### DIFF
--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -89,16 +89,21 @@ function Bar({
   // index-based (i * STEP), independent of viewport width, so widening mid-drag is reorder-safe.
   const [dragActive, setDragActive] = useState(false);
 
-  // Preserve the user's place when a clip is removed: a length DECREASE captures the current
-  // offset (the effect runs before the shrunken content re-lays out and snaps the scroll), and
-  // onContentSizeChange restores it clamped to the new content width. A length increase (new
-  // recording) deliberately does nothing — the bar never yanks away from where the user was.
+  // Length-change reactions, mutually exclusive by direction (reorder never changes length):
+  // — DECREASE (delete): preserve the user's place. Capture the current offset (the effect
+  //   runs before the shrunken content re-lays out and snaps the scroll) and restore it in
+  //   onContentSizeChange, clamped to the new content width.
+  // — INCREASE (new recording or library import): scroll the new clip into view (#167).
+  //   Record mode only — while previewing, the playhead-follow owns the scroll. Deferred to
+  //   onContentSizeChange so the added thumb has laid out before the scrollToEnd.
   const prevCount = useRef(segments.length);
   const restoreOffset = useRef<number | null>(null);
+  const stickToEnd = useRef(false);
   useEffect(() => {
     if (segments.length < prevCount.current) restoreOffset.current = scrollOffset.value;
+    else if (segments.length > prevCount.current && !cursor) stickToEnd.current = true;
     prevCount.current = segments.length;
-  }, [segments.length, scrollOffset]);
+  }, [segments.length, scrollOffset, cursor]);
 
   // Drag-to-trash. The trash floats above the bar, shown only while dragging; dropping a clip
   // on it deletes that clip — otherwise the drag just reorders. Hit-testing is done from the
@@ -159,6 +164,11 @@ function Bar({
                 const target = Math.min(restoreOffset.current, Math.max(0, w - viewportW.value));
                 restoreOffset.current = null;
                 scrollRef.current?.scrollTo({ x: target, animated: false });
+              }
+              // Honor a pending scroll-to-newest now that the added thumb has been measured.
+              if (stickToEnd.current) {
+                stickToEnd.current = false;
+                scrollRef.current?.scrollToEnd({ animated: true });
               }
             }}>
             <Sortable.Grid

--- a/src/features/recorder/segment-bar.tsx
+++ b/src/features/recorder/segment-bar.tsx
@@ -100,6 +100,9 @@ function Bar({
   const restoreOffset = useRef<number | null>(null);
   const stickToEnd = useRef(false);
   useEffect(() => {
+    // Preview opened before a pending scroll-to-newest ran — drop it; playhead-follow owns
+    // the scroll now, and a stale flag would otherwise fire on a LATER content-size change.
+    if (cursor) stickToEnd.current = false;
     if (segments.length < prevCount.current) restoreOffset.current = scrollOffset.value;
     else if (segments.length > prevCount.current && !cursor) stickToEnd.current = true;
     prevCount.current = segments.length;
@@ -166,7 +169,9 @@ function Bar({
                 scrollRef.current?.scrollTo({ x: target, animated: false });
               }
               // Honor a pending scroll-to-newest now that the added thumb has been measured.
-              if (stickToEnd.current) {
+              // Re-checked against cursor: the native event can land before the effect above
+              // has cleared a stale flag on a just-opened preview.
+              if (stickToEnd.current && !cursor) {
                 stickToEnd.current = false;
                 scrollRef.current?.scrollToEnd({ animated: true });
               }


### PR DESCRIPTION
Closes #167.

Stacked on #170 (same file); only the last commit is this PR's change.

Scroll-to-newest existed in f2a1e38 but was dropped in 400fc68 with the scroll-preservation work — since then a clip recorded or imported past the right edge of a full bar lands invisibly off-screen.

## Change

Reinstated alongside the preservation logic as one direction-keyed effect — reorder never changes the segment count, so the branches are mutually exclusive by construction:

- **Length increase** (recording finalized or library import — both arrive through the same live query) in record mode → animated `scrollToEnd`, deferred to `onContentSizeChange` so the new thumb has laid out before the scroll fires
- **Length decrease** (delete) → the existing restore-offset behavior, untouched
- **Gated on the cursor being absent** — while previewing, playhead-follow owns the scroll, so the two mechanisms can't fight

## Testing
- `tsc --noEmit`, ESLint, and the jest suite clean
- Verified on device: new recordings and library imports scroll the newest thumb into view on an overflowing bar; scroll position still preserved on delete; playhead-follow unaffected while previewing

